### PR TITLE
Fix sky pitching on camera look up down

### DIFF
--- a/shaders/sky.vert
+++ b/shaders/sky.vert
@@ -30,7 +30,7 @@ void main() {
     mat4 invProj = inverse(ubo.proj);
     vec4 clipPos = vec4(pos, 1.0, 1.0);
     vec4 viewPos = invProj * clipPos;
-    vec3 viewDir = normalize(viewPos.xyz);
+    vec3 viewDir = normalize(viewPos.xyz / viewPos.w);
 
     // Transform to world space using only rotation
     // transpose(mat3) = inverse for orthonormal rotation matrices


### PR DESCRIPTION
The sky was incorrectly pitching when looking up/down. The issue was in the sky.vert shader where the view-space direction calculation was missing the perspective divide after unprojecting from clip space.

Changed viewPos.xyz to viewPos.xyz / viewPos.w before normalizing to properly handle the homogeneous coordinate transformation.