### PR TITLE
Add third-person camera proxy with free look

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     src/WindSystem.cpp
     src/PostProcessSystem.cpp
     src/FroxelSystem.cpp
+    src/Player.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/src/Application.h
+++ b/src/Application.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "Renderer.h"
 #include "Camera.h"
+#include "Player.h"
 
 class Application {
 public:
@@ -17,6 +18,10 @@ public:
 private:
     void handleInput(float deltaTime);
     void handleGamepadInput(float deltaTime);
+    void handleFreeCameraInput(float deltaTime, const bool* keyState);
+    void handleThirdPersonInput(float deltaTime, const bool* keyState);
+    void handleFreeCameraGamepadInput(float deltaTime);
+    void handleThirdPersonGamepadInput(float deltaTime);
     void processEvents();
     void openGamepad(SDL_JoystickID id);
     void closeGamepad();
@@ -26,8 +31,10 @@ private:
     SDL_Gamepad* gamepad = nullptr;
     Renderer renderer;
     Camera camera;
+    Player player;
 
     bool running = false;
+    bool thirdPersonMode = false;  // Toggle between free camera and third-person
     float moveSpeed = 3.0f;
     float rotateSpeed = 60.0f;
 

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -9,17 +9,32 @@ public:
 
     void setAspectRatio(float aspect);
 
+    // Free camera movement
     void moveForward(float delta);
     void moveRight(float delta);
     void moveUp(float delta);
     void rotatePitch(float delta);
     void rotateYaw(float delta);
 
+    // Third-person camera controls
+    void setThirdPersonTarget(const glm::vec3& target);
+    void orbitYaw(float delta);
+    void orbitPitch(float delta);
+    void adjustDistance(float delta);
+    void setDistance(float dist);
+    float getDistance() const { return thirdPersonDistance; }
+
+    // Update third-person camera position based on target
+    void updateThirdPerson();
+
     glm::mat4 getViewMatrix() const;
     glm::mat4 getProjectionMatrix() const;
     glm::vec3 getPosition() const { return position; }
     float getNearPlane() const { return nearPlane; }
     float getFarPlane() const { return farPlane; }
+
+    // Get the yaw for player rotation in third-person mode
+    float getYaw() const { return yaw; }
 
 private:
     void updateVectors();
@@ -36,4 +51,10 @@ private:
     float aspectRatio;
     float nearPlane;
     float farPlane;
+
+    // Third-person camera settings
+    glm::vec3 thirdPersonTarget;
+    float thirdPersonDistance;
+    float thirdPersonMinDistance;
+    float thirdPersonMaxDistance;
 };

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -56,6 +56,7 @@ public:
     void createPlane(float width, float depth);
     void createDisc(float radius, int segments, float uvScale = 1.0f);
     void createSphere(float radius, int stacks, int slices);
+    void createCapsule(float radius, float height, int stacks, int slices);
     void upload(VmaAllocator allocator, VkDevice device, VkCommandPool commandPool, VkQueue queue);
     void destroy(VmaAllocator allocator);
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1,0 +1,47 @@
+#include "Player.h"
+#include <cmath>
+
+Player::Player()
+    : position(0.0f, 0.0f, 0.0f)
+    , yaw(0.0f)
+{
+}
+
+void Player::moveForward(float delta) {
+    position += getForward() * delta;
+}
+
+void Player::moveRight(float delta) {
+    position += getRight() * delta;
+}
+
+void Player::rotate(float yawDelta) {
+    yaw += yawDelta;
+    // Keep yaw in reasonable range
+    while (yaw > 360.0f) yaw -= 360.0f;
+    while (yaw < 0.0f) yaw += 360.0f;
+}
+
+glm::vec3 Player::getFocusPoint() const {
+    // Camera focus at roughly eye level (top of capsule minus a bit)
+    return position + glm::vec3(0.0f, CAPSULE_HEIGHT * 0.85f, 0.0f);
+}
+
+glm::mat4 Player::getModelMatrix() const {
+    glm::mat4 model = glm::mat4(1.0f);
+    // Translate to position (capsule center is at ground level, so offset up by half height)
+    model = glm::translate(model, position + glm::vec3(0.0f, CAPSULE_HEIGHT * 0.5f, 0.0f));
+    // Rotate around Y axis based on yaw
+    model = glm::rotate(model, glm::radians(yaw), glm::vec3(0.0f, 1.0f, 0.0f));
+    return model;
+}
+
+glm::vec3 Player::getForward() const {
+    float radYaw = glm::radians(yaw);
+    return glm::vec3(sin(radYaw), 0.0f, cos(radYaw));
+}
+
+glm::vec3 Player::getRight() const {
+    float radYaw = glm::radians(yaw + 90.0f);
+    return glm::vec3(sin(radYaw), 0.0f, cos(radYaw));
+}

--- a/src/Player.h
+++ b/src/Player.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+class Player {
+public:
+    // Capsule dimensions for a ~1.8m tall player
+    static constexpr float CAPSULE_HEIGHT = 1.8f;
+    static constexpr float CAPSULE_RADIUS = 0.3f;
+
+    Player();
+
+    // Movement relative to player's facing direction
+    void moveForward(float delta);
+    void moveRight(float delta);
+
+    // Rotation
+    void rotate(float yawDelta);
+
+    // Getters
+    glm::vec3 getPosition() const { return position; }
+    float getYaw() const { return yaw; }
+
+    // Get the center point for camera focus (eye level)
+    glm::vec3 getFocusPoint() const;
+
+    // Get the model matrix for rendering
+    glm::mat4 getModelMatrix() const;
+
+    // Set position directly
+    void setPosition(const glm::vec3& pos) { position = pos; }
+
+private:
+    glm::vec3 position;
+    float yaw;  // Horizontal rotation in degrees
+
+    // Get forward direction based on yaw
+    glm::vec3 getForward() const;
+    glm::vec3 getRight() const;
+};

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -85,6 +85,9 @@ public:
     void toggleCascadeDebug() { showCascadeDebug = !showCascadeDebug; }
     bool isShowingCascadeDebug() const { return showCascadeDebug; }
 
+    // Player rendering
+    void updatePlayerTransform(const glm::mat4& transform);
+
     // Celestial/astronomical settings
     void setLocation(const GeographicLocation& location) { celestialCalculator.setLocation(location); }
     const GeographicLocation& getLocation() const { return celestialCalculator.getLocation(); }
@@ -191,6 +194,7 @@ private:
     Mesh groundMesh;
     Mesh cubeMesh;
     Mesh sphereMesh;
+    Mesh capsuleMesh;
     Texture crateTexture;
     Texture crateNormalMap;
     Texture groundTexture;
@@ -200,6 +204,7 @@ private:
 
     std::vector<SceneObject> sceneObjects;
     std::vector<VkDescriptorSet> metalDescriptorSets;
+    size_t playerObjectIndex = 0;  // Index of the player in sceneObjects
 
     uint32_t currentFrame = 0;
     static constexpr int MAX_FRAMES_IN_FLIGHT = 2;


### PR DESCRIPTION
- Add Player class with position, orientation, and movement controls
- Add createCapsule() method to Mesh class for player representation
- Extend Camera with third-person orbit mode (target tracking, distance control)
- Toggle between free camera and third-person mode with Tab key (or L3 on gamepad)
- Third-person controls: WASD moves player relative to camera, arrows orbit camera
- Player is represented by a 1.8m tall metallic capsule