### PR TITLE
Connect WindSystem data to WeatherSystem uniforms

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1611,7 +1611,7 @@ void Renderer::render(const Camera& camera) {
 
     glm::mat4 viewProj = camera.getProjectionMatrix() * camera.getViewMatrix();
     grassSystem.updateUniforms(currentFrame, camera.getPosition(), viewProj);
-    weatherSystem.updateUniforms(currentFrame, camera.getPosition(), viewProj, deltaTime, grassTime);
+    weatherSystem.updateUniforms(currentFrame, camera.getPosition(), viewProj, deltaTime, grassTime, windSystem);
 
     // Begin command buffer recording
     vkResetCommandBuffer(commandBuffers[currentFrame], 0);

--- a/src/WeatherSystem.cpp
+++ b/src/WeatherSystem.cpp
@@ -1,4 +1,5 @@
 #include "WeatherSystem.h"
+#include "WindSystem.h"
 #include "ShaderLoader.h"
 #include <SDL3/SDL.h>
 #include <cstring>
@@ -553,7 +554,8 @@ void WeatherSystem::updateDescriptorSets(VkDevice dev, const std::vector<VkBuffe
 }
 
 void WeatherSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
-                                    const glm::mat4& viewProj, float deltaTime, float totalTime) {
+                                    const glm::mat4& viewProj, float deltaTime, float totalTime,
+                                    const WindSystem& windSystem) {
     WeatherUniforms uniforms{};
 
     uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
@@ -575,8 +577,11 @@ void WeatherSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraP
         }
     }
 
-    // Wind will be sampled from wind system, set defaults here
-    uniforms.windDirectionStrength = glm::vec4(1.0f, 0.0f, 1.0f, 0.5f);
+    // Sample wind parameters from wind system
+    glm::vec2 windDir = windSystem.getWindDirection();
+    float windStr = windSystem.getWindStrength();
+    float turbulence = windSystem.getGustAmplitude();
+    uniforms.windDirectionStrength = glm::vec4(windDir.x, windDir.y, windStr, turbulence);
 
     // Gravity for rain (downward with terminal velocity)
     uniforms.gravity = glm::vec4(0.0f, -9.8f, 0.0f, 11.0f);  // Terminal velocity ~11 m/s for rain

--- a/src/WeatherSystem.h
+++ b/src/WeatherSystem.h
@@ -6,6 +6,9 @@
 #include <vector>
 #include <string>
 
+// Forward declaration
+class WindSystem;
+
 // Weather particle data (32 bytes, matches GPU struct)
 struct WeatherParticle {
     glm::vec3 position;     // World-space position
@@ -70,7 +73,8 @@ public:
 
     // Update weather uniforms each frame
     void updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
-                        const glm::mat4& viewProj, float deltaTime, float totalTime);
+                        const glm::mat4& viewProj, float deltaTime, float totalTime,
+                        const WindSystem& windSystem);
 
     // Record compute dispatch for particle simulation
     void recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex, float time, float deltaTime);


### PR DESCRIPTION
- Update WeatherSystem::updateUniforms to accept WindSystem reference
- Populate windDirectionStrength from WindSystem instead of placeholder
- Pass wind direction, strength, and gust amplitude to compute shader
- Ensure CPU and GPU use same source of truth for wind data