### PR TITLE
Optimize light culling with frustum testing

### DIFF
--- a/src/Camera.h
+++ b/src/Camera.h
@@ -30,6 +30,7 @@ public:
     glm::mat4 getViewMatrix() const;
     glm::mat4 getProjectionMatrix() const;
     glm::vec3 getPosition() const { return position; }
+    glm::vec3 getFront() const { return front; }
     float getNearPlane() const { return nearPlane; }
     float getFarPlane() const { return farPlane; }
 

--- a/src/Light.h
+++ b/src/Light.h
@@ -62,6 +62,33 @@ struct Light {
     }
 };
 
+// Frustum culling helper - tests if a sphere is inside the view frustum
+// Returns true if the sphere (light) is potentially visible
+inline bool isSphereInFrustum(const glm::vec3& center, float radius, const glm::mat4& viewProj) {
+    // Transform the sphere center to clip space
+    glm::vec4 clipPos = viewProj * glm::vec4(center, 1.0f);
+
+    // Perspective divide to get NDC coordinates
+    if (clipPos.w <= 0.0f) {
+        // Behind the camera
+        return false;
+    }
+
+    glm::vec3 ndc = glm::vec3(clipPos) / clipPos.w;
+
+    // Calculate the radius in NDC space (conservative approximation)
+    // We test the radius against the clip space w-coordinate
+    float ndcRadius = radius / clipPos.w;
+
+    // Test against all 6 frustum planes in NDC space (range: -1 to 1 for x,y and 0 to 1 for z in Vulkan)
+    // Add radius margin to account for the sphere's size
+    if (ndc.x + ndcRadius < -1.0f || ndc.x - ndcRadius > 1.0f) return false;  // Left/Right
+    if (ndc.y + ndcRadius < -1.0f || ndc.y - ndcRadius > 1.0f) return false;  // Bottom/Top
+    if (ndc.z + ndcRadius < 0.0f || ndc.z - ndcRadius > 1.0f) return false;   // Near/Far (Vulkan depth range)
+
+    return true;
+}
+
 // Manages a collection of lights with culling and prioritization
 class LightManager {
 public:
@@ -91,9 +118,10 @@ public:
 
     size_t getLightCount() const { return lights.size(); }
 
-    // Build GPU buffer with culling based on camera position
+    // Build GPU buffer with culling based on camera position, frustum, and view direction
     // Returns the number of active lights after culling
-    uint32_t buildLightBuffer(LightBuffer& buffer, const glm::vec3& cameraPos, float cullRadius = 100.0f) const {
+    uint32_t buildLightBuffer(LightBuffer& buffer, const glm::vec3& cameraPos, const glm::vec3& cameraFront,
+                              const glm::mat4& viewProjMatrix, float cullRadius = 100.0f) const {
         // Collect enabled lights with their distances
         struct LightDistance {
             size_t index;
@@ -108,14 +136,26 @@ public:
             const Light& light = lights[i];
             if (!light.enabled) continue;
 
+            // Test against frustum first (cheap rejection)
+            if (!isSphereInFrustum(light.position, light.radius, viewProjMatrix)) {
+                continue;
+            }
+
             float dist = glm::length(light.position - cameraPos);
 
             // Skip lights too far from camera (outside cull radius + light radius)
             if (dist > cullRadius + light.radius) continue;
 
+            // Calculate angular weighting based on alignment with view direction
+            // Lights in front of the camera get higher weight than those behind
+            glm::vec3 toLight = glm::normalize(light.position - cameraPos);
+            float angleFactor = glm::max(0.0f, glm::dot(toLight, cameraFront));
+            // Bias towards forward-facing lights: range from 0.25 (behind) to 1.0 (front)
+            angleFactor = 0.25f + 0.75f * angleFactor;
+
             // Calculate effective weight for prioritization
-            // Higher priority and closer distance = higher weight
-            float effectiveWeight = light.priority / (dist + 1.0f);
+            // Higher priority, closer distance, and better alignment with view = higher weight
+            float effectiveWeight = (light.priority * angleFactor) / (dist + 1.0f);
 
             candidates.push_back({i, dist, effectiveWeight});
         }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1355,9 +1355,10 @@ void Renderer::setupSceneLights() {
     lightManager.addLight(greenLight);
 }
 
-void Renderer::updateLightBuffer(uint32_t currentImage, const glm::vec3& cameraPos) {
+void Renderer::updateLightBuffer(uint32_t currentImage, const Camera& camera) {
     LightBuffer buffer{};
-    lightManager.buildLightBuffer(buffer, cameraPos, lightCullRadius);
+    glm::mat4 viewProj = camera.getProjectionMatrix() * camera.getViewMatrix();
+    lightManager.buildLightBuffer(buffer, camera.getPosition(), camera.getFront(), viewProj, lightCullRadius);
     memcpy(lightBuffersMapped[currentImage], &buffer, sizeof(LightBuffer));
 }
 
@@ -1573,7 +1574,7 @@ void Renderer::updateUniformBuffer(uint32_t currentImage, const Camera& camera) 
     memcpy(uniformBuffersMapped[currentImage], &ubo, sizeof(ubo));
 
     // Update light buffer with camera-based culling
-    updateLightBuffer(currentImage, camera.getPosition());
+    updateLightBuffer(currentImage, camera);
 
     // Calculate sun screen position (pure) and update post-process (state mutation)
     glm::vec2 sunScreenPos = calculateSunScreenPos(camera, lighting.sunDir);

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -246,6 +246,6 @@ private:
     float lightCullRadius = 100.0f;        // Radius from camera for light culling
 
     bool createLightBuffers();
-    void updateLightBuffer(uint32_t currentImage, const glm::vec3& cameraPos);
+    void updateLightBuffer(uint32_t currentImage, const Camera& camera);
     void setupSceneLights();               // Initialize default scene lights
 };


### PR DESCRIPTION
This commit enhances LightManager::buildLightBuffer with:
- Frustum culling: Tests lights against camera frustum using sphere-frustum intersection in NDC space before sorting. Lights outside the view are culled early, reducing the candidate set.
- Angular weighting: Incorporates dot product with camera forward vector into effectiveWeight calculation. Lights aligned with view direction get higher priority (weight range: 0.25 for behind to 1.0 for front).
- Maintains existing priority mechanism to select best MAX_LIGHTS.

Changes:
- Added Camera::getFront() getter to expose view direction
- Added isSphereInFrustum() helper for frustum culling
- Updated buildLightBuffer signature to accept camera forward and view-proj matrix
- Modified effectiveWeight formula: (priority * angleFactor) / (distance + 1)
- Updated Renderer::updateLightBuffer to pass Camera reference instead of just position

The combined weight calculation now favors lights that are:
1. Higher priority
2. Closer to camera
3. More aligned with view direction
4. Within the view frustum