### PR TITLE
Add confetti button to player controls

### DIFF
--- a/shaders/leaf.comp
+++ b/shaders/leaf.comp
@@ -57,6 +57,7 @@ layout(binding = 3) uniform LeafUniforms {
     vec4 playerVelocity;        // xyz = velocity, w = speed
     vec4 spawnRegionMin;
     vec4 spawnRegionMax;
+    vec4 confettiSpawnPos;      // xyz = spawn position, w = cone angle
     float groundLevel;
     float deltaTime;
     float time;
@@ -66,7 +67,9 @@ layout(binding = 3) uniform LeafUniforms {
     float gustThreshold;
     float targetFallingCount;
     float targetGroundedCount;
-    float padding[3];
+    float confettiSpawnCount;
+    float confettiVelocity;
+    float padding[1];
 } uniforms;
 
 // Wind uniforms
@@ -296,6 +299,62 @@ void spawnGroundedLeaf(uint idx) {
     outputParticles[idx].flags = FLAG_ACTIVE;
 }
 
+// Spawn confetti (small colorful particles in an upward cone)
+void spawnConfettiLeaf(uint idx) {
+    float seed = float(idx) * 0.003 + uniforms.time * 0.2;
+    vec3 rnd = hash3(vec3(seed, seed * 1.3, seed * 2.7));
+    vec3 rnd2 = hash3(vec3(seed * 2.1, seed * 3.3, seed * 1.9));
+
+    // Spawn from confetti spawn position
+    vec3 pos = uniforms.confettiSpawnPos.xyz;
+
+    // Randomize spawn position slightly (small radius around spawn point)
+    float spawnRadius = 0.3;
+    pos.x += (rnd.x - 0.5) * spawnRadius;
+    pos.z += (rnd.y - 0.5) * spawnRadius;
+
+    // Initial velocity in upward cone
+    float coneAngle = uniforms.confettiSpawnPos.w;  // Cone angle from uniforms
+
+    // Generate random direction within cone
+    float theta = rnd2.x * 6.28318;  // Random angle around Y axis
+    float phi = rnd2.y * coneAngle;  // Random angle from vertical (cone spread)
+
+    // Convert spherical to cartesian (upward cone)
+    vec3 direction;
+    direction.y = cos(phi);  // Vertical component (always positive = upward)
+    float r = sin(phi);
+    direction.x = r * cos(theta);
+    direction.z = r * sin(theta);
+
+    vec3 velocity = direction * uniforms.confettiVelocity;
+
+    // Random initial orientation
+    vec3 axis = normalize(vec3(rnd.x - 0.5, rnd.y - 0.5, rnd.z - 0.5));
+    float angle = rnd2.z * 6.28318;
+    vec4 orientation = quatFromAxisAngle(axis, angle);
+
+    // High angular velocity for spinning confetti
+    vec3 angularVel = (rnd2 - 0.5) * 12.0;  // Fast spinning
+
+    // Small size for confetti (3cm = 0.03m)
+    float size = 0.03;
+
+    // Random leaf type for colorful confetti
+    uint leafType = uint(rnd.z * 4.0) % 4u;
+
+    outputParticles[idx].position = pos;
+    outputParticles[idx].state = STATE_FALLING;
+    outputParticles[idx].velocity = velocity;
+    outputParticles[idx].groundTime = 0.0;
+    outputParticles[idx].orientation = orientation;
+    outputParticles[idx].angularVelocity = angularVel;
+    outputParticles[idx].size = size;
+    outputParticles[idx].hash = hash(float(idx) + uniforms.time * 2.0);
+    outputParticles[idx].leafType = leafType;
+    outputParticles[idx].flags = FLAG_ACTIVE;
+}
+
 void main() {
     uint idx = gl_GlobalInvocationID.x;
     if (idx >= MAX_PARTICLES) return;
@@ -313,6 +372,7 @@ void main() {
     // Determine target counts
     uint targetFalling = uint(uniforms.targetFallingCount);
     uint targetGrounded = uint(uniforms.targetGroundedCount);
+    uint confettiCount = uint(uniforms.confettiSpawnCount);
     uint totalTarget = targetFalling + targetGrounded;
 
     // Only process particles up to total target
@@ -325,20 +385,30 @@ void main() {
     // Read previous particle state
     LeafParticle p = inputParticles[idx];
 
+    // Check if this particle should be confetti
+    bool shouldBeConfetti = (idx < confettiCount) && (confettiCount > 0);
+
     // Determine if this slot should be falling or grounded
     bool shouldBeFalling = idx < targetFalling;
 
     // Check if particle needs respawn
     bool needsRespawn = (p.flags & FLAG_ACTIVE) == 0 || p.state == STATE_INACTIVE;
 
-    // Also respawn if too far from camera
+    // Force respawn for confetti particles
+    if (shouldBeConfetti) {
+        needsRespawn = true;
+    }
+
+    // Also respawn if too far from camera (but not for confetti)
     float distToCamera = length(p.position - cameraPos);
-    if (distToCamera > uniforms.maxDrawDistance * 1.5) {
+    if (!shouldBeConfetti && distToCamera > uniforms.maxDrawDistance * 1.5) {
         needsRespawn = true;
     }
 
     if (needsRespawn) {
-        if (shouldBeFalling) {
+        if (shouldBeConfetti) {
+            spawnConfettiLeaf(idx);
+        } else if (shouldBeFalling) {
             spawnFallingLeaf(idx);
         } else {
             spawnGroundedLeaf(idx);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -202,7 +202,7 @@ void Application::processEvents() {
                         renderer.setWeatherType(0); // Set to rain type, but intensity 0
                         renderer.setWeatherIntensity(0.0f); // Clear
                     }
-                    
+
                     std::string weatherStatus = "Clear";
                     if (renderer.getIntensity() > 0.0f) {
                         if (renderer.getWeatherType() == 0) {
@@ -212,6 +212,12 @@ void Application::processEvents() {
                         }
                     }
                     SDL_Log("Weather type: %s, Intensity: %.1f", weatherStatus.c_str(), renderer.getIntensity());
+                }
+                else if (event.key.scancode == SDL_SCANCODE_F) {
+                    // Spawn confetti from player's location
+                    glm::vec3 playerPos = player.getPosition();
+                    renderer.spawnConfetti(playerPos, 8.0f, 100.0f, 0.5f);
+                    SDL_Log("Confetti! 🎉");
                 }
                 break;
             case SDL_EVENT_GAMEPAD_ADDED:

--- a/src/LeafSystem.cpp
+++ b/src/LeafSystem.cpp
@@ -578,6 +578,11 @@ void LeafSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
     uniforms.spawnRegionMin = glm::vec4(spawnRegionMin, 0.0f);
     uniforms.spawnRegionMax = glm::vec4(spawnRegionMax, 0.0f);
 
+    // Confetti spawn parameters
+    uniforms.confettiSpawnPos = glm::vec4(confettiSpawnPosition, confettiConeAngle);
+    uniforms.confettiSpawnCount = confettiToSpawn;
+    uniforms.confettiVelocity = confettiSpawnVelocity;
+
     // General parameters
     uniforms.groundLevel = groundLevel;
     uniforms.deltaTime = deltaTime;
@@ -594,6 +599,9 @@ void LeafSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
     uniforms.targetGroundedCount = leafIntensity * 20000.0f; // 0-20000 grounded leaves
 
     memcpy(uniformMappedPtrs[frameIndex], &uniforms, sizeof(LeafUniforms));
+
+    // Reset confetti spawn count after it's been sent to GPU
+    confettiToSpawn = 0.0f;
 }
 
 void LeafSystem::recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex, float time, float deltaTime) {

--- a/src/LeafSystem.h
+++ b/src/LeafSystem.h
@@ -37,6 +37,7 @@ struct LeafUniforms {
     glm::vec4 playerVelocity;           // xyz = player velocity, w = speed magnitude
     glm::vec4 spawnRegionMin;           // xyz = AABB minimum
     glm::vec4 spawnRegionMax;           // xyz = AABB maximum
+    glm::vec4 confettiSpawnPos;         // xyz = confetti spawn position, w = cone angle
     float groundLevel;                  // Y coordinate of ground plane
     float deltaTime;                    // Frame delta time
     float time;                         // Accumulated time
@@ -46,7 +47,9 @@ struct LeafUniforms {
     float gustThreshold;                // Wind strength to lift grounded leaves
     float targetFallingCount;           // Target number of falling leaves
     float targetGroundedCount;          // Target number of grounded leaves
-    float padding[3];                   // Alignment padding
+    float confettiSpawnCount;           // Number of confetti to spawn this frame
+    float confettiVelocity;             // Initial upward velocity for confetti
+    float padding[1];                   // Alignment padding
 };
 
 // Push constants for leaf rendering
@@ -101,6 +104,14 @@ public:
         spawnRegionMax = maxBounds;
     }
 
+    // Confetti control
+    void spawnConfetti(const glm::vec3& position, float velocity = 8.0f, float count = 100.0f, float coneAngle = 0.5f) {
+        confettiSpawnPosition = position;
+        confettiSpawnVelocity = velocity;
+        confettiToSpawn = count;
+        confettiConeAngle = coneAngle;
+    }
+
 private:
     bool createBuffers();
     bool createComputeDescriptorSetLayout();
@@ -152,6 +163,12 @@ private:
     float groundLevel = 0.0f;           // Ground plane Y coordinate
     glm::vec3 spawnRegionMin = glm::vec3(-50.0f, 10.0f, -50.0f);
     glm::vec3 spawnRegionMax = glm::vec3(50.0f, 20.0f, 50.0f);
+
+    // Confetti parameters
+    glm::vec3 confettiSpawnPosition = glm::vec3(0.0f);
+    float confettiSpawnVelocity = 0.0f;
+    float confettiToSpawn = 0.0f;
+    float confettiConeAngle = 0.5f;
 
     // Particle counts
     static constexpr uint32_t MAX_PARTICLES = 100000;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -89,6 +89,9 @@ public:
     // Leaf control
     void setLeafIntensity(float intensity) { leafSystem.setIntensity(intensity); }
     float getLeafIntensity() const { return leafSystem.getIntensity(); }
+    void spawnConfetti(const glm::vec3& position, float velocity = 8.0f, float count = 100.0f, float coneAngle = 0.5f) {
+        leafSystem.spawnConfetti(position, velocity, count, coneAngle);
+    }
 
     // Player rendering
     void updatePlayerTransform(const glm::mat4& transform);


### PR DESCRIPTION
Implement a confetti effect system using the existing leaf particle system:
- Press 'F' key to spawn confetti from player's location
- Confetti spawns as small (3cm) colorful particles
- Particles shoot upward in a cone pattern with initial velocity
- Fast spinning angular velocity for festive effect
- Particles float down to the ground using leaf physics

Technical changes:
- Add confetti spawn parameters to LeafUniforms (position, velocity, count, cone angle)
- Implement spawnConfettiLeaf function in leaf.comp shader with cone-based velocity
- Add spawnConfetti method to LeafSystem class
- Add F key handler in Application to trigger confetti from player position
- Expose spawnConfetti through Renderer class for easy access