### PR TITLE
Add slow sidereal rotation to starfield

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -2305,6 +2305,7 @@ Renderer::LightingParams Renderer::calculateLightingParams(float timeOfDay) cons
     params.sunColor = celestialCalculator.getSunColor(sunPos.altitude);
     params.moonColor = celestialCalculator.getMoonColor(moonPos.altitude, moonPos.illumination);
     params.ambientColor = celestialCalculator.getAmbientColor(sunPos.altitude);
+    params.julianDay = dateTime.toJulianDay();
 
     return params;
 }
@@ -2345,6 +2346,7 @@ UniformBufferObject Renderer::buildUniformBufferData(const Camera& camera, const
     ubo.timeOfDay = timeOfDay;
     ubo.shadowMapSize = static_cast<float>(SHADOW_MAP_SIZE);
     ubo.debugCascades = showCascadeDebug ? 1.0f : 0.0f;
+    ubo.julianDay = static_cast<float>(lighting.julianDay);
 
     return ubo;
 }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -39,7 +39,7 @@ struct UniformBufferObject {
     float timeOfDay;
     float shadowMapSize;
     float debugCascades;           // 1.0 = show cascade colors
-    float padding;
+    float julianDay;               // Julian day for sidereal rotation
 };
 
 struct ShadowPushConstants {
@@ -157,6 +157,7 @@ private:
         glm::vec3 sunColor;
         glm::vec3 moonColor;
         glm::vec3 ambientColor;
+        double julianDay;
     };
     LightingParams calculateLightingParams(float timeOfDay) const;
     UniformBufferObject buildUniformBufferData(const Camera& camera, const LightingParams& lighting, float timeOfDay) const;


### PR DESCRIPTION
Implements slow celestial rotation that tracks night progression:
- Added julianDay field to UniformBufferObject (replacing padding)
- Calculate Julian day in LightingParams from current DateTime
- Pass Julian day to sky fragment shader
- Apply Y-axis rotation to starfield based on days since J2000 epoch
- Uses sidereal rate of 360.9856 degrees per day

Stars now realistically rotate with Earth's rotation, creating accurate celestial motion throughout the night.