### PR TITLE
Integrate leaves with height map

### DIFF
--- a/shaders/leaf.comp
+++ b/shaders/leaf.comp
@@ -69,6 +69,8 @@ layout(binding = 3) uniform LeafUniforms {
     float targetGroundedCount;
     float confettiSpawnCount;
     float confettiVelocity;
+    float terrainSize;
+    float terrainHeightScale;
     float padding[1];
 } uniforms;
 
@@ -77,6 +79,9 @@ layout(binding = 4) uniform WindUniforms {
     vec4 windDirectionAndStrength;  // xy = normalized direction, z = strength, w = speed
     vec4 windParams;                // x = gustFrequency, y = gustAmplitude, z = noiseScale, w = time
 } wind;
+
+// Terrain heightmap for leaf placement on terrain
+layout(binding = 5) uniform sampler2D terrainHeightMap;
 
 layout(push_constant) uniform PushConstants {
     float time;
@@ -168,6 +173,23 @@ float perlinNoise(float x, float y) {
         v
     );
     return (res + 1.0) * 0.5;
+}
+
+// Sample terrain height at world XZ position
+float sampleTerrainHeight(vec2 worldXZ) {
+    // Convert world XZ to heightmap UV: terrain is centered at origin
+    vec2 terrainUV = worldXZ / uniforms.terrainSize + 0.5;
+
+    // Check if within terrain bounds
+    if (terrainUV.x < 0.0 || terrainUV.x > 1.0 || terrainUV.y < 0.0 || terrainUV.y > 1.0) {
+        return uniforms.groundLevel;  // Fall back to flat ground level outside terrain
+    }
+
+    // Sample heightmap (R32_SFLOAT format, values in [0,1])
+    float heightSample = texture(terrainHeightMap, terrainUV).r;
+
+    // Convert to world Y using same formula as terrain shader
+    return (heightSample - 0.5) * uniforms.terrainHeightScale;
 }
 
 // Sample wind with turbulence
@@ -273,7 +295,8 @@ void spawnGroundedLeaf(uint idx) {
     vec3 pos;
     pos.x = mix(uniforms.spawnRegionMin.x, uniforms.spawnRegionMax.x, rnd.x);
     pos.z = mix(uniforms.spawnRegionMin.z, uniforms.spawnRegionMax.z, rnd.z);
-    pos.y = uniforms.groundLevel + 0.01;  // Slightly above ground
+    float terrainY = sampleTerrainHeight(vec2(pos.x, pos.z));
+    pos.y = terrainY + 0.01;  // Slightly above terrain
 
     // Flat orientation with random yaw
     float yaw = rnd.y * 6.28318;
@@ -466,9 +489,10 @@ void main() {
             // Update position
             p.position += p.velocity * dt;
 
-            // Ground collision
-            if (p.position.y <= uniforms.groundLevel + p.size * 0.5) {
-                p.position.y = uniforms.groundLevel + 0.01;
+            // Ground collision - sample terrain at current position
+            float terrainY = sampleTerrainHeight(p.position.xz);
+            if (p.position.y <= terrainY + p.size * 0.5) {
+                p.position.y = terrainY + 0.01;
                 p.velocity = vec3(0.0);
                 p.angularVelocity = vec3(0.0);
                 p.state = STATE_GROUNDED;
@@ -530,10 +554,13 @@ void main() {
             // Update position
             p.position += p.velocity * dt;
 
+            // Sample terrain at current position
+            float terrainY = sampleTerrainHeight(p.position.xz);
+
             // Check if settled
             float speed = length(p.velocity);
-            if (speed < 0.1 && p.position.y <= uniforms.groundLevel + p.size) {
-                p.position.y = uniforms.groundLevel + 0.01;
+            if (speed < 0.1 && p.position.y <= terrainY + p.size) {
+                p.position.y = terrainY + 0.01;
                 p.velocity = vec3(0.0);
                 p.angularVelocity = vec3(0.0);
                 p.state = STATE_GROUNDED;
@@ -541,8 +568,8 @@ void main() {
             }
 
             // Ground collision
-            if (p.position.y <= uniforms.groundLevel + 0.01) {
-                p.position.y = uniforms.groundLevel + 0.01;
+            if (p.position.y <= terrainY + 0.01) {
+                p.position.y = terrainY + 0.01;
                 if (p.velocity.y < 0.0) p.velocity.y *= -0.3;  // Small bounce
             }
         }

--- a/src/LeafSystem.h
+++ b/src/LeafSystem.h
@@ -49,6 +49,8 @@ struct LeafUniforms {
     float targetGroundedCount;          // Target number of grounded leaves
     float confettiSpawnCount;           // Number of confetti to spawn this frame
     float confettiVelocity;             // Initial upward velocity for confetti
+    float terrainSize;                  // Terrain size for heightmap UV calculation
+    float terrainHeightScale;           // Terrain height scale
     float padding[1];                   // Alignment padding
 };
 
@@ -77,14 +79,17 @@ public:
     bool init(const InitInfo& info);
     void destroy(VkDevice device, VmaAllocator allocator);
 
-    // Update descriptor sets with external resources (UBO, wind buffer)
+    // Update descriptor sets with external resources (UBO, wind buffer, heightmap)
     void updateDescriptorSets(VkDevice device, const std::vector<VkBuffer>& uniformBuffers,
-                              const std::vector<VkBuffer>& windBuffers);
+                              const std::vector<VkBuffer>& windBuffers,
+                              VkImageView terrainHeightMapView,
+                              VkSampler terrainHeightMapSampler);
 
     // Update leaf uniforms each frame
     void updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
                         const glm::mat4& viewProj, const glm::vec3& playerPos,
-                        const glm::vec3& playerVel, float deltaTime, float totalTime);
+                        const glm::vec3& playerVel, float deltaTime, float totalTime,
+                        float terrainSize, float terrainHeightScale);
 
     // Record compute dispatch for particle simulation
     void recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex, float time, float deltaTime);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -220,8 +220,9 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
 
     if (!leafSystem.init(leafInfo)) return false;
 
-    // Update leaf system descriptor sets with wind buffers
-    leafSystem.updateDescriptorSets(device, uniformBuffers, windBuffers);
+    // Update leaf system descriptor sets with wind buffers and terrain heightmap
+    leafSystem.updateDescriptorSets(device, uniformBuffers, windBuffers,
+                                     terrainSystem.getHeightMapView(), terrainSystem.getHeightMapSampler());
 
     // Set default leaf intensity (autumn scene)
     leafSystem.setIntensity(0.5f);
@@ -2182,7 +2183,8 @@ void Renderer::render(const Camera& camera) {
     // TODO: Integrate actual player velocity from Player class for proper disruption
     glm::vec3 playerPos = camera.getPosition();
     glm::vec3 playerVel = glm::vec3(0.0f);  // Will be updated when player movement tracking is added
-    leafSystem.updateUniforms(currentFrame, camera.getPosition(), viewProj, playerPos, playerVel, deltaTime, grassTime);
+    leafSystem.updateUniforms(currentFrame, camera.getPosition(), viewProj, playerPos, playerVel, deltaTime, grassTime,
+                               terrainConfig.size, terrainConfig.heightScale);
 
     // Begin command buffer recording
     vkResetCommandBuffer(commandBuffers[currentFrame], 0);


### PR DESCRIPTION
Following the same pattern as grass heightmap integration (eeef55c), this integrates the leaf particle system with the terrain heightmap to ensure leaves land and rest on the actual terrain surface instead of a flat plane.

Changes:
- LeafSystem: Add terrain parameters (size, heightScale) to uniforms
- LeafSystem: Add heightmap sampler binding (binding 5) to compute shader
- leaf.comp: Add sampleTerrainHeight() function to query terrain at XZ coords
- leaf.comp: Replace all groundLevel checks with heightmap sampling for:
  * Grounded leaf spawning
  * Falling leaf ground collision
  * Disturbed leaf settling
- Renderer: Pass terrain heightmap view/sampler to leaf descriptor sets
- Renderer: Pass terrain size/heightScale to leaf uniforms each frame

The heightmap sampling uses the same UV calculation and height formula as the terrain shader, ensuring consistency across the scene.