### PR TITLE
Implement grass far LOD terrain interaction

### DIFF
--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -4,7 +4,8 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 struct GrassInstance {
     vec4 positionAndFacing;  // xyz = position, w = facing angle
-    vec4 heightHashTilt;     // x = height, y = hash, z = tilt, w = unused
+    vec4 heightHashTilt;     // x = height, y = hash, z = tilt, w = clumpId
+    vec4 terrainNormal;      // xyz = terrain normal (for tangent alignment), w = unused
 };
 
 struct DrawIndirectCommand {
@@ -52,6 +53,24 @@ float hash2(vec2 p) {
 // Returns vec2 hash for a cell
 vec2 hash2v(vec2 p) {
     return vec2(hash(p), hash(p + vec2(47.0, 13.0)));
+}
+
+// Calculate terrain normal from heightmap gradient (same method as terrain.vert)
+vec3 calculateTerrainNormal(vec2 uv) {
+    vec2 texelSize = 1.0 / vec2(textureSize(terrainHeightMap, 0));
+
+    float hL = texture(terrainHeightMap, uv + vec2(-texelSize.x, 0.0)).r * uniforms.terrainHeightScale;
+    float hR = texture(terrainHeightMap, uv + vec2(texelSize.x, 0.0)).r * uniforms.terrainHeightScale;
+    float hD = texture(terrainHeightMap, uv + vec2(0.0, -texelSize.y)).r * uniforms.terrainHeightScale;
+    float hU = texture(terrainHeightMap, uv + vec2(0.0, texelSize.y)).r * uniforms.terrainHeightScale;
+
+    // Approximate gradient
+    // terrainSize is total terrain extent, texelSize is in UV space
+    float worldTexelSize = uniforms.terrainSize / float(textureSize(terrainHeightMap, 0).x);
+    float dx = (hR - hL) / (2.0 * worldTexelSize);
+    float dz = (hU - hD) / (2.0 * worldTexelSize);
+
+    return normalize(vec3(-dx, 1.0, -dz));
 }
 
 // Clumping parameters
@@ -141,6 +160,9 @@ void main() {
 
     vec3 worldPos = vec3(x, terrainY, z);
 
+    // Calculate terrain normal for tangent-aligned grass placement
+    vec3 terrainNormal = calculateTerrainNormal(terrainUV);
+
     // Distance culling (relative to camera)
     float distToCamera = length(worldPos - uniforms.cameraPosition.xyz);
     if (distToCamera > uniforms.maxDrawDistance) return;
@@ -206,4 +228,5 @@ void main() {
     // Write instance data (clumpId stored in w for fragment shader color variation)
     instances[slot].positionAndFacing = vec4(worldPos, facing);
     instances[slot].heightHashTilt = vec4(height, bladeHash, tilt, clumpId);
+    instances[slot].terrainNormal = vec4(terrainNormal, 0.0);
 }

--- a/shaders/terrain/terrain.frag
+++ b/shaders/terrain/terrain.frag
@@ -52,6 +52,12 @@ layout(std140, binding = 4) uniform TerrainUniforms {
 layout(binding = 3) uniform sampler2D heightMap;
 layout(binding = 6) uniform sampler2D terrainAlbedo;
 layout(binding = 7) uniform sampler2DArrayShadow shadowMapArray;
+layout(binding = 8) uniform sampler2D grassFarLODTexture;  // Far LOD grass texture
+
+// Far LOD grass parameters (where to start/end grass-to-terrain transition)
+const float GRASS_RENDER_DISTANCE = 60.0;     // Should match grass system maxDrawDistance
+const float FAR_LOD_TRANSITION_START = 50.0;  // Start blending far LOD
+const float FAR_LOD_TRANSITION_END = 70.0;    // Full far LOD (terrain with grass tint)
 
 // Inputs from vertex shader
 layout(location = 0) in vec2 fragTexCoord;
@@ -83,6 +89,27 @@ void main() {
     // Add some variation based on slope
     vec3 normal = normalize(fragNormal);
     float slope = 1.0 - normal.y;
+
+    // === FAR LOD GRASS BLENDING ===
+    // At distances beyond grass render distance, blend in grass texture to maintain
+    // grass coverage without rendering individual blades
+    float distToCamera = length(fragWorldPos - ubo.cameraPosition.xyz);
+    float farLodBlend = smoothstep(FAR_LOD_TRANSITION_START, FAR_LOD_TRANSITION_END, distToCamera);
+
+    // Sample far LOD grass texture (tiled based on world position for consistency)
+    vec2 grassUV = fragWorldPos.xz * 0.05;  // Larger scale for distant grass
+    vec3 farGrassColor = texture(grassFarLODTexture, grassUV).rgb;
+
+    // Only apply far LOD grass on flat-ish terrain (where real grass would grow)
+    // Grass doesn't grow on steep slopes
+    float grassGrowthFactor = 1.0 - smoothstep(0.2, 0.5, slope);
+
+    // Blend far LOD grass into terrain albedo
+    // As distance increases, replace terrain texture with grass-tinted ground
+    if (farLodBlend > 0.01 && grassGrowthFactor > 0.01) {
+        // Mix terrain with far LOD grass color based on distance
+        albedo = mix(albedo, farGrassColor, farLodBlend * grassGrowthFactor);
+    }
 
     // Blend in rock color on steep slopes
     vec3 rockColor = vec3(0.4, 0.35, 0.3);

--- a/src/GrassSystem.h
+++ b/src/GrassSystem.h
@@ -24,7 +24,8 @@ struct GrassUniforms {
 
 struct GrassInstance {
     glm::vec4 positionAndFacing;  // xyz = position, w = facing angle
-    glm::vec4 heightHashTilt;     // x = height, y = hash, z = tilt, w = unused
+    glm::vec4 heightHashTilt;     // x = height, y = hash, z = tilt, w = clumpId
+    glm::vec4 terrainNormal;      // xyz = terrain normal (for tangent alignment), w = unused
 };
 
 class GrassSystem {

--- a/src/TerrainSystem.h
+++ b/src/TerrainSystem.h
@@ -186,6 +186,12 @@ private:
     VkImageView terrainAlbedoView = VK_NULL_HANDLE;
     VkSampler terrainAlbedoSampler = VK_NULL_HANDLE;
 
+    // Grass far LOD texture (for terrain blending at distance)
+    VkImage grassFarLODImage = VK_NULL_HANDLE;
+    VmaAllocation grassFarLODAllocation = VK_NULL_HANDLE;
+    VkImageView grassFarLODView = VK_NULL_HANDLE;
+    VkSampler grassFarLODSampler = VK_NULL_HANDLE;
+
     // Indirect dispatch/draw buffers
     VkBuffer indirectDispatchBuffer = VK_NULL_HANDLE;
     VmaAllocation indirectDispatchAllocation = VK_NULL_HANDLE;


### PR DESCRIPTION
Grass blades now sit tangential to the terrain surface instead of always growing straight up. This makes grass on hillsides look much more natural.

Changes:
- grass.comp: Calculate terrain normal from heightmap gradient
- grass.comp/grass.vert/grass_shadow.vert: Expand GrassInstance to include terrainNormal vec4
- grass.vert: Add buildTerrainBasis() to create orthonormal frame from terrain normal, orient blade using terrain basis instead of simple Y rotation
- grass_shadow.vert: Same terrain basis changes for shadow consistency
- terrain.frag: Add far LOD grass texture blending at distance (binding 8) to maintain grass coverage beyond grass render distance
- TerrainSystem: Create and bind grass far LOD texture
- GrassSystem.h: Update C++ GrassInstance struct to match shader