### PR TITLE
Fix multi-scatter LUT atmosphere buffer refresh

### DIFF
--- a/src/AtmosphereLUTSystem.cpp
+++ b/src/AtmosphereLUTSystem.cpp
@@ -739,6 +739,11 @@ void AtmosphereLUTSystem::computeTransmittanceLUT(VkCommandBuffer cmd) {
 }
 
 void AtmosphereLUTSystem::computeMultiScatterLUT(VkCommandBuffer cmd) {
+    // Update uniform buffer with atmosphere params
+    AtmosphereLUTUniforms uniforms{};
+    uniforms.params = atmosphereParams;
+    memcpy(uniformMappedPtr, &uniforms, sizeof(AtmosphereLUTUniforms));
+
     // Transition to GENERAL layout for compute write
     VkImageMemoryBarrier barrier{};
     barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;


### PR DESCRIPTION
The multi-scatter LUT dispatch was using stale atmosphere uniform data from previous passes. Now properly updates the uniform buffer with current atmosphere parameters before dispatch, matching the pattern used in transmittance and sky-view LUT computations.