### PR TITLE
Fix atmospheric shading zero line artifact

### DIFF
--- a/shaders/atmosphere_common.glsl
+++ b/shaders/atmosphere_common.glsl
@@ -292,8 +292,8 @@ float integrateExponentialFog(vec3 startPos, vec3 endPos) {
 
     // Exponential fog component
     float expIntegral = FOG_DENSITY * FOG_SCALE_HEIGHT *
-        abs(exp(-(max(h0 - FOG_BASE_HEIGHT, 0.0)) * invScaleHeight) -
-            exp(-(max(h1 - FOG_BASE_HEIGHT, 0.0)) * invScaleHeight)) /
+        abs(exp(-((h0 - FOG_BASE_HEIGHT)) * invScaleHeight) -
+            exp(-((h1 - FOG_BASE_HEIGHT)) * invScaleHeight)) /
         max(abs(deltaH / distance), 0.001);
 
     // Sigmoidal component (approximate with average)


### PR DESCRIPTION
Remove max() clamps in exponential fog integral that were creating a discontinuity when rays crossed FOG_BASE_HEIGHT. The clamps at h0 - FOG_BASE_HEIGHT and h1 - FOG_BASE_HEIGHT caused a sharp transition when one height was above and one below the base height, resulting in a visible artifact line in the atmospheric shading.

The exponential function now evaluates smoothly across the full height range without clamping, eliminating the zero-line artifact.

Fixed in shaders/atmosphere_common.glsl:295-296