### PR TITLE
Implement Purkinje Effect visual feature

### DIFF
--- a/src/PostProcessSystem.cpp
+++ b/src/PostProcessSystem.cpp
@@ -660,6 +660,11 @@ void PostProcessSystem::recordPostProcess(VkCommandBuffer cmd, uint32_t frameInd
     ubo->froxelDepthDist = froxelDepthDist;
     ubo->nearPlane = nearPlane;
     ubo->farPlane = farPlane;
+    // Purkinje effect (Phase 5.6)
+    // Convert adapted luminance to approximate scene illuminance in lux
+    // Mapping: adaptedLuminance * 200 gives reasonable lux-like values
+    // where target luminance 0.05 → 10 lux (Purkinje activation threshold)
+    ubo->sceneIlluminance = adaptedLuminance * 200.0f;
 
     // Store computed exposure for next frame
     lastAutoExposure = autoExposureEnabled ? computedExposure : manualExposure;

--- a/src/PostProcessSystem.h
+++ b/src/PostProcessSystem.h
@@ -25,7 +25,8 @@ struct PostProcessUniforms {
     float froxelDepthDist;    // Depth distribution factor
     float nearPlane;          // Camera near plane for depth linearization
     float farPlane;           // Camera far plane for depth linearization
-    float padding1;
+    // Purkinje effect (Phase 5.6)
+    float sceneIlluminance;   // Scene illuminance in lux for Purkinje effect
     float padding2;
     float padding3;
 };


### PR DESCRIPTION
Add simplified Purkinje effect to simulate human mesopic/scotopic vision for convincing night scenes. The effect activates below 10 lux and includes:
- Desaturation in low light (rods are monochromatic)
- Blue shift (rods more sensitive to shorter wavelengths)
- Brightness boost for dark areas (rod sensitivity)

Scene illuminance is derived from the histogram-based adapted luminance and passed to the shader via the uniform buffer.