### PR TITLE
Add shared environment settings for wind-driven systems

### DIFF
--- a/src/EnvironmentSettings.h
+++ b/src/EnvironmentSettings.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+// Shared environment settings used across systems for consistent wind and interaction tuning
+struct EnvironmentSettings {
+    // Wind parameters
+    glm::vec2 windDirection = glm::vec2(1.0f, 0.0f);
+    float windStrength = 1.0f;
+    float windSpeed = 5.0f;
+    float gustFrequency = 0.5f;
+    float gustAmplitude = 0.3f;
+    float noiseScale = 0.1f;
+
+    // Interaction limits
+    float leafDisruptionRadius = 2.0f;
+    float leafDisruptionStrength = 5.0f;
+    float leafGustLiftThreshold = 1.5f;
+    float grassDisplacementDecay = 0.97f;
+    float grassMaxDisplacement = 1.0f;
+};
+

--- a/src/GrassSystem.cpp
+++ b/src/GrassSystem.cpp
@@ -1149,7 +1149,9 @@ void GrassSystem::recordDisplacementUpdate(VkCommandBuffer cmd, uint32_t frameIn
     DisplacementUniforms dispUniforms;
     dispUniforms.regionCenter = glm::vec4(displacementRegionCenter.x, displacementRegionCenter.y,
                                           DISPLACEMENT_REGION_SIZE, texelSize);
-    dispUniforms.params = glm::vec4(displacementDecayRate, maxDisplacement, 1.0f / 60.0f,
+    const EnvironmentSettings fallbackSettings{};
+    const EnvironmentSettings& settings = environmentSettings ? *environmentSettings : fallbackSettings;
+    dispUniforms.params = glm::vec4(settings.grassDisplacementDecay, settings.grassMaxDisplacement, 1.0f / 60.0f,
                                     static_cast<float>(currentDisplacementSources.size()));
     memcpy(displacementUniformMappedPtrs[frameIndex], &dispUniforms, sizeof(DisplacementUniforms));
 

--- a/src/GrassSystem.h
+++ b/src/GrassSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EnvironmentSettings.h"
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
@@ -82,6 +83,8 @@ public:
     VkImageView getDisplacementImageView() const { return displacementImageView; }
     VkSampler getDisplacementSampler() const { return displacementSampler; }
 
+    void setEnvironmentSettings(const EnvironmentSettings* settings) { environmentSettings = settings; }
+
 private:
     bool createShadowPipeline();
     bool createBuffers();
@@ -149,8 +152,6 @@ private:
 
     // Displacement source data for current frame
     std::vector<DisplacementSource> currentDisplacementSources;
-    float displacementDecayRate = 0.97f;   // Grass springs back over time (slower = closer to 1.0)
-    float maxDisplacement = 1.0f;          // Maximum displacement magnitude
 
     // Double-buffered storage buffers: A/B sets that alternate each frame
     // Set A and Set B alternate: compute writes to one while graphics reads from other
@@ -183,4 +184,6 @@ private:
     VkSampler terrainHeightMapSampler = VK_NULL_HANDLE;
 
     static constexpr uint32_t MAX_INSTANCES = 100000;  // ~100k rendered after culling
+
+    const EnvironmentSettings* environmentSettings = nullptr;
 };

--- a/src/LeafSystem.cpp
+++ b/src/LeafSystem.cpp
@@ -645,6 +645,8 @@ void LeafSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
                                  const glm::vec3& playerVel, float deltaTime, float totalTime,
                                  float terrainSize, float terrainHeightScale) {
     LeafUniforms uniforms{};
+    const EnvironmentSettings fallbackSettings{};
+    const EnvironmentSettings& settings = environmentSettings ? *environmentSettings : fallbackSettings;
 
     uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
 
@@ -686,9 +688,9 @@ void LeafSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
     uniforms.maxDrawDistance = 60.0f;
 
     // Disruption parameters
-    uniforms.disruptionRadius = 2.0f;
-    uniforms.disruptionStrength = 5.0f;
-    uniforms.gustThreshold = 1.5f;
+    uniforms.disruptionRadius = settings.leafDisruptionRadius;
+    uniforms.disruptionStrength = settings.leafDisruptionStrength;
+    uniforms.gustThreshold = settings.leafGustLiftThreshold;
 
     // Target counts based on intensity
     uniforms.targetFallingCount = leafIntensity * 5000.0f;   // 0-5000 falling leaves

--- a/src/LeafSystem.h
+++ b/src/LeafSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EnvironmentSettings.h"
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
@@ -119,6 +120,8 @@ public:
         confettiConeAngle = coneAngle;
     }
 
+    void setEnvironmentSettings(const EnvironmentSettings* settings) { environmentSettings = settings; }
+
 private:
     bool createBuffers();
     bool createComputeDescriptorSetLayout();
@@ -189,6 +192,8 @@ private:
     // Displacement region center (updated from camera position)
     glm::vec2 displacementRegionCenter = glm::vec2(0.0f);
     static constexpr float DISPLACEMENT_REGION_SIZE = 50.0f;
+
+    const EnvironmentSettings* environmentSettings = nullptr;
 
     // Particle counts
     static constexpr uint32_t MAX_PARTICLES = 100000;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -196,6 +196,10 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
 
     if (!windSystem.init(windInfo)) return false;
 
+    const EnvironmentSettings* environmentSettings = &windSystem.getEnvironmentSettings();
+    grassSystem.setEnvironmentSettings(environmentSettings);
+    leafSystem.setEnvironmentSettings(environmentSettings);
+
     // Get wind buffers for grass descriptor sets
     std::vector<VkBuffer> windBuffers(MAX_FRAMES_IN_FLIGHT);
     for (uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {

--- a/src/WindSystem.cpp
+++ b/src/WindSystem.cpp
@@ -87,17 +87,17 @@ void WindSystem::updateUniforms(uint32_t frameIndex) {
 
     // Pack direction (xy), strength (z), and speed (w)
     uniforms.windDirectionAndStrength = glm::vec4(
-        windDirection.x,
-        windDirection.y,
-        windStrength,
-        windSpeed
+        environmentSettings.windDirection.x,
+        environmentSettings.windDirection.y,
+        environmentSettings.windStrength,
+        environmentSettings.windSpeed
     );
 
     // Pack gust parameters, noise scale, and time
     uniforms.windParams = glm::vec4(
-        gustFrequency,
-        gustAmplitude,
-        noiseScale,
+        environmentSettings.gustFrequency,
+        environmentSettings.gustAmplitude,
+        environmentSettings.noiseScale,
         totalTime
     );
 
@@ -115,28 +115,28 @@ VkDescriptorBufferInfo WindSystem::getBufferInfo(uint32_t frameIndex) const {
 void WindSystem::setWindDirection(const glm::vec2& direction) {
     float len = glm::length(direction);
     if (len > 0.0001f) {
-        windDirection = direction / len;
+        environmentSettings.windDirection = direction / len;
     }
 }
 
 void WindSystem::setWindStrength(float strength) {
-    windStrength = glm::max(0.0f, strength);
+    environmentSettings.windStrength = glm::max(0.0f, strength);
 }
 
 void WindSystem::setWindSpeed(float speed) {
-    windSpeed = glm::max(0.0f, speed);
+    environmentSettings.windSpeed = glm::max(0.0f, speed);
 }
 
 void WindSystem::setGustFrequency(float frequency) {
-    gustFrequency = glm::max(0.0f, frequency);
+    environmentSettings.gustFrequency = glm::max(0.0f, frequency);
 }
 
 void WindSystem::setGustAmplitude(float amplitude) {
-    gustAmplitude = glm::max(0.0f, amplitude);
+    environmentSettings.gustAmplitude = glm::max(0.0f, amplitude);
 }
 
 void WindSystem::setNoiseScale(float scale) {
-    noiseScale = glm::max(0.001f, scale);
+    environmentSettings.noiseScale = glm::max(0.001f, scale);
 }
 
 float WindSystem::fade(float t) const {
@@ -192,7 +192,7 @@ float WindSystem::perlinNoise(float x, float y) const {
 
 float WindSystem::sampleWindAtPosition(const glm::vec2& worldPos) const {
     // Scroll position in wind direction
-    glm::vec2 scrolledPos = worldPos - windDirection * totalTime * windSpeed * 0.4f;
+    glm::vec2 scrolledPos = worldPos - environmentSettings.windDirection * totalTime * environmentSettings.windSpeed * 0.4f;
 
     // Three octaves: ~10m, ~5m, ~2.5m wavelengths
     float baseFreq = 0.1f;
@@ -204,7 +204,7 @@ float WindSystem::sampleWindAtPosition(const glm::vec2& worldPos) const {
     float noise = n1 * 0.7f + n2 * 0.2f + n3 * 0.1f;
 
     // Add gust variation (time-based sine wave)
-    float gust = (std::sin(totalTime * gustFrequency * 6.28318f) * 0.5f + 0.5f) * gustAmplitude;
+    float gust = (std::sin(totalTime * environmentSettings.gustFrequency * 6.28318f) * 0.5f + 0.5f) * environmentSettings.gustAmplitude;
 
-    return (noise + gust) * windStrength;
+    return (noise + gust) * environmentSettings.windStrength;
 }

--- a/src/WindSystem.h
+++ b/src/WindSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EnvironmentSettings.h"
 #include <glm/glm.hpp>
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
@@ -39,27 +40,30 @@ public:
     // Get descriptor buffer info for binding
     VkDescriptorBufferInfo getBufferInfo(uint32_t frameIndex) const;
 
+    // Shared environment settings
+    const EnvironmentSettings& getEnvironmentSettings() const { return environmentSettings; }
+
     // Wind direction control (normalized 2D direction)
     void setWindDirection(const glm::vec2& direction);
-    glm::vec2 getWindDirection() const { return windDirection; }
+    glm::vec2 getWindDirection() const { return environmentSettings.windDirection; }
 
     // Wind strength (0 = calm, 1 = normal, 2+ = storm)
     void setWindStrength(float strength);
-    float getWindStrength() const { return windStrength; }
+    float getWindStrength() const { return environmentSettings.windStrength; }
 
     // Wind speed (how fast the noise pattern scrolls in the wind direction)
     void setWindSpeed(float speed);
-    float getWindSpeed() const { return windSpeed; }
+    float getWindSpeed() const { return environmentSettings.windSpeed; }
 
     // Gust parameters
     void setGustFrequency(float frequency);
     void setGustAmplitude(float amplitude);
-    float getGustFrequency() const { return gustFrequency; }
-    float getGustAmplitude() const { return gustAmplitude; }
+    float getGustFrequency() const { return environmentSettings.gustFrequency; }
+    float getGustAmplitude() const { return environmentSettings.gustAmplitude; }
 
     // Noise scale (controls the size of wind waves in world units)
     void setNoiseScale(float scale);
-    float getNoiseScale() const { return noiseScale; }
+    float getNoiseScale() const { return environmentSettings.noiseScale; }
 
     // Sample wind strength at a world position (for CPU-side gameplay)
     // Returns wind strength multiplier at that position
@@ -76,12 +80,7 @@ private:
     float grad(int hash, float x, float y) const;
 
     // Wind parameters
-    glm::vec2 windDirection = glm::vec2(1.0f, 0.0f);  // Default: blowing in +X direction
-    float windStrength = 1.0f;                          // Base wind strength multiplier
-    float windSpeed = 5.0f;                             // Speed of noise scroll (world units/sec)
-    float gustFrequency = 0.5f;                         // Frequency of gusts
-    float gustAmplitude = 0.3f;                         // Additional amplitude from gusts
-    float noiseScale = 0.1f;                            // Noise sampling scale (1/wavelength)
+    EnvironmentSettings environmentSettings{};
 
     // Time tracking
     float totalTime = 0.0f;


### PR DESCRIPTION
## Summary
- add a shared EnvironmentSettings structure to centralize wind and interaction parameters
- have WindSystem own the settings and expose them to leaf and grass systems
- route leaf and grass uniform updates through the shared environment settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929738648c48327b157d368684a760e)