### PR TITLE
Fix flag physics simulation on collision

### DIFF
--- a/src/ClothSimulation.cpp
+++ b/src/ClothSimulation.cpp
@@ -15,7 +15,9 @@ void ClothSimulation::create(int w, int h, float spacing, const glm::vec3& topLe
         for (int x = 0; x < width; ++x) {
             Particle p;
             p.position = topLeftPosition + glm::vec3(x * spacing, -y * spacing, 0.0f);
-            p.oldPosition = p.position;
+            // Give particles a small initial velocity by offsetting oldPosition slightly
+            // This prevents the cloth from appearing "frozen" until something collides with it
+            p.oldPosition = p.position - glm::vec3(0.0f, 0.001f, 0.0f);
             p.acceleration = glm::vec3(0.0f);
             p.mass = 1.0f;
             p.pinned = false;


### PR DESCRIPTION
The flag appeared frozen because Verlet integration derives velocity from position delta (current - old). At initialization, oldPosition == position, so all particles started with zero velocity.

When a collision occurred, it modified position but left oldPosition unchanged, creating instant velocity that made the flag suddenly animate.

Fix: Initialize particles with a small downward velocity by offsetting oldPosition slightly (0.001m). This gives the cloth natural movement from the start without needing collision to "wake it up".

Location: src/ClothSimulation.cpp:20