### PR TITLE
Add pipeline builder and refactor pipeline setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     src/Mesh.cpp
     src/Texture.cpp
     src/ShaderLoader.cpp
+    src/PipelineBuilder.cpp
     src/GrassSystem.cpp
     src/CelestialCalculator.cpp
     src/WindSystem.cpp

--- a/src/PipelineBuilder.cpp
+++ b/src/PipelineBuilder.cpp
@@ -1,0 +1,137 @@
+#include "PipelineBuilder.h"
+#include "ShaderLoader.h"
+#include <SDL3/SDL.h>
+
+PipelineBuilder::PipelineBuilder(VkDevice device) : device(device) {}
+
+PipelineBuilder::~PipelineBuilder() { cleanupShaderModules(); }
+
+PipelineBuilder& PipelineBuilder::reset() {
+    descriptorBindings.clear();
+    pushConstantRanges.clear();
+    shaderStages.clear();
+    cleanupShaderModules();
+    return *this;
+}
+
+PipelineBuilder& PipelineBuilder::addDescriptorBinding(uint32_t binding, VkDescriptorType type, uint32_t count,
+                                                       VkShaderStageFlags stageFlags, const VkSampler* immutableSamplers) {
+    VkDescriptorSetLayoutBinding layoutBinding{};
+    layoutBinding.binding = binding;
+    layoutBinding.descriptorType = type;
+    layoutBinding.descriptorCount = count;
+    layoutBinding.stageFlags = stageFlags;
+    layoutBinding.pImmutableSamplers = immutableSamplers;
+    descriptorBindings.push_back(layoutBinding);
+    return *this;
+}
+
+bool PipelineBuilder::buildDescriptorSetLayout(VkDescriptorSetLayout& layout) const {
+    VkDescriptorSetLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutInfo.bindingCount = static_cast<uint32_t>(descriptorBindings.size());
+    layoutInfo.pBindings = descriptorBindings.data();
+
+    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &layout) != VK_SUCCESS) {
+        SDL_Log("Failed to create descriptor set layout via PipelineBuilder");
+        return false;
+    }
+    return true;
+}
+
+PipelineBuilder& PipelineBuilder::addPushConstantRange(VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size) {
+    VkPushConstantRange range{};
+    range.stageFlags = stageFlags;
+    range.offset = offset;
+    range.size = size;
+    pushConstantRanges.push_back(range);
+    return *this;
+}
+
+PipelineBuilder& PipelineBuilder::addShaderStage(const std::string& path, VkShaderStageFlagBits stage, const char* entry) {
+    VkShaderModule module = ShaderLoader::loadShaderModule(device, path);
+    if (module == VK_NULL_HANDLE) {
+        SDL_Log("Failed to load shader module at %s", path.c_str());
+        return *this;
+    }
+
+    VkPipelineShaderStageCreateInfo stageInfo{};
+    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stageInfo.stage = stage;
+    stageInfo.module = module;
+    stageInfo.pName = entry;
+
+    shaderStages.push_back(stageInfo);
+    shaderModules.push_back(module);
+    return *this;
+}
+
+bool PipelineBuilder::buildPipelineLayout(const std::vector<VkDescriptorSetLayout>& setLayouts, VkPipelineLayout& layout) const {
+    VkPipelineLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layoutInfo.setLayoutCount = static_cast<uint32_t>(setLayouts.size());
+    layoutInfo.pSetLayouts = setLayouts.data();
+    layoutInfo.pushConstantRangeCount = static_cast<uint32_t>(pushConstantRanges.size());
+    layoutInfo.pPushConstantRanges = pushConstantRanges.data();
+
+    if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &layout) != VK_SUCCESS) {
+        SDL_Log("Failed to create pipeline layout via PipelineBuilder");
+        return false;
+    }
+
+    return true;
+}
+
+bool PipelineBuilder::buildComputePipeline(VkPipelineLayout layout, VkPipeline& pipeline) {
+    if (shaderStages.empty()) {
+        SDL_Log("No shader stages provided for compute pipeline");
+        return false;
+    }
+
+    VkComputePipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipelineInfo.stage = shaderStages[0];
+    pipelineInfo.layout = layout;
+
+    VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    cleanupShaderModules();
+
+    if (result != VK_SUCCESS) {
+        SDL_Log("Failed to create compute pipeline via PipelineBuilder");
+        return false;
+    }
+
+    return true;
+}
+
+bool PipelineBuilder::buildGraphicsPipeline(const VkGraphicsPipelineCreateInfo& pipelineInfoBase, VkPipelineLayout layout,
+                                            VkPipeline& pipeline) {
+    if (shaderStages.empty()) {
+        SDL_Log("No shader stages provided for graphics pipeline");
+        return false;
+    }
+
+    VkGraphicsPipelineCreateInfo pipelineInfo = pipelineInfoBase;
+    pipelineInfo.stageCount = static_cast<uint32_t>(shaderStages.size());
+    pipelineInfo.pStages = shaderStages.data();
+    pipelineInfo.layout = layout;
+
+    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    cleanupShaderModules();
+
+    if (result != VK_SUCCESS) {
+        SDL_Log("Failed to create graphics pipeline via PipelineBuilder");
+        return false;
+    }
+
+    return true;
+}
+
+void PipelineBuilder::cleanupShaderModules() {
+    for (VkShaderModule module : shaderModules) {
+        vkDestroyShaderModule(device, module, nullptr);
+    }
+    shaderModules.clear();
+    shaderStages.clear();
+}
+

--- a/src/PipelineBuilder.h
+++ b/src/PipelineBuilder.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vector>
+#include <string>
+
+class PipelineBuilder {
+public:
+    explicit PipelineBuilder(VkDevice device);
+    ~PipelineBuilder();
+
+    PipelineBuilder& reset();
+
+    PipelineBuilder& addDescriptorBinding(uint32_t binding, VkDescriptorType type, uint32_t count,
+                                          VkShaderStageFlags stageFlags, const VkSampler* immutableSamplers = nullptr);
+
+    bool buildDescriptorSetLayout(VkDescriptorSetLayout& layout) const;
+
+    PipelineBuilder& addPushConstantRange(VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size);
+
+    PipelineBuilder& addShaderStage(const std::string& path, VkShaderStageFlagBits stage, const char* entry = "main");
+
+    bool buildPipelineLayout(const std::vector<VkDescriptorSetLayout>& setLayouts, VkPipelineLayout& layout) const;
+
+    bool buildComputePipeline(VkPipelineLayout layout, VkPipeline& pipeline);
+
+    bool buildGraphicsPipeline(const VkGraphicsPipelineCreateInfo& pipelineInfoBase, VkPipelineLayout layout,
+                               VkPipeline& pipeline);
+
+private:
+    VkDevice device;
+    std::vector<VkDescriptorSetLayoutBinding> descriptorBindings;
+    std::vector<VkPushConstantRange> pushConstantRanges;
+    std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
+    std::vector<VkShaderModule> shaderModules;
+
+    void cleanupShaderModules();
+};
+


### PR DESCRIPTION
## Summary
- introduce a reusable PipelineBuilder helper to wrap descriptor set layout, pipeline layout, and pipeline creation
- refactor grass compute/graphics/shadow setup to build layouts and pipelines through the builder
- refactor weather compute and graphics pipeline creation to reduce duplicated setup code

## Testing
- cmake --preset debug && cmake --build build/debug

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692973e1bbb083279d5775d47f52fd07)