### PR TITLE
Introduce BindingBuilder for descriptor layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     src/Texture.cpp
     src/ShaderLoader.cpp
     src/PipelineBuilder.cpp
+    src/BindingBuilder.cpp
     src/GrassSystem.cpp
     src/CelestialCalculator.cpp
     src/WindSystem.cpp

--- a/src/BindingBuilder.cpp
+++ b/src/BindingBuilder.cpp
@@ -1,0 +1,35 @@
+#include "BindingBuilder.h"
+
+BindingBuilder::BindingBuilder() {
+    descriptorBinding.descriptorCount = 1;
+}
+
+BindingBuilder& BindingBuilder::setBinding(uint32_t binding) {
+    descriptorBinding.binding = binding;
+    return *this;
+}
+
+BindingBuilder& BindingBuilder::setDescriptorType(VkDescriptorType type) {
+    descriptorBinding.descriptorType = type;
+    return *this;
+}
+
+BindingBuilder& BindingBuilder::setDescriptorCount(uint32_t count) {
+    descriptorBinding.descriptorCount = count;
+    return *this;
+}
+
+BindingBuilder& BindingBuilder::setStageFlags(VkShaderStageFlags stageFlags) {
+    descriptorBinding.stageFlags = stageFlags;
+    return *this;
+}
+
+BindingBuilder& BindingBuilder::setImmutableSamplers(const VkSampler* immutableSamplers) {
+    descriptorBinding.pImmutableSamplers = immutableSamplers;
+    return *this;
+}
+
+VkDescriptorSetLayoutBinding BindingBuilder::build() const {
+    return descriptorBinding;
+}
+

--- a/src/BindingBuilder.h
+++ b/src/BindingBuilder.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+class BindingBuilder {
+public:
+    BindingBuilder();
+
+    BindingBuilder& setBinding(uint32_t binding);
+    BindingBuilder& setDescriptorType(VkDescriptorType type);
+    BindingBuilder& setDescriptorCount(uint32_t count);
+    BindingBuilder& setStageFlags(VkShaderStageFlags stageFlags);
+    BindingBuilder& setImmutableSamplers(const VkSampler* immutableSamplers);
+
+    VkDescriptorSetLayoutBinding build() const;
+
+private:
+    VkDescriptorSetLayoutBinding descriptorBinding{};
+};
+

--- a/src/FroxelSystem.cpp
+++ b/src/FroxelSystem.cpp
@@ -1,5 +1,6 @@
 #include "FroxelSystem.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL_log.h>
 #include <glm/gtc/matrix_transform.hpp>
 #include <array>
@@ -207,43 +208,21 @@ bool FroxelSystem::createSampler() {
 }
 
 bool FroxelSystem::createDescriptorSetLayout() {
-    std::array<VkDescriptorSetLayoutBinding, 6> bindings{};
+    auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
+        return BindingBuilder()
+            .setBinding(binding)
+            .setDescriptorType(type)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
+    };
 
-    // Binding 0: Current scattering volume (storage image, write)
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    // Binding 1: Integrated volume (storage image, read/write)
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    // Binding 2: Uniform buffer
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    // Binding 3: Shadow map (sampled image with sampler)
-    bindings[3].binding = 3;
-    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[3].descriptorCount = 1;
-    bindings[3].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    // Binding 4: Light buffer (SSBO for local lights)
-    bindings[4].binding = 4;
-    bindings[4].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[4].descriptorCount = 1;
-    bindings[4].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-
-    // Binding 5: History scattering volume (storage image, read-only for temporal)
-    bindings[5].binding = 5;
-    bindings[5].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    bindings[5].descriptorCount = 1;
-    bindings[5].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    std::array<VkDescriptorSetLayoutBinding, 6> bindings = {
+        makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+        makeComputeBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+        makeComputeBinding(2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER),
+        makeComputeBinding(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+        makeComputeBinding(4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+        makeComputeBinding(5, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)};
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/PipelineBuilder.cpp
+++ b/src/PipelineBuilder.cpp
@@ -1,5 +1,6 @@
 #include "PipelineBuilder.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL.h>
 
 PipelineBuilder::PipelineBuilder(VkDevice device) : device(device) {}
@@ -16,12 +17,13 @@ PipelineBuilder& PipelineBuilder::reset() {
 
 PipelineBuilder& PipelineBuilder::addDescriptorBinding(uint32_t binding, VkDescriptorType type, uint32_t count,
                                                        VkShaderStageFlags stageFlags, const VkSampler* immutableSamplers) {
-    VkDescriptorSetLayoutBinding layoutBinding{};
-    layoutBinding.binding = binding;
-    layoutBinding.descriptorType = type;
-    layoutBinding.descriptorCount = count;
-    layoutBinding.stageFlags = stageFlags;
-    layoutBinding.pImmutableSamplers = immutableSamplers;
+    VkDescriptorSetLayoutBinding layoutBinding = BindingBuilder()
+                                                     .setBinding(binding)
+                                                     .setDescriptorType(type)
+                                                     .setDescriptorCount(count)
+                                                     .setStageFlags(stageFlags)
+                                                     .setImmutableSamplers(immutableSamplers)
+                                                     .build();
     descriptorBindings.push_back(layoutBinding);
     return *this;
 }


### PR DESCRIPTION
## Summary
- add a reusable BindingBuilder to simplify descriptor set layout binding creation
- refactor pipeline builder and several systems to construct descriptor layouts through the new builder
- register the new utility in the build configuration

## Testing
- cmake --preset debug *(fails: missing /scripts/buildsystems/vcpkg.cmake toolchain and Ninja)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297c35b108832798c888f88bc92c44)