### PR TITLE
Apply particle system across all locations

### DIFF
--- a/src/GrassSystem.cpp
+++ b/src/GrassSystem.cpp
@@ -504,38 +504,13 @@ bool GrassSystem::createShadowPipeline() {
 }
 
 bool GrassSystem::createDescriptorSets() {
-    // Allocate and update descriptor sets for both buffer sets (A and B)
-    // We only need one descriptor set per buffer set for compute (no per-frame needed)
-    // The uniform buffer binding will use dynamic offset or be updated each frame
+    // Allocate standard compute and graphics descriptor sets for both buffer sets
+    if (!particleSystem.createStandardDescriptorSets()) {
+        return false;
+    }
+
+    // Allocate shadow descriptor sets for both buffer sets
     for (uint32_t set = 0; set < BUFFER_SET_COUNT; set++) {
-        // Allocate compute descriptor set for this buffer set
-        VkDescriptorSetAllocateInfo computeAllocInfo{};
-        computeAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        computeAllocInfo.descriptorPool = getDescriptorPool();
-        computeAllocInfo.descriptorSetCount = 1;
-        computeAllocInfo.pSetLayouts = &getComputePipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet computeSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &computeAllocInfo, &computeSet) != VK_SUCCESS) {
-            SDL_Log("Failed to allocate grass compute descriptor set (set %u)", set);
-            return false;
-        }
-        particleSystem.setComputeDescriptorSet(set, computeSet);
-
-        // Allocate graphics descriptor set for this buffer set
-        VkDescriptorSetAllocateInfo graphicsAllocInfo{};
-        graphicsAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        graphicsAllocInfo.descriptorPool = getDescriptorPool();
-        graphicsAllocInfo.descriptorSetCount = 1;
-        graphicsAllocInfo.pSetLayouts = &getGraphicsPipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet graphicsSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &graphicsAllocInfo, &graphicsSet) != VK_SUCCESS) {
-            SDL_Log("Failed to allocate grass graphics descriptor set (set %u)", set);
-            return false;
-        }
-        particleSystem.setGraphicsDescriptorSet(set, graphicsSet);
-
         // Allocate shadow descriptor set for this buffer set
         VkDescriptorSetAllocateInfo shadowAllocInfo{};
         shadowAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;

--- a/src/LeafSystem.h
+++ b/src/LeafSystem.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "ParticleSystem.h"
+#include "BufferUtils.h"
 
 // Leaf particle states
 enum class LeafState : uint32_t {
@@ -140,15 +141,11 @@ private:
 
     // Double-buffered storage buffers
     static constexpr uint32_t BUFFER_SET_COUNT = 2;
-    VkBuffer particleBuffers[BUFFER_SET_COUNT];
-    VmaAllocation particleAllocations[BUFFER_SET_COUNT];
-    VkBuffer indirectBuffers[BUFFER_SET_COUNT];
-    VmaAllocation indirectAllocations[BUFFER_SET_COUNT];
+    BufferUtils::DoubleBufferedBufferSet particleBuffers;
+    BufferUtils::DoubleBufferedBufferSet indirectBuffers;
 
     // Uniform buffers (per frame)
-    std::vector<VkBuffer> uniformBuffers;
-    std::vector<VmaAllocation> uniformAllocations;
-    std::vector<void*> uniformMappedPtrs;
+    BufferUtils::PerFrameBufferSet uniformBuffers;
 
     // Descriptor sets
     // Descriptor sets managed through ParticleSystem helper

--- a/src/ParticleSystem.h
+++ b/src/ParticleSystem.h
@@ -14,6 +14,9 @@ public:
     bool init(const InitInfo& info, const Hooks& hooks, uint32_t bufferSets = 2);
     void destroy(VkDevice device, VmaAllocator allocator);
 
+    // Create standard descriptor sets for all buffer sets (allocates both compute and graphics descriptor sets)
+    bool createStandardDescriptorSets();
+
     void advanceBufferSet();
 
     uint32_t getComputeBufferSet() const { return computeBufferSet; }

--- a/src/WeatherSystem.cpp
+++ b/src/WeatherSystem.cpp
@@ -205,38 +205,7 @@ bool WeatherSystem::createGraphicsPipeline() {
 }
 
 bool WeatherSystem::createDescriptorSets() {
-    // Allocate descriptor sets for both buffer sets
-    for (uint32_t set = 0; set < BUFFER_SET_COUNT; set++) {
-        // Compute descriptor set
-        VkDescriptorSetAllocateInfo computeAllocInfo{};
-        computeAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        computeAllocInfo.descriptorPool = getDescriptorPool();
-        computeAllocInfo.descriptorSetCount = 1;
-        computeAllocInfo.pSetLayouts = &getComputePipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet computeSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &computeAllocInfo, &computeSet) != VK_SUCCESS) {
-            SDL_Log("Failed to allocate weather compute descriptor set (set %u)", set);
-            return false;
-        }
-        particleSystem.setComputeDescriptorSet(set, computeSet);
-
-        // Graphics descriptor set
-        VkDescriptorSetAllocateInfo graphicsAllocInfo{};
-        graphicsAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        graphicsAllocInfo.descriptorPool = getDescriptorPool();
-        graphicsAllocInfo.descriptorSetCount = 1;
-        graphicsAllocInfo.pSetLayouts = &getGraphicsPipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet graphicsSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &graphicsAllocInfo, &graphicsSet) != VK_SUCCESS) {
-            SDL_Log("Failed to allocate weather graphics descriptor set (set %u)", set);
-            return false;
-        }
-        particleSystem.setGraphicsDescriptorSet(set, graphicsSet);
-    }
-
-    return true;
+    return particleSystem.createStandardDescriptorSets();
 }
 
 void WeatherSystem::updateDescriptorSets(VkDevice dev, const std::vector<VkBuffer>& rendererUniformBuffers,


### PR DESCRIPTION
This refactoring ensures all particle systems (Leaf, Weather, Grass) use the shared ParticleSystem helper and BufferUtils consistently:

Changes:
- Refactored LeafSystem to use BufferUtils for buffer management (matching WeatherSystem and GrassSystem patterns)
- Extracted duplicated descriptor set allocation into ParticleSystem's createStandardDescriptorSets() method
- Updated all three particle systems to use the centralized descriptor set allocation
- Reduced code duplication by ~85 lines while maintaining functionality

Benefits:
- Consistent buffer management across all particle systems
- Reduced maintenance burden through shared code
- Easier to extend particle system functionality in the future