### PR TITLE
Apply BindingBuilder across codebase

### DIFF
--- a/src/AtmosphereLUTSystem.cpp
+++ b/src/AtmosphereLUTSystem.cpp
@@ -1,5 +1,6 @@
 #include "AtmosphereLUTSystem.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL_log.h>
 #include <array>
 #include <vector>
@@ -455,17 +456,19 @@ bool AtmosphereLUTSystem::createUniformBuffer() {
 bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
     // Transmittance LUT descriptor set layout (just output image and uniform buffer)
     {
-        std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
+        auto outputImage = BindingBuilder()
+            .setBinding(0)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[0].binding = 0;
-        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[0].descriptorCount = 1;
-        bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto uniformBuffer = BindingBuilder()
+            .setBinding(1)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[1].binding = 1;
-        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bindings[1].descriptorCount = 1;
-        bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {outputImage, uniformBuffer};
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -490,22 +493,25 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Multi-scatter LUT descriptor set layout (transmittance input, output image, uniform buffer)
     {
-        std::array<VkDescriptorSetLayoutBinding, 3> bindings{};
+        auto outputImage = BindingBuilder()
+            .setBinding(0)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[0].binding = 0;
-        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[0].descriptorCount = 1;
-        bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto transmittanceInput = BindingBuilder()
+            .setBinding(1)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[1].binding = 1;
-        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        bindings[1].descriptorCount = 1;
-        bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto uniformBuffer = BindingBuilder()
+            .setBinding(2)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[2].binding = 2;
-        bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bindings[2].descriptorCount = 1;
-        bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        std::array<VkDescriptorSetLayoutBinding, 3> bindings = {outputImage, transmittanceInput, uniformBuffer};
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -530,27 +536,31 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Sky-view LUT descriptor set layout (transmittance + multiscatter inputs, output image, uniform buffer)
     {
-        std::array<VkDescriptorSetLayoutBinding, 4> bindings{};
+        auto outputImage = BindingBuilder()
+            .setBinding(0)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[0].binding = 0;
-        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[0].descriptorCount = 1;
-        bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto transmittanceInput = BindingBuilder()
+            .setBinding(1)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[1].binding = 1;
-        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        bindings[1].descriptorCount = 1;
-        bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto multiScatterInput = BindingBuilder()
+            .setBinding(2)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[2].binding = 2;
-        bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        bindings[2].descriptorCount = 1;
-        bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto uniformBuffer = BindingBuilder()
+            .setBinding(3)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[3].binding = 3;
-        bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bindings[3].descriptorCount = 1;
-        bindings[3].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {outputImage, transmittanceInput, multiScatterInput, uniformBuffer};
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -576,27 +586,31 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
     // Irradiance LUT descriptor set layout (Phase 4.1.9)
     // Two output images (Rayleigh and Mie), transmittance input, uniform buffer
     {
-        std::array<VkDescriptorSetLayoutBinding, 4> bindings{};
+        auto rayleighOutput = BindingBuilder()
+            .setBinding(0)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[0].binding = 0;
-        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[0].descriptorCount = 1;
-        bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto mieOutput = BindingBuilder()
+            .setBinding(1)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[1].binding = 1;
-        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[1].descriptorCount = 1;
-        bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto transmittanceInput = BindingBuilder()
+            .setBinding(2)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[2].binding = 2;
-        bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        bindings[2].descriptorCount = 1;
-        bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto uniformBuffer = BindingBuilder()
+            .setBinding(3)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[3].binding = 3;
-        bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bindings[3].descriptorCount = 1;
-        bindings[3].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {rayleighOutput, mieOutput, transmittanceInput, uniformBuffer};
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -621,17 +635,19 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Cloud Map LUT descriptor set layout (output image, uniform buffer)
     {
-        std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
+        auto outputImage = BindingBuilder()
+            .setBinding(0)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[0].binding = 0;
-        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        bindings[0].descriptorCount = 1;
-        bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        auto uniformBuffer = BindingBuilder()
+            .setBinding(1)
+            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+            .build();
 
-        bindings[1].binding = 1;
-        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        bindings[1].descriptorCount = 1;
-        bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {outputImage, uniformBuffer};
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/BloomSystem.cpp
+++ b/src/BloomSystem.cpp
@@ -1,5 +1,6 @@
 #include "BloomSystem.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <array>
 #include <algorithm>
 #include <cmath>
@@ -229,11 +230,11 @@ bool BloomSystem::createSampler() {
 bool BloomSystem::createDescriptorSetLayouts() {
     // Both downsample and upsample use the same descriptor set layout
     // Binding 0: input texture (sampler2D)
-    VkDescriptorSetLayoutBinding binding = {};
-    binding.binding = 0;
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    binding.descriptorCount = 1;
-    binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto binding = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
     VkDescriptorSetLayoutCreateInfo layoutInfo = {};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/GrassSystem.cpp
+++ b/src/GrassSystem.cpp
@@ -1,6 +1,7 @@
 #include "GrassSystem.h"
 #include "ShaderLoader.h"
 #include "PipelineBuilder.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL.h>
 #include <cstring>
 #include <array>
@@ -179,25 +180,28 @@ bool GrassSystem::createDisplacementResources() {
 
 bool GrassSystem::createDisplacementPipeline() {
     // Create descriptor set layout for displacement update compute shader
-    std::array<VkDescriptorSetLayoutBinding, 3> bindings{};
-
     // Displacement map (storage image, read-write)
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto displacementMap = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Source buffer (SSBO)
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto sourceBuffer = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Displacement uniforms
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto displacementUniforms = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
+
+    std::array<VkDescriptorSetLayoutBinding, 3> bindings = {displacementMap, sourceBuffer, displacementUniforms};
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/LeafSystem.cpp
+++ b/src/LeafSystem.cpp
@@ -1,5 +1,6 @@
 #include "LeafSystem.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL.h>
 #include <cstring>
 #include <algorithm>
@@ -132,55 +133,66 @@ bool LeafSystem::createBuffers() {
 }
 
 bool LeafSystem::createComputeDescriptorSetLayout() {
-    std::array<VkDescriptorSetLayoutBinding, 8> bindings{};
-
     // Particle buffer input (previous frame state)
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto particleBufferInput = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Particle buffer output (current frame result)
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto particleBufferOutput = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Indirect buffer (output)
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto indirectBuffer = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Leaf uniforms
-    bindings[3].binding = 3;
-    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[3].descriptorCount = 1;
-    bindings[3].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto leafUniforms = BindingBuilder()
+        .setBinding(3)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Wind uniforms
-    bindings[4].binding = 4;
-    bindings[4].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[4].descriptorCount = 1;
-    bindings[4].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto windUniforms = BindingBuilder()
+        .setBinding(4)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Terrain heightmap
-    bindings[5].binding = 5;
-    bindings[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[5].descriptorCount = 1;
-    bindings[5].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto terrainHeightmap = BindingBuilder()
+        .setBinding(5)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Displacement map (shared with grass system for player interaction)
-    bindings[6].binding = 6;
-    bindings[6].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    bindings[6].descriptorCount = 1;
-    bindings[6].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto displacementMap = BindingBuilder()
+        .setBinding(6)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
 
     // Displacement region uniform buffer
-    bindings[7].binding = 7;
-    bindings[7].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[7].descriptorCount = 1;
-    bindings[7].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    auto displacementRegion = BindingBuilder()
+        .setBinding(7)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
+        .build();
+
+    std::array<VkDescriptorSetLayoutBinding, 8> bindings = {
+        particleBufferInput, particleBufferOutput, indirectBuffer,
+        leafUniforms, windUniforms, terrainHeightmap, displacementMap, displacementRegion
+    };
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -250,25 +262,28 @@ bool LeafSystem::createComputePipeline() {
 }
 
 bool LeafSystem::createGraphicsDescriptorSetLayout() {
-    std::array<VkDescriptorSetLayoutBinding, 3> bindings{};
-
     // UBO (scene uniforms)
-    bindings[0].binding = 0;
-    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[0].descriptorCount = 1;
-    bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto uboBinding = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
     // Particle buffer (read-only in vertex shader)
-    bindings[1].binding = 1;
-    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    bindings[1].descriptorCount = 1;
-    bindings[1].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    auto particleBuffer = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT)
+        .build();
 
     // Wind uniforms (for consistent animation)
-    bindings[2].binding = 2;
-    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    bindings[2].descriptorCount = 1;
-    bindings[2].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    auto windUniforms = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT)
+        .build();
+
+    std::array<VkDescriptorSetLayoutBinding, 3> bindings = {uboBinding, particleBuffer, windUniforms};
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,6 +1,7 @@
 #define VMA_IMPLEMENTATION
 #include "Renderer.h"
 #include "ShaderLoader.h"
+#include "BindingBuilder.h"
 #include <SDL3/SDL_vulkan.h>
 #include <glm/gtc/matrix_transform.hpp>
 #include <stdexcept>
@@ -1535,61 +1536,53 @@ bool Renderer::createSyncObjects() {
 }
 
 bool Renderer::createDescriptorSetLayout() {
-    VkDescriptorSetLayoutBinding uboLayoutBinding{};
-    uboLayoutBinding.binding = 0;
-    uboLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    uboLayoutBinding.descriptorCount = 1;
-    uboLayoutBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    uboLayoutBinding.pImmutableSamplers = nullptr;
+    auto uboLayoutBinding = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding samplerLayoutBinding{};
-    samplerLayoutBinding.binding = 1;
-    samplerLayoutBinding.descriptorCount = 1;
-    samplerLayoutBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    samplerLayoutBinding.pImmutableSamplers = nullptr;
-    samplerLayoutBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto samplerLayoutBinding = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding shadowSamplerBinding{};
-    shadowSamplerBinding.binding = 2;
-    shadowSamplerBinding.descriptorCount = 1;
-    shadowSamplerBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    shadowSamplerBinding.pImmutableSamplers = nullptr;
-    shadowSamplerBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto shadowSamplerBinding = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding normalMapBinding{};
-    normalMapBinding.binding = 3;
-    normalMapBinding.descriptorCount = 1;
-    normalMapBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    normalMapBinding.pImmutableSamplers = nullptr;
-    normalMapBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto normalMapBinding = BindingBuilder()
+        .setBinding(3)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding lightBufferBinding{};
-    lightBufferBinding.binding = 4;
-    lightBufferBinding.descriptorCount = 1;
-    lightBufferBinding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    lightBufferBinding.pImmutableSamplers = nullptr;
-    lightBufferBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto lightBufferBinding = BindingBuilder()
+        .setBinding(4)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding emissiveMapBinding{};
-    emissiveMapBinding.binding = 5;
-    emissiveMapBinding.descriptorCount = 1;
-    emissiveMapBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    emissiveMapBinding.pImmutableSamplers = nullptr;
-    emissiveMapBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto emissiveMapBinding = BindingBuilder()
+        .setBinding(5)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding pointShadowBinding{};
-    pointShadowBinding.binding = 6;
-    pointShadowBinding.descriptorCount = 1;
-    pointShadowBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    pointShadowBinding.pImmutableSamplers = nullptr;
-    pointShadowBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto pointShadowBinding = BindingBuilder()
+        .setBinding(6)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding spotShadowBinding{};
-    spotShadowBinding.binding = 7;
-    spotShadowBinding.descriptorCount = 1;
-    spotShadowBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    spotShadowBinding.pImmutableSamplers = nullptr;
-    spotShadowBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    auto spotShadowBinding = BindingBuilder()
+        .setBinding(7)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
     std::array<VkDescriptorSetLayoutBinding, 8> bindings = {uboLayoutBinding, samplerLayoutBinding, shadowSamplerBinding, normalMapBinding, lightBufferBinding, emissiveMapBinding, pointShadowBinding, spotShadowBinding};
 
@@ -1616,54 +1609,47 @@ bool Renderer::createSkyDescriptorSetLayout() {
     // 5: Mie Irradiance LUT sampler (Phase 4.1.9)
     // 6: Cloud Map LUT sampler (Paraboloid projection, updated per-frame)
 
-    VkDescriptorSetLayoutBinding uboBinding{};
-    uboBinding.binding = 0;
-    uboBinding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    uboBinding.descriptorCount = 1;
-    uboBinding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    uboBinding.pImmutableSamplers = nullptr;
+    auto uboBinding = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding transmittanceLUTBinding{};
-    transmittanceLUTBinding.binding = 1;
-    transmittanceLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    transmittanceLUTBinding.descriptorCount = 1;
-    transmittanceLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    transmittanceLUTBinding.pImmutableSamplers = nullptr;
+    auto transmittanceLUTBinding = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding multiScatterLUTBinding{};
-    multiScatterLUTBinding.binding = 2;
-    multiScatterLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    multiScatterLUTBinding.descriptorCount = 1;
-    multiScatterLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    multiScatterLUTBinding.pImmutableSamplers = nullptr;
+    auto multiScatterLUTBinding = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding skyViewLUTBinding{};
-    skyViewLUTBinding.binding = 3;
-    skyViewLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    skyViewLUTBinding.descriptorCount = 1;
-    skyViewLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    skyViewLUTBinding.pImmutableSamplers = nullptr;
+    auto skyViewLUTBinding = BindingBuilder()
+        .setBinding(3)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding rayleighIrradianceLUTBinding{};
-    rayleighIrradianceLUTBinding.binding = 4;
-    rayleighIrradianceLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    rayleighIrradianceLUTBinding.descriptorCount = 1;
-    rayleighIrradianceLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    rayleighIrradianceLUTBinding.pImmutableSamplers = nullptr;
+    auto rayleighIrradianceLUTBinding = BindingBuilder()
+        .setBinding(4)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding mieIrradianceLUTBinding{};
-    mieIrradianceLUTBinding.binding = 5;
-    mieIrradianceLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    mieIrradianceLUTBinding.descriptorCount = 1;
-    mieIrradianceLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    mieIrradianceLUTBinding.pImmutableSamplers = nullptr;
+    auto mieIrradianceLUTBinding = BindingBuilder()
+        .setBinding(5)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
-    VkDescriptorSetLayoutBinding cloudMapLUTBinding{};
-    cloudMapLUTBinding.binding = 6;
-    cloudMapLUTBinding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    cloudMapLUTBinding.descriptorCount = 1;
-    cloudMapLUTBinding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    cloudMapLUTBinding.pImmutableSamplers = nullptr;
+    auto cloudMapLUTBinding = BindingBuilder()
+        .setBinding(6)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
 
     std::array<VkDescriptorSetLayoutBinding, 7> bindings = {
         uboBinding, transmittanceLUTBinding, multiScatterLUTBinding, skyViewLUTBinding,


### PR DESCRIPTION
Refactored manual VkDescriptorSetLayoutBinding creation to use the BindingBuilder pattern throughout the codebase for consistency and improved code clarity.

Changes:
- Renderer.cpp: Refactored createDescriptorSetLayout() and createSkyDescriptorSetLayout() to use BindingBuilder
- LeafSystem.cpp: Applied BindingBuilder to both compute and graphics descriptor layouts
- GrassSystem.cpp: Updated displacement pipeline descriptor layout
- BloomSystem.cpp: Converted descriptor set layouts to use BindingBuilder
- AtmosphereLUTSystem.cpp: Refactored all 5 LUT descriptor layouts (transmittance, multi-scatter, sky-view, irradiance, and cloud map)

The BindingBuilder pattern provides a cleaner, more maintainable API for creating Vulkan descriptor bindings with sensible defaults.