### PR TITLE
Implement Builder pattern for Renderable objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     src/ShaderLoader.cpp
     src/PipelineBuilder.cpp
     src/BindingBuilder.cpp
+    src/RenderableBuilder.cpp
     src/GrassSystem.cpp
     src/CelestialCalculator.cpp
     src/WindSystem.cpp

--- a/src/RenderableBuilder.cpp
+++ b/src/RenderableBuilder.cpp
@@ -1,0 +1,79 @@
+#include "RenderableBuilder.h"
+#include <SDL3/SDL_log.h>
+
+RenderableBuilder& RenderableBuilder::withMesh(Mesh* mesh) {
+    mesh_ = mesh;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withTexture(Texture* texture) {
+    texture_ = texture;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withTransform(const glm::mat4& transform) {
+    transform_ = transform;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withRoughness(float roughness) {
+    roughness_ = roughness;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withMetallic(float metallic) {
+    metallic_ = metallic;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withEmissiveIntensity(float intensity) {
+    emissiveIntensity_ = intensity;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withEmissiveColor(const glm::vec3& color) {
+    emissiveColor_ = color;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::withCastsShadow(bool casts) {
+    castsShadow_ = casts;
+    return *this;
+}
+
+RenderableBuilder& RenderableBuilder::atPosition(const glm::vec3& position) {
+    transform_ = glm::translate(glm::mat4(1.0f), position);
+    return *this;
+}
+
+bool RenderableBuilder::isValid() const {
+    return mesh_ != nullptr && texture_ != nullptr && transform_.has_value();
+}
+
+Renderable RenderableBuilder::build() const {
+    // Assert that all required fields are set
+    if (!mesh_) {
+        SDL_Log("RenderableBuilder::build() failed: mesh is required");
+        assert(mesh_ != nullptr && "RenderableBuilder: mesh is required");
+    }
+    if (!texture_) {
+        SDL_Log("RenderableBuilder::build() failed: texture is required");
+        assert(texture_ != nullptr && "RenderableBuilder: texture is required");
+    }
+    if (!transform_.has_value()) {
+        SDL_Log("RenderableBuilder::build() failed: transform is required");
+        assert(transform_.has_value() && "RenderableBuilder: transform is required");
+    }
+
+    Renderable renderable;
+    renderable.transform = transform_.value();
+    renderable.mesh = mesh_;
+    renderable.texture = texture_;
+    renderable.roughness = roughness_;
+    renderable.metallic = metallic_;
+    renderable.emissiveIntensity = emissiveIntensity_;
+    renderable.emissiveColor = emissiveColor_;
+    renderable.castsShadow = castsShadow_;
+
+    return renderable;
+}

--- a/src/RenderableBuilder.h
+++ b/src/RenderableBuilder.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <optional>
+#include <cassert>
+
+class Mesh;
+class Texture;
+
+// A fully-configured renderable object - can only be created via RenderableBuilder
+struct Renderable {
+    glm::mat4 transform;
+    Mesh* mesh;
+    Texture* texture;
+    float roughness = 0.5f;
+    float metallic = 0.0f;
+    float emissiveIntensity = 0.0f;
+    glm::vec3 emissiveColor = glm::vec3(1.0f);
+    bool castsShadow = true;
+
+private:
+    friend class RenderableBuilder;
+    Renderable() = default;
+};
+
+// Builder class that ensures a Renderable cannot be created without required fields
+class RenderableBuilder {
+public:
+    RenderableBuilder() = default;
+
+    // Required: Set the mesh for this renderable
+    RenderableBuilder& withMesh(Mesh* mesh);
+
+    // Required: Set the texture for this renderable
+    RenderableBuilder& withTexture(Texture* texture);
+
+    // Required: Set the world transform
+    RenderableBuilder& withTransform(const glm::mat4& transform);
+
+    // Optional: Set PBR roughness (default: 0.5)
+    RenderableBuilder& withRoughness(float roughness);
+
+    // Optional: Set PBR metallic (default: 0.0)
+    RenderableBuilder& withMetallic(float metallic);
+
+    // Optional: Set emissive intensity (default: 0.0, no emission)
+    RenderableBuilder& withEmissiveIntensity(float intensity);
+
+    // Optional: Set emissive color (default: white)
+    RenderableBuilder& withEmissiveColor(const glm::vec3& color);
+
+    // Optional: Set whether object casts shadows (default: true)
+    RenderableBuilder& withCastsShadow(bool casts);
+
+    // Convenience: Set position only (creates translation matrix)
+    RenderableBuilder& atPosition(const glm::vec3& position);
+
+    // Build the renderable - asserts if required fields are missing
+    // Returns a fully configured Renderable
+    Renderable build() const;
+
+    // Check if all required fields are set
+    bool isValid() const;
+
+private:
+    std::optional<glm::mat4> transform_;
+    Mesh* mesh_ = nullptr;
+    Texture* texture_ = nullptr;
+    float roughness_ = 0.5f;
+    float metallic_ = 0.0f;
+    float emissiveIntensity_ = 0.0f;
+    glm::vec3 emissiveColor_ = glm::vec3(1.0f);
+    bool castsShadow_ = true;
+};

--- a/src/SceneBuilder.cpp
+++ b/src/SceneBuilder.cpp
@@ -111,68 +111,137 @@ void SceneBuilder::createSceneObjects() {
     // Ground disc removed - terrain system provides the ground now
 
     // Wooden crate - slightly shiny, non-metallic
-    sceneObjects.push_back({
-        glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 0.5f, 0.0f)),
-        &cubeMesh, &crateTexture, 0.4f, 0.0f
-    });
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(2.0f, 0.5f, 0.0f))
+        .withMesh(&cubeMesh)
+        .withTexture(&crateTexture)
+        .withRoughness(0.4f)
+        .withMetallic(0.0f)
+        .build());
 
     // Rotated wooden crate
     glm::mat4 rotatedCube = glm::translate(glm::mat4(1.0f), glm::vec3(-1.5f, 0.5f, 1.0f));
     rotatedCube = glm::rotate(rotatedCube, glm::radians(30.0f), glm::vec3(0.0f, 1.0f, 0.0f));
-    sceneObjects.push_back({rotatedCube, &cubeMesh, &crateTexture, 0.4f, 0.0f});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(rotatedCube)
+        .withMesh(&cubeMesh)
+        .withTexture(&crateTexture)
+        .withRoughness(0.4f)
+        .withMetallic(0.0f)
+        .build());
 
     // Polished metal sphere - smooth, fully metallic
-    sceneObjects.push_back({
-        glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.5f, -2.0f)),
-        &sphereMesh, &metalTexture, 0.1f, 1.0f
-    });
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(0.0f, 0.5f, -2.0f))
+        .withMesh(&sphereMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.1f)
+        .withMetallic(1.0f)
+        .build());
 
     // Rough/brushed metal sphere - moderately rough, metallic
-    sceneObjects.push_back({
-        glm::translate(glm::mat4(1.0f), glm::vec3(-3.0f, 0.5f, -1.0f)),
-        &sphereMesh, &metalTexture, 0.5f, 1.0f
-    });
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(-3.0f, 0.5f, -1.0f))
+        .withMesh(&sphereMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.5f)
+        .withMetallic(1.0f)
+        .build());
 
     // Polished metal cube - smooth, fully metallic
-    sceneObjects.push_back({
-        glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 0.5f, -2.0f)),
-        &cubeMesh, &metalTexture, 0.1f, 1.0f
-    });
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(3.0f, 0.5f, -2.0f))
+        .withMesh(&cubeMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.1f)
+        .withMetallic(1.0f)
+        .build());
 
     // Brushed metal cube - rough, metallic
     glm::mat4 brushedCube = glm::translate(glm::mat4(1.0f), glm::vec3(-3.0f, 0.5f, -3.0f));
     brushedCube = glm::rotate(brushedCube, glm::radians(45.0f), glm::vec3(0.0f, 1.0f, 0.0f));
-    sceneObjects.push_back({brushedCube, &cubeMesh, &metalTexture, 0.6f, 1.0f});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(brushedCube)
+        .withMesh(&cubeMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.6f)
+        .withMetallic(1.0f)
+        .build());
 
     // Glowing emissive sphere on top of the first crate - demonstrates bloom effect
     glm::mat4 glowingSphereTransform = glm::translate(glm::mat4(1.0f), glm::vec3(2.0f, 1.3f, 0.0f));
     glowingSphereTransform = glm::scale(glowingSphereTransform, glm::vec3(0.3f));
-    sceneObjects.push_back({glowingSphereTransform, &sphereMesh, &metalTexture, 0.2f, 0.0f, 25.0f, glm::vec3(1.0f, 0.9f, 0.7f), false});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(glowingSphereTransform)
+        .withMesh(&sphereMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.2f)
+        .withMetallic(0.0f)
+        .withEmissiveIntensity(25.0f)
+        .withEmissiveColor(glm::vec3(1.0f, 0.9f, 0.7f))
+        .withCastsShadow(false)
+        .build());
 
     // Blue light indicator sphere - saturated blue, lower intensity to preserve color
     glm::mat4 blueLightTransform = glm::translate(glm::mat4(1.0f), glm::vec3(-3.0f, 2.0f, 2.0f));
     blueLightTransform = glm::scale(blueLightTransform, glm::vec3(0.2f));
-    sceneObjects.push_back({blueLightTransform, &sphereMesh, &metalTexture, 0.2f, 0.0f, 4.0f, glm::vec3(0.0f, 0.3f, 1.0f), false});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(blueLightTransform)
+        .withMesh(&sphereMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.2f)
+        .withMetallic(0.0f)
+        .withEmissiveIntensity(4.0f)
+        .withEmissiveColor(glm::vec3(0.0f, 0.3f, 1.0f))
+        .withCastsShadow(false)
+        .build());
 
     // Green light indicator sphere - saturated green, lower intensity to preserve color
     glm::mat4 greenLightTransform = glm::translate(glm::mat4(1.0f), glm::vec3(4.0f, 1.5f, -2.0f));
     greenLightTransform = glm::scale(greenLightTransform, glm::vec3(0.2f));
-    sceneObjects.push_back({greenLightTransform, &sphereMesh, &metalTexture, 0.2f, 0.0f, 3.0f, glm::vec3(0.0f, 1.0f, 0.2f), false});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(greenLightTransform)
+        .withMesh(&sphereMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.2f)
+        .withMetallic(0.0f)
+        .withEmissiveIntensity(3.0f)
+        .withEmissiveColor(glm::vec3(0.0f, 1.0f, 0.2f))
+        .withCastsShadow(false)
+        .build());
 
     // Player capsule - centered at origin, uses metal texture for visibility
     playerObjectIndex = sceneObjects.size();
-    glm::mat4 playerTransform = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.9f, 0.0f));
-    sceneObjects.push_back({playerTransform, &capsuleMesh, &metalTexture, 0.3f, 0.8f, 0.0f, glm::vec3(1.0f), true});
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(0.0f, 0.9f, 0.0f))
+        .withMesh(&capsuleMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.3f)
+        .withMetallic(0.8f)
+        .withCastsShadow(true)
+        .build());
 
     // Flag pole - positioned at (5, 1.5, 0) so the 3m pole sits on the ground
     flagPoleIndex = sceneObjects.size();
-    glm::mat4 flagPoleTransform = glm::translate(glm::mat4(1.0f), glm::vec3(5.0f, 1.5f, 0.0f));
-    sceneObjects.push_back({flagPoleTransform, &flagPoleMesh, &metalTexture, 0.4f, 0.9f, 0.0f, glm::vec3(1.0f), true});
+    sceneObjects.push_back(RenderableBuilder()
+        .atPosition(glm::vec3(5.0f, 1.5f, 0.0f))
+        .withMesh(&flagPoleMesh)
+        .withTexture(&metalTexture)
+        .withRoughness(0.4f)
+        .withMetallic(0.9f)
+        .withCastsShadow(true)
+        .build());
 
     // Flag cloth - will be positioned and updated by ClothSimulation
     flagClothIndex = sceneObjects.size();
-    glm::mat4 flagClothTransform = glm::mat4(1.0f);  // Identity, will be handled differently
-    sceneObjects.push_back({flagClothTransform, &flagClothMesh, &crateTexture, 0.6f, 0.0f, 0.0f, glm::vec3(1.0f), true});
+    sceneObjects.push_back(RenderableBuilder()
+        .withTransform(glm::mat4(1.0f))  // Identity, will be handled differently
+        .withMesh(&flagClothMesh)
+        .withTexture(&crateTexture)
+        .withRoughness(0.6f)
+        .withMetallic(0.0f)
+        .withCastsShadow(true)
+        .build());
 }
 
 void SceneBuilder::uploadFlagClothMesh(VmaAllocator allocator, VkDevice device, VkCommandPool commandPool, VkQueue queue) {

--- a/src/SceneBuilder.h
+++ b/src/SceneBuilder.h
@@ -9,17 +9,10 @@
 
 #include "Mesh.h"
 #include "Texture.h"
+#include "RenderableBuilder.h"
 
-struct SceneObject {
-    glm::mat4 transform;
-    Mesh* mesh;
-    Texture* texture;
-    float roughness = 0.5f;
-    float metallic = 0.0f;
-    float emissiveIntensity = 0.0f;
-    glm::vec3 emissiveColor = glm::vec3(1.0f);  // Default white (uses texture color)
-    bool castsShadow = true;
-};
+// Backward compatibility alias - Renderable is the canonical type
+using SceneObject = Renderable;
 
 // Holds all scene resources (meshes, textures) and provides scene objects
 class SceneBuilder {


### PR DESCRIPTION
Introduce a builder pattern for creating Renderable objects that ensures mesh, texture, and transform are always set before use. The build() method asserts if any required field is missing, catching configuration errors at creation time rather than render time.

- Add RenderableBuilder class with fluent API for mesh, texture, transform
- Add optional settings for roughness, metallic, emissive, castsShadow
- Add convenience atPosition() method for simple translations
- Update SceneBuilder to use RenderableBuilder for all scene objects
- Maintain backward compatibility with SceneObject alias for Renderable