### PR TITLE
Implement vertical terrain subdivision for cliffs

### DIFF
--- a/shaders/terrain/terrain_subdivision.comp
+++ b/shaders/terrain/terrain_subdivision.comp
@@ -44,6 +44,26 @@ float sampleHeight(vec2 uv) {
     return (texture(heightMap, uv).r - 0.5) * HEIGHT_SCALE;
 }
 
+// Compute heightmap gradient (direction of steepest ascent in UV space)
+vec2 computeGradient(vec2 uv) {
+    vec2 texelSize = 1.0 / vec2(textureSize(heightMap, 0));
+
+    float hL = texture(heightMap, uv + vec2(-texelSize.x, 0.0)).r;
+    float hR = texture(heightMap, uv + vec2(texelSize.x, 0.0)).r;
+    float hD = texture(heightMap, uv + vec2(0.0, -texelSize.y)).r;
+    float hU = texture(heightMap, uv + vec2(0.0, texelSize.y)).r;
+
+    // Gradient in UV space (pointing uphill)
+    return vec2(hR - hL, hU - hD) / (2.0 * texelSize);
+}
+
+// Compute slope magnitude (0 = flat, 1+ = steep)
+float computeSlopeMagnitude(vec2 gradient) {
+    // Scale gradient by terrain aspect ratio to get actual slope
+    float gradientMag = length(gradient) * HEIGHT_SCALE / TERRAIN_SIZE;
+    return gradientMag;
+}
+
 // Transform UV to world position
 vec3 uvToWorldPos(vec2 uv) {
     float height = sampleHeight(uv);
@@ -92,7 +112,11 @@ float computeScreenSpaceEdgeLength(vec3 p0, vec3 p1) {
     return length(s1 - s0);
 }
 
+// Gradient alignment weight - higher values = more subdivision on cliffs
+const float GRADIENT_ALIGNMENT_WEIGHT = 2.0;
+
 // Compute LOD for a triangle - returns longest edge length in pixels
+// Modified to penalize triangles stretched along the terrain gradient (perpendicular to contours)
 float computeTriangleLOD(vec2 v0, vec2 v1, vec2 v2) {
     vec3 p0 = uvToWorldPos(v0);
     vec3 p1 = uvToWorldPos(v1);
@@ -100,6 +124,33 @@ float computeTriangleLOD(vec2 v0, vec2 v1, vec2 v2) {
 
     // Find longest edge (in LEB, the longest edge is always between v1 and v2)
     float e12 = computeScreenSpaceEdgeLength(p1, p2);
+
+    // Compute gradient at triangle center
+    vec2 centerUV = (v0 + v1 + v2) / 3.0;
+    vec2 gradient = computeGradient(centerUV);
+    float slopeMag = computeSlopeMagnitude(gradient);
+
+    // Only apply gradient penalty on steep slopes
+    if (slopeMag > 0.1) {
+        // Edge direction in UV space (longest edge v1->v2)
+        vec2 edgeDir = v2 - v1;
+        float edgeLen = length(edgeDir);
+
+        if (edgeLen > 0.0001) {
+            edgeDir /= edgeLen;
+
+            // How aligned is this edge with the gradient direction?
+            // 1.0 = edge runs along gradient (bad - stretched on cliff)
+            // 0.0 = edge runs along contour (good - aligned with cliff face)
+            vec2 gradientDir = normalize(gradient);
+            float gradientAlignment = abs(dot(edgeDir, gradientDir));
+
+            // Penalize edges that run along the gradient direction
+            // This encourages subdivision to create edges that run along contours
+            float stretchFactor = 1.0 + gradientAlignment * slopeMag * GRADIENT_ALIGNMENT_WEIGHT;
+            e12 *= stretchFactor;
+        }
+    }
 
     return e12;
 }


### PR DESCRIPTION
Modify the terrain LOD system to consider heightmap gradients when evaluating triangle subdivision. Triangles that are stretched along the gradient direction (perpendicular to contour lines) are now penalized, encouraging the subdivision to create edges that align with the cliff face rather than arbitrary XZ directions.

- Add computeGradient() to sample heightmap gradient at UV coordinate
- Add computeSlopeMagnitude() to calculate slope steepness
- Modify computeTriangleLOD() to penalize gradient-aligned edges
- Edges running along contours (parallel to cliff face) can be larger
- Edges running down the slope get subdivided more aggressively