### PR TITLE
Refactor TerrainSystem into multiple classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ set(SOURCES
     src/PhysicsSystem.cpp
     src/ParticleSystem.cpp
     src/TerrainSystem.cpp
+    src/TerrainHeightMap.cpp
+    src/TerrainTextures.cpp
+    src/TerrainCBT.cpp
     src/ClothSimulation.cpp
     src/SnowMaskSystem.cpp
     src/VolumetricSnowSystem.cpp

--- a/src/TerrainCBT.cpp
+++ b/src/TerrainCBT.cpp
@@ -1,0 +1,176 @@
+#include "TerrainCBT.h"
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+namespace {
+    // Get bit field offset for a node at ceiling (maxDepth) level
+    uint32_t cbt_NodeBitID_BitField_CPU(uint32_t nodeId, int nodeDepth, int maxDepth) {
+        uint32_t ceilNodeId = nodeId << (maxDepth - nodeDepth);
+        return (2u << maxDepth) + ceilNodeId;
+    }
+
+    // Set a single bit in the bitfield (leaf node marker)
+    void cbt_HeapWrite_BitField_CPU(std::vector<uint32_t>& heap, uint32_t nodeId, int nodeDepth, int maxDepth) {
+        uint32_t bitID = cbt_NodeBitID_BitField_CPU(nodeId, nodeDepth, maxDepth);
+        uint32_t heapIndex = bitID >> 5;
+        uint32_t localBit = bitID & 31u;
+        if (heapIndex < heap.size()) {
+            heap[heapIndex] |= (1u << localBit);
+        }
+    }
+
+    // Node bit ID for sum reduction tree
+    uint32_t cbt_NodeBitID_CPU(uint32_t id, int depth, int maxDepth) {
+        uint32_t tmp1 = 2u << depth;
+        uint32_t tmp2 = uint32_t(1 + maxDepth - depth);
+        return tmp1 + id * tmp2;
+    }
+
+    int cbt_NodeBitSize_CPU(int depth, int maxDepth) {
+        return maxDepth - depth + 1;
+    }
+
+    // Read a value from the heap at a specific node position
+    uint32_t cbt_HeapRead_CPU(const std::vector<uint32_t>& heap, uint32_t id, int depth, int maxDepth) {
+        uint32_t bitOffset = cbt_NodeBitID_CPU(id, depth, maxDepth);
+        int bitCount = cbt_NodeBitSize_CPU(depth, maxDepth);
+
+        uint32_t heapIndex = bitOffset >> 5;
+        uint32_t localBitOffset = bitOffset & 31u;
+
+        uint32_t bitCountLSB = std::min(32u - localBitOffset, (uint32_t)bitCount);
+        uint32_t bitCountMSB = (uint32_t)bitCount - bitCountLSB;
+
+        uint32_t maskLSB = (1u << bitCountLSB) - 1u;
+        uint32_t lsb = (heap[heapIndex] >> localBitOffset) & maskLSB;
+
+        uint32_t msb = 0;
+        if (bitCountMSB > 0 && heapIndex + 1 < heap.size()) {
+            uint32_t maskMSB = (1u << bitCountMSB) - 1u;
+            msb = heap[heapIndex + 1] & maskMSB;
+        }
+
+        return lsb | (msb << bitCountLSB);
+    }
+
+    // Write a value to the heap at a specific node position
+    void cbt_HeapWrite_CPU(std::vector<uint32_t>& heap, uint32_t id, int depth, int maxDepth, uint32_t value) {
+        uint32_t bitOffset = cbt_NodeBitID_CPU(id, depth, maxDepth);
+        int bitCount = cbt_NodeBitSize_CPU(depth, maxDepth);
+
+        uint32_t heapIndex = bitOffset >> 5;
+        uint32_t localBitOffset = bitOffset & 31u;
+
+        uint32_t bitCountLSB = std::min(32u - localBitOffset, (uint32_t)bitCount);
+        uint32_t bitCountMSB = (uint32_t)bitCount - bitCountLSB;
+
+        // Clear and set LSB part
+        uint32_t maskLSB = ~(((1u << bitCountLSB) - 1u) << localBitOffset);
+        heap[heapIndex] = (heap[heapIndex] & maskLSB) | ((value & ((1u << bitCountLSB) - 1u)) << localBitOffset);
+
+        // If value spans two words, write MSB part
+        if (bitCountMSB > 0 && heapIndex + 1 < heap.size()) {
+            uint32_t maskMSB = ~((1u << bitCountMSB) - 1u);
+            heap[heapIndex + 1] = (heap[heapIndex + 1] & maskMSB) | (value >> bitCountLSB);
+        }
+    }
+
+    // Compute sum reduction from leaf nodes up to root
+    void cbt_ComputeSumReduction_CPU(std::vector<uint32_t>& heap, int maxDepth, int leafDepth) {
+        for (int depth = leafDepth - 1; depth >= 0; --depth) {
+            uint32_t minNodeID = 1u << depth;
+            uint32_t maxNodeID = 2u << depth;
+
+            for (uint32_t nodeID = minNodeID; nodeID < maxNodeID; ++nodeID) {
+                uint32_t leftChild = nodeID << 1;
+                uint32_t rightChild = leftChild | 1u;
+
+                uint32_t leftValue = cbt_HeapRead_CPU(heap, leftChild, depth + 1, maxDepth);
+                uint32_t rightValue = cbt_HeapRead_CPU(heap, rightChild, depth + 1, maxDepth);
+
+                cbt_HeapWrite_CPU(heap, nodeID, depth, maxDepth, leftValue + rightValue);
+            }
+        }
+    }
+}
+
+uint32_t TerrainCBT::calculateBufferSize(int maxDepth) {
+    // For max depth D, the bitfield needs 2^(D-1) bits = 2^(D-4) bytes
+    // Plus the sum reduction tree overhead
+    uint64_t bitfieldBytes = 1ull << (maxDepth - 1);
+    // Add some extra for alignment and sum reduction, cap at 64MB
+    return static_cast<uint32_t>(std::min(bitfieldBytes * 2, (uint64_t)64 * 1024 * 1024));
+}
+
+bool TerrainCBT::init(const InitInfo& info) {
+    maxDepth = info.maxDepth;
+    bufferSize = calculateBufferSize(maxDepth);
+
+    // Create buffer
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = bufferSize;
+    bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+
+    if (vmaCreateBuffer(info.allocator, &bufferInfo, &allocInfo, &buffer, &allocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create CBT buffer" << std::endl;
+        return false;
+    }
+
+    // Initialize CBT with triangles covering the terrain quad
+    std::vector<uint32_t> initData(bufferSize / sizeof(uint32_t), 0);
+    int initDepth = info.initDepth;
+
+    // heap[0] stores (1 << maxDepth) as a marker for the max depth
+    initData[0] = (1u << maxDepth);
+
+    // Step 1: Set bitfield bits for all leaf nodes at initDepth
+    uint32_t minNodeID = 1u << initDepth;
+    uint32_t maxNodeID = 2u << initDepth;
+
+    for (uint32_t nodeID = minNodeID; nodeID < maxNodeID; ++nodeID) {
+        cbt_HeapWrite_BitField_CPU(initData, nodeID, initDepth, maxDepth);
+    }
+
+    // Step 2: Initialize leaf node counts to 1
+    for (uint32_t nodeID = minNodeID; nodeID < maxNodeID; ++nodeID) {
+        cbt_HeapWrite_CPU(initData, nodeID, initDepth, maxDepth, 1);
+    }
+
+    // Step 3: Compute sum reduction upward from initDepth to depth 0
+    cbt_ComputeSumReduction_CPU(initData, maxDepth, initDepth);
+
+    // Verify: root should have correct count
+    uint32_t rootCount = cbt_HeapRead_CPU(initData, 1, 0, maxDepth);
+    std::cout << "CBT root count after init: " << rootCount << std::endl;
+
+    // Map the CBT buffer and write initialization data
+    void* data;
+    if (vmaMapMemory(info.allocator, allocation, &data) != VK_SUCCESS) {
+        std::cerr << "Failed to map CBT buffer for initialization" << std::endl;
+        return false;
+    }
+    memcpy(data, initData.data(), bufferSize);
+    vmaUnmapMemory(info.allocator, allocation);
+
+    std::cout << "CBT initialized with " << (maxNodeID - minNodeID) << " triangles at depth "
+              << initDepth << ", max depth " << maxDepth << std::endl;
+
+    return true;
+}
+
+void TerrainCBT::destroy(VmaAllocator allocator) {
+    if (buffer) {
+        vmaDestroyBuffer(allocator, buffer, allocation);
+        buffer = VK_NULL_HANDLE;
+        allocation = VK_NULL_HANDLE;
+    }
+}

--- a/src/TerrainCBT.h
+++ b/src/TerrainCBT.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <cstdint>
+
+// Concurrent Binary Tree (CBT) buffer for terrain subdivision
+class TerrainCBT {
+public:
+    struct InitInfo {
+        VmaAllocator allocator;
+        int maxDepth;
+        int initDepth;  // Initial subdivision depth (e.g., 6 for 64 triangles)
+    };
+
+    TerrainCBT() = default;
+    ~TerrainCBT() = default;
+
+    bool init(const InitInfo& info);
+    void destroy(VmaAllocator allocator);
+
+    // Buffer accessors
+    VkBuffer getBuffer() const { return buffer; }
+    uint32_t getBufferSize() const { return bufferSize; }
+    int getMaxDepth() const { return maxDepth; }
+
+private:
+    static uint32_t calculateBufferSize(int maxDepth);
+
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    uint32_t bufferSize = 0;
+    int maxDepth = 20;
+};

--- a/src/TerrainHeightMap.cpp
+++ b/src/TerrainHeightMap.cpp
@@ -1,0 +1,288 @@
+#include "TerrainHeightMap.h"
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+#include <glm/glm.hpp>
+
+bool TerrainHeightMap::init(const InitInfo& info) {
+    device = info.device;
+    allocator = info.allocator;
+    graphicsQueue = info.graphicsQueue;
+    commandPool = info.commandPool;
+    resolution = info.resolution;
+    terrainSize = info.terrainSize;
+    heightScale = info.heightScale;
+
+    if (!generateHeightData()) return false;
+    if (!createGPUResources()) return false;
+    if (!uploadToGPU()) return false;
+
+    std::cout << "TerrainHeightMap initialized: " << resolution << "x" << resolution << std::endl;
+    return true;
+}
+
+void TerrainHeightMap::destroy(VkDevice device, VmaAllocator allocator) {
+    if (sampler) vkDestroySampler(device, sampler, nullptr);
+    if (imageView) vkDestroyImageView(device, imageView, nullptr);
+    if (image) vmaDestroyImage(allocator, image, allocation);
+
+    sampler = VK_NULL_HANDLE;
+    imageView = VK_NULL_HANDLE;
+    image = VK_NULL_HANDLE;
+    allocation = VK_NULL_HANDLE;
+}
+
+bool TerrainHeightMap::generateHeightData() {
+    cpuData.resize(resolution * resolution);
+
+    for (uint32_t y = 0; y < resolution; y++) {
+        for (uint32_t x = 0; x < resolution; x++) {
+            float fx = static_cast<float>(x) / resolution;
+            float fy = static_cast<float>(y) / resolution;
+
+            // Distance from center (0.5, 0.5)
+            float dx = fx - 0.5f;
+            float dy = fy - 0.5f;
+            float dist = sqrt(dx * dx + dy * dy);
+
+            // Multiple octaves of sine-based noise for hills
+            float height = 0.0f;
+            height += 0.5f * sin(fx * 3.14159f * 2.0f) * sin(fy * 3.14159f * 2.0f);
+            height += 0.25f * sin(fx * 3.14159f * 4.0f + 0.5f) * sin(fy * 3.14159f * 4.0f + 0.3f);
+            height += 0.125f * sin(fx * 3.14159f * 8.0f + 1.0f) * sin(fy * 3.14159f * 8.0f + 0.7f);
+            height += 0.0625f * sin(fx * 3.14159f * 16.0f + 2.0f) * sin(fy * 3.14159f * 16.0f + 1.5f);
+
+            // Flatten center area where scene objects are
+            float flattenFactor = glm::smoothstep(0.02f, 0.08f, dist);
+            height *= flattenFactor;
+
+            // Add steep cliff area for testing triplanar mapping
+            float cliffCenterX = 0.70f;
+            float cliffCenterY = 0.70f;
+            float distToCliffCenter = sqrt((fx - cliffCenterX) * (fx - cliffCenterX) +
+                                           (fy - cliffCenterY) * (fy - cliffCenterY));
+
+            float cliffRadius = 0.08f;
+            float cliffTransition = 0.015f;
+            float cliffHeight = 0.8f;
+
+            float cliffFactor = 1.0f - glm::smoothstep(cliffRadius - cliffTransition,
+                                                        cliffRadius + cliffTransition,
+                                                        distToCliffCenter);
+            height += cliffFactor * cliffHeight;
+
+            // Add a second smaller cliff area
+            float cliff2CenterX = 0.25f;
+            float cliff2CenterY = 0.30f;
+            float distToCliff2 = sqrt((fx - cliff2CenterX) * (fx - cliff2CenterX) +
+                                      (fy - cliff2CenterY) * (fy - cliff2CenterY));
+            float cliff2Factor = 1.0f - glm::smoothstep(0.05f - 0.01f, 0.05f + 0.01f, distToCliff2);
+            height += cliff2Factor * 0.6f;
+
+            // Normalize to [0, 1]
+            height = (height + 1.0f) * 0.5f;
+            height = std::clamp(height, 0.0f, 1.0f);
+            cpuData[y * resolution + x] = height;
+        }
+    }
+
+    return true;
+}
+
+bool TerrainHeightMap::createGPUResources() {
+    // Create Vulkan image
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = VK_FORMAT_R32_SFLOAT;
+    imageInfo.extent = {resolution, resolution, 1};
+    imageInfo.mipLevels = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    if (vmaCreateImage(allocator, &imageInfo, &allocInfo, &image, &allocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create height map image" << std::endl;
+        return false;
+    }
+
+    // Create image view
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = image;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = VK_FORMAT_R32_SFLOAT;
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = 1;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
+        std::cerr << "Failed to create height map image view" << std::endl;
+        return false;
+    }
+
+    // Create sampler
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+
+    if (vkCreateSampler(device, &samplerInfo, nullptr, &sampler) != VK_SUCCESS) {
+        std::cerr << "Failed to create height map sampler" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+bool TerrainHeightMap::uploadToGPU() {
+    VkDeviceSize imageSize = resolution * resolution * sizeof(float);
+
+    // Create staging buffer
+    VkBuffer stagingBuffer;
+    VmaAllocation stagingAllocation;
+
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = imageSize;
+    bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+
+    if (vmaCreateBuffer(allocator, &bufferInfo, &allocInfo, &stagingBuffer, &stagingAllocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create staging buffer for height map upload" << std::endl;
+        return false;
+    }
+
+    // Copy data to staging buffer
+    void* mappedData;
+    vmaMapMemory(allocator, stagingAllocation, &mappedData);
+    memcpy(mappedData, cpuData.data(), imageSize);
+    vmaUnmapMemory(allocator, stagingAllocation);
+
+    // Allocate command buffer
+    VkCommandBufferAllocateInfo cmdAllocInfo{};
+    cmdAllocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cmdAllocInfo.commandPool = commandPool;
+    cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmdAllocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer cmd;
+    vkAllocateCommandBuffers(device, &cmdAllocInfo, &cmd);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &beginInfo);
+
+    // Transition image to transfer destination
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+    barrier.srcAccessMask = 0;
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    // Copy buffer to image
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+    region.imageOffset = {0, 0, 0};
+    region.imageExtent = {resolution, resolution, 1};
+
+    vkCmdCopyBufferToImage(cmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    // Transition image to shader read
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    vkEndCommandBuffer(cmd);
+
+    // Submit and wait
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &cmd;
+
+    vkQueueSubmit(graphicsQueue, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(graphicsQueue);
+
+    // Cleanup
+    vkFreeCommandBuffers(device, commandPool, 1, &cmd);
+    vmaDestroyBuffer(allocator, stagingBuffer, stagingAllocation);
+
+    return true;
+}
+
+float TerrainHeightMap::getHeightAt(float x, float z) const {
+    // Convert world position to UV coordinates
+    float u = (x / terrainSize) + 0.5f;
+    float v = (z / terrainSize) + 0.5f;
+
+    // Clamp to valid range
+    u = std::clamp(u, 0.0f, 1.0f);
+    v = std::clamp(v, 0.0f, 1.0f);
+
+    // Sample height map with bilinear interpolation
+    float fx = u * (resolution - 1);
+    float fy = v * (resolution - 1);
+
+    int x0 = static_cast<int>(fx);
+    int y0 = static_cast<int>(fy);
+    int x1 = std::min(x0 + 1, static_cast<int>(resolution - 1));
+    int y1 = std::min(y0 + 1, static_cast<int>(resolution - 1));
+
+    float tx = fx - x0;
+    float ty = fy - y0;
+
+    float h00 = cpuData[y0 * resolution + x0];
+    float h10 = cpuData[y0 * resolution + x1];
+    float h01 = cpuData[y1 * resolution + x0];
+    float h11 = cpuData[y1 * resolution + x1];
+
+    float h0 = h00 * (1.0f - tx) + h10 * tx;
+    float h1 = h01 * (1.0f - tx) + h11 * tx;
+    float h = h0 * (1.0f - ty) + h1 * ty;
+
+    // Match shader: (h - 0.5) * heightScale, centers height around Y=0
+    return (h - 0.5f) * heightScale;
+}

--- a/src/TerrainHeightMap.h
+++ b/src/TerrainHeightMap.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <vector>
+
+// Height map for terrain - handles generation, GPU texture, and CPU queries
+class TerrainHeightMap {
+public:
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        VkQueue graphicsQueue;
+        VkCommandPool commandPool;
+        uint32_t resolution;
+        float terrainSize;
+        float heightScale;
+    };
+
+    TerrainHeightMap() = default;
+    ~TerrainHeightMap() = default;
+
+    bool init(const InitInfo& info);
+    void destroy(VkDevice device, VmaAllocator allocator);
+
+    // GPU resource accessors
+    VkImageView getView() const { return imageView; }
+    VkSampler getSampler() const { return sampler; }
+
+    // CPU-side height query (for physics/collision)
+    float getHeightAt(float x, float z) const;
+
+    // Raw data accessors
+    const float* getData() const { return cpuData.data(); }
+    uint32_t getResolution() const { return resolution; }
+
+private:
+    bool generateHeightData();
+    bool createGPUResources();
+    bool uploadToGPU();
+
+    // Init params (stored for queries)
+    VkDevice device = VK_NULL_HANDLE;
+    VmaAllocator allocator = VK_NULL_HANDLE;
+    VkQueue graphicsQueue = VK_NULL_HANDLE;
+    VkCommandPool commandPool = VK_NULL_HANDLE;
+    float terrainSize = 500.0f;
+    float heightScale = 50.0f;
+    uint32_t resolution = 512;
+
+    // GPU resources
+    VkImage image = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    VkImageView imageView = VK_NULL_HANDLE;
+    VkSampler sampler = VK_NULL_HANDLE;
+
+    // CPU-side data for collision queries
+    std::vector<float> cpuData;
+};

--- a/src/TerrainTextures.cpp
+++ b/src/TerrainTextures.cpp
@@ -1,0 +1,325 @@
+#include "TerrainTextures.h"
+#include <cstring>
+#include <cmath>
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+bool TerrainTextures::init(const InitInfo& info) {
+    device = info.device;
+    allocator = info.allocator;
+    graphicsQueue = info.graphicsQueue;
+    commandPool = info.commandPool;
+
+    if (!createAlbedoTexture()) return false;
+    if (!createGrassFarLODTexture()) return false;
+
+    std::cout << "TerrainTextures initialized" << std::endl;
+    return true;
+}
+
+void TerrainTextures::destroy(VkDevice device, VmaAllocator allocator) {
+    if (albedoSampler) vkDestroySampler(device, albedoSampler, nullptr);
+    if (albedoView) vkDestroyImageView(device, albedoView, nullptr);
+    if (albedoImage) vmaDestroyImage(allocator, albedoImage, albedoAllocation);
+
+    if (grassFarLODSampler) vkDestroySampler(device, grassFarLODSampler, nullptr);
+    if (grassFarLODView) vkDestroyImageView(device, grassFarLODView, nullptr);
+    if (grassFarLODImage) vmaDestroyImage(allocator, grassFarLODImage, grassFarLODAllocation);
+
+    albedoSampler = VK_NULL_HANDLE;
+    albedoView = VK_NULL_HANDLE;
+    albedoImage = VK_NULL_HANDLE;
+    grassFarLODSampler = VK_NULL_HANDLE;
+    grassFarLODView = VK_NULL_HANDLE;
+    grassFarLODImage = VK_NULL_HANDLE;
+}
+
+bool TerrainTextures::createAlbedoTexture() {
+    const uint32_t texSize = 256;
+    std::vector<uint8_t> texData(texSize * texSize * 4);
+
+    for (uint32_t y = 0; y < texSize; y++) {
+        for (uint32_t x = 0; x < texSize; x++) {
+            float fx = static_cast<float>(x) / texSize;
+            float fy = static_cast<float>(y) / texSize;
+
+            // Green grass base color with variation
+            float noise = 0.5f + 0.5f * sin(fx * 50.0f) * sin(fy * 50.0f);
+            noise += 0.25f * sin(fx * 100.0f + 1.0f) * sin(fy * 100.0f + 0.5f);
+
+            uint8_t r = static_cast<uint8_t>(std::clamp((80 + 40 * noise), 0.0f, 255.0f));
+            uint8_t g = static_cast<uint8_t>(std::clamp((120 + 60 * noise), 0.0f, 255.0f));
+            uint8_t b = static_cast<uint8_t>(std::clamp((60 + 30 * noise), 0.0f, 255.0f));
+
+            size_t idx = (y * texSize + x) * 4;
+            texData[idx + 0] = r;
+            texData[idx + 1] = g;
+            texData[idx + 2] = b;
+            texData[idx + 3] = 255;
+        }
+    }
+
+    // Create Vulkan image
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+    imageInfo.extent = {texSize, texSize, 1};
+    imageInfo.mipLevels = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    if (vmaCreateImage(allocator, &imageInfo, &allocInfo, &albedoImage, &albedoAllocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create terrain albedo image" << std::endl;
+        return false;
+    }
+
+    // Create image view
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = albedoImage;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = 1;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(device, &viewInfo, nullptr, &albedoView) != VK_SUCCESS) {
+        std::cerr << "Failed to create terrain albedo image view" << std::endl;
+        return false;
+    }
+
+    // Create sampler
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.anisotropyEnable = VK_TRUE;
+    samplerInfo.maxAnisotropy = 16.0f;
+
+    if (vkCreateSampler(device, &samplerInfo, nullptr, &albedoSampler) != VK_SUCCESS) {
+        std::cerr << "Failed to create terrain albedo sampler" << std::endl;
+        return false;
+    }
+
+    // Upload texture to GPU
+    if (!uploadImageData(albedoImage, texData.data(), texSize, texSize, VK_FORMAT_R8G8B8A8_SRGB, 4)) {
+        std::cerr << "Failed to upload terrain albedo texture to GPU" << std::endl;
+        return false;
+    }
+
+    std::cout << "Terrain albedo texture uploaded: " << texSize << "x" << texSize << std::endl;
+    return true;
+}
+
+bool TerrainTextures::createGrassFarLODTexture() {
+    const uint32_t texSize = 256;
+    std::vector<uint8_t> texData(texSize * texSize * 4);
+
+    for (uint32_t y = 0; y < texSize; y++) {
+        for (uint32_t x = 0; x < texSize; x++) {
+            float fx = static_cast<float>(x) / texSize;
+            float fy = static_cast<float>(y) / texSize;
+
+            // Grass-like color with subtle variation (matches grass blade colors)
+            float noise = 0.5f + 0.3f * sin(fx * 80.0f) * sin(fy * 80.0f);
+            noise += 0.15f * sin(fx * 160.0f + 0.5f) * sin(fy * 160.0f + 0.3f);
+
+            // Match grass blade colors from grass.vert
+            uint8_t r = static_cast<uint8_t>(std::clamp((60 + 30 * noise), 0.0f, 255.0f));
+            uint8_t g = static_cast<uint8_t>(std::clamp((130 + 50 * noise), 0.0f, 255.0f));
+            uint8_t b = static_cast<uint8_t>(std::clamp((40 + 25 * noise), 0.0f, 255.0f));
+
+            size_t idx = (y * texSize + x) * 4;
+            texData[idx + 0] = r;
+            texData[idx + 1] = g;
+            texData[idx + 2] = b;
+            texData[idx + 3] = 255;
+        }
+    }
+
+    // Create Vulkan image
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+    imageInfo.extent = {texSize, texSize, 1};
+    imageInfo.mipLevels = 1;
+    imageInfo.arrayLayers = 1;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    if (vmaCreateImage(allocator, &imageInfo, &allocInfo, &grassFarLODImage, &grassFarLODAllocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create grass far LOD image" << std::endl;
+        return false;
+    }
+
+    // Create image view
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = grassFarLODImage;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = VK_FORMAT_R8G8B8A8_SRGB;
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = 1;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(device, &viewInfo, nullptr, &grassFarLODView) != VK_SUCCESS) {
+        std::cerr << "Failed to create grass far LOD image view" << std::endl;
+        return false;
+    }
+
+    // Create sampler
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_LINEAR;
+    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    samplerInfo.anisotropyEnable = VK_TRUE;
+    samplerInfo.maxAnisotropy = 16.0f;
+
+    if (vkCreateSampler(device, &samplerInfo, nullptr, &grassFarLODSampler) != VK_SUCCESS) {
+        std::cerr << "Failed to create grass far LOD sampler" << std::endl;
+        return false;
+    }
+
+    // Upload texture to GPU
+    if (!uploadImageData(grassFarLODImage, texData.data(), texSize, texSize, VK_FORMAT_R8G8B8A8_SRGB, 4)) {
+        std::cerr << "Failed to upload grass far LOD texture to GPU" << std::endl;
+        return false;
+    }
+
+    std::cout << "Grass far LOD texture uploaded: " << texSize << "x" << texSize << std::endl;
+    return true;
+}
+
+bool TerrainTextures::uploadImageData(VkImage image, const void* data, uint32_t width, uint32_t height,
+                                       VkFormat format, uint32_t bytesPerPixel) {
+    VkDeviceSize imageSize = width * height * bytesPerPixel;
+
+    // Create staging buffer
+    VkBuffer stagingBuffer;
+    VmaAllocation stagingAllocation;
+
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = imageSize;
+    bufferInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+
+    if (vmaCreateBuffer(allocator, &bufferInfo, &allocInfo, &stagingBuffer, &stagingAllocation, nullptr) != VK_SUCCESS) {
+        std::cerr << "Failed to create staging buffer for image upload" << std::endl;
+        return false;
+    }
+
+    // Copy data to staging buffer
+    void* mappedData;
+    vmaMapMemory(allocator, stagingAllocation, &mappedData);
+    memcpy(mappedData, data, imageSize);
+    vmaUnmapMemory(allocator, stagingAllocation);
+
+    // Allocate command buffer
+    VkCommandBufferAllocateInfo cmdAllocInfo{};
+    cmdAllocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cmdAllocInfo.commandPool = commandPool;
+    cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmdAllocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer cmd;
+    vkAllocateCommandBuffers(device, &cmdAllocInfo, &cmd);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &beginInfo);
+
+    // Transition image to transfer destination
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+    barrier.srcAccessMask = 0;
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    // Copy buffer to image
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.mipLevel = 0;
+    region.imageSubresource.baseArrayLayer = 0;
+    region.imageSubresource.layerCount = 1;
+    region.imageOffset = {0, 0, 0};
+    region.imageExtent = {width, height, 1};
+
+    vkCmdCopyBufferToImage(cmd, stagingBuffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    // Transition image to shader read
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    vkEndCommandBuffer(cmd);
+
+    // Submit and wait
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &cmd;
+
+    vkQueueSubmit(graphicsQueue, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(graphicsQueue);
+
+    // Cleanup
+    vkFreeCommandBuffers(device, commandPool, 1, &cmd);
+    vmaDestroyBuffer(allocator, stagingBuffer, stagingAllocation);
+
+    return true;
+}

--- a/src/TerrainTextures.h
+++ b/src/TerrainTextures.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+
+// Terrain textures - albedo and grass far LOD textures
+class TerrainTextures {
+public:
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        VkQueue graphicsQueue;
+        VkCommandPool commandPool;
+    };
+
+    TerrainTextures() = default;
+    ~TerrainTextures() = default;
+
+    bool init(const InitInfo& info);
+    void destroy(VkDevice device, VmaAllocator allocator);
+
+    // Terrain albedo texture
+    VkImageView getAlbedoView() const { return albedoView; }
+    VkSampler getAlbedoSampler() const { return albedoSampler; }
+
+    // Grass far LOD texture (for terrain blending at distance)
+    VkImageView getGrassFarLODView() const { return grassFarLODView; }
+    VkSampler getGrassFarLODSampler() const { return grassFarLODSampler; }
+
+private:
+    bool createAlbedoTexture();
+    bool createGrassFarLODTexture();
+    bool uploadImageData(VkImage image, const void* data, uint32_t width, uint32_t height,
+                         VkFormat format, uint32_t bytesPerPixel);
+
+    // Init params
+    VkDevice device = VK_NULL_HANDLE;
+    VmaAllocator allocator = VK_NULL_HANDLE;
+    VkQueue graphicsQueue = VK_NULL_HANDLE;
+    VkCommandPool commandPool = VK_NULL_HANDLE;
+
+    // Terrain albedo texture
+    VkImage albedoImage = VK_NULL_HANDLE;
+    VmaAllocation albedoAllocation = VK_NULL_HANDLE;
+    VkImageView albedoView = VK_NULL_HANDLE;
+    VkSampler albedoSampler = VK_NULL_HANDLE;
+
+    // Grass far LOD texture
+    VkImage grassFarLODImage = VK_NULL_HANDLE;
+    VmaAllocation grassFarLODAllocation = VK_NULL_HANDLE;
+    VkImageView grassFarLODView = VK_NULL_HANDLE;
+    VkSampler grassFarLODSampler = VK_NULL_HANDLE;
+};


### PR DESCRIPTION
Split the monolithic TerrainSystem (~1750 lines) into:
- TerrainHeightMap: Height data generation, GPU texture, CPU queries
- TerrainTextures: Albedo and grass far LOD textures
- TerrainCBT: Concurrent Binary Tree buffer management

TerrainSystem now uses composition to delegate to these classes while maintaining its existing public API. This improves maintainability and makes TerrainHeightMap reusable for physics/collision.