### PR TITLE
Extract sky rendering into separate module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
     src/ClothSimulation.cpp
     src/SnowMaskSystem.cpp
     src/VolumetricSnowSystem.cpp
+    src/SkySystem.cpp
     src/GuiSystem.cpp
 )
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -126,8 +126,18 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     postProcessSystem.setBloomTexture(bloomSystem.getBloomOutput(), bloomSystem.getBloomSampler());
 
     if (!createGraphicsPipeline()) return false;
-    if (!createSkyDescriptorSetLayout()) return false;  // Create sky layout before sky pipeline
-    if (!createSkyPipeline()) return false;
+
+    // Initialize sky system (needs HDR render pass from postProcessSystem)
+    SkySystem::InitInfo skyInfo{};
+    skyInfo.device = device;
+    skyInfo.allocator = allocator;
+    skyInfo.descriptorPool = descriptorPool;
+    skyInfo.shaderPath = resourcePath + "/shaders";
+    skyInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
+    skyInfo.extent = swapchainExtent;
+    skyInfo.hdrRenderPass = postProcessSystem.getHDRRenderPass();
+
+    if (!skySystem.init(skyInfo)) return false;
     if (!createShadowPipeline()) return false;
     if (!createDynamicShadowPipeline()) return false;
     if (!createCommandBuffers()) return false;
@@ -366,7 +376,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     SDL_Log("Atmosphere LUTs exported as PNG to: %s", resourcePath.c_str());
 
     // Create sky descriptor sets now that uniform buffers and LUTs are ready
-    if (!createSkyDescriptorSets()) return false;
+    if (!skySystem.createDescriptorSets(uniformBuffers, sizeof(UniformBufferObject), atmosphereLUTSystem)) return false;
 
     if (!createSyncObjects()) return false;
 
@@ -424,15 +434,13 @@ void Renderer::shutdown() {
         leafSystem.destroy(device, allocator);
         froxelSystem.destroy(device, allocator);
         atmosphereLUTSystem.destroy(device, allocator);
+        skySystem.destroy(device, allocator);
         postProcessSystem.destroy(device, allocator);
         bloomSystem.destroy(device, allocator);
 
-        vkDestroyPipeline(device, skyPipeline, nullptr);
         vkDestroyPipeline(device, graphicsPipeline, nullptr);
         vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
-        vkDestroyPipelineLayout(device, skyPipelineLayout, nullptr);
         vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
-        vkDestroyDescriptorSetLayout(device, skyDescriptorSetLayout, nullptr);
 
         // Shadow cleanup
         if (shadowPipeline != VK_NULL_HANDLE) {
@@ -1653,224 +1661,6 @@ bool Renderer::createDescriptorSetLayout() {
     return true;
 }
 
-bool Renderer::createSkyDescriptorSetLayout() {
-    // Sky shader bindings:
-    // 0: UBO (same as main shader)
-    // 1: Transmittance LUT sampler
-    // 2: Multi-scatter LUT sampler
-    // 3: Sky-view LUT sampler (updated per-frame)
-    // 4: Rayleigh Irradiance LUT sampler (Phase 4.1.9)
-    // 5: Mie Irradiance LUT sampler (Phase 4.1.9)
-    // 6: Cloud Map LUT sampler (Paraboloid projection, updated per-frame)
-
-    auto uboBinding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto transmittanceLUTBinding = BindingBuilder()
-        .setBinding(1)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto multiScatterLUTBinding = BindingBuilder()
-        .setBinding(2)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto skyViewLUTBinding = BindingBuilder()
-        .setBinding(3)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto rayleighIrradianceLUTBinding = BindingBuilder()
-        .setBinding(4)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto mieIrradianceLUTBinding = BindingBuilder()
-        .setBinding(5)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto cloudMapLUTBinding = BindingBuilder()
-        .setBinding(6)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    std::array<VkDescriptorSetLayoutBinding, 7> bindings = {
-        uboBinding, transmittanceLUTBinding, multiScatterLUTBinding, skyViewLUTBinding,
-        rayleighIrradianceLUTBinding, mieIrradianceLUTBinding, cloudMapLUTBinding
-    };
-
-    VkDescriptorSetLayoutCreateInfo layoutInfo{};
-    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
-    layoutInfo.pBindings = bindings.data();
-
-    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &skyDescriptorSetLayout) != VK_SUCCESS) {
-        SDL_Log("Failed to create sky descriptor set layout");
-        return false;
-    }
-
-    // Create pipeline layout for sky shader
-    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
-    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pipelineLayoutInfo.setLayoutCount = 1;
-    pipelineLayoutInfo.pSetLayouts = &skyDescriptorSetLayout;
-    pipelineLayoutInfo.pushConstantRangeCount = 0;
-    pipelineLayoutInfo.pPushConstantRanges = nullptr;
-
-    if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &skyPipelineLayout) != VK_SUCCESS) {
-        SDL_Log("Failed to create sky pipeline layout");
-        return false;
-    }
-
-    return true;
-}
-
-bool Renderer::createSkyDescriptorSets() {
-    // Allocate sky descriptor sets (one per frame in flight)
-    std::vector<VkDescriptorSetLayout> layouts(MAX_FRAMES_IN_FLIGHT, skyDescriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT);
-    allocInfo.pSetLayouts = layouts.data();
-
-    skyDescriptorSets.resize(MAX_FRAMES_IN_FLIGHT);
-    if (vkAllocateDescriptorSets(device, &allocInfo, skyDescriptorSets.data()) != VK_SUCCESS) {
-        SDL_Log("Failed to allocate sky descriptor sets");
-        return false;
-    }
-
-    // Get LUT views and sampler from atmosphere system
-    VkImageView transmittanceLUTView = atmosphereLUTSystem.getTransmittanceLUTView();
-    VkImageView multiScatterLUTView = atmosphereLUTSystem.getMultiScatterLUTView();
-    VkImageView skyViewLUTView = atmosphereLUTSystem.getSkyViewLUTView();
-    VkImageView rayleighIrradianceLUTView = atmosphereLUTSystem.getRayleighIrradianceLUTView();
-    VkImageView mieIrradianceLUTView = atmosphereLUTSystem.getMieIrradianceLUTView();
-    VkImageView cloudMapLUTView = atmosphereLUTSystem.getCloudMapLUTView();
-    VkSampler lutSampler = atmosphereLUTSystem.getLUTSampler();
-
-    // Update each descriptor set
-    for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
-        // UBO binding
-        VkDescriptorBufferInfo bufferInfo{};
-        bufferInfo.buffer = uniformBuffers[i];
-        bufferInfo.offset = 0;
-        bufferInfo.range = sizeof(UniformBufferObject);
-
-        // Transmittance LUT binding
-        VkDescriptorImageInfo transmittanceInfo{};
-        transmittanceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        transmittanceInfo.imageView = transmittanceLUTView;
-        transmittanceInfo.sampler = lutSampler;
-
-        // Multi-scatter LUT binding
-        VkDescriptorImageInfo multiScatterInfo{};
-        multiScatterInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        multiScatterInfo.imageView = multiScatterLUTView;
-        multiScatterInfo.sampler = lutSampler;
-
-        // Sky-view LUT binding (updated per-frame with sun direction)
-        VkDescriptorImageInfo skyViewInfo{};
-        skyViewInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        skyViewInfo.imageView = skyViewLUTView;
-        skyViewInfo.sampler = lutSampler;
-
-        // Rayleigh Irradiance LUT binding (Phase 4.1.9)
-        VkDescriptorImageInfo rayleighIrradianceInfo{};
-        rayleighIrradianceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        rayleighIrradianceInfo.imageView = rayleighIrradianceLUTView;
-        rayleighIrradianceInfo.sampler = lutSampler;
-
-        // Mie Irradiance LUT binding (Phase 4.1.9)
-        VkDescriptorImageInfo mieIrradianceInfo{};
-        mieIrradianceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        mieIrradianceInfo.imageView = mieIrradianceLUTView;
-        mieIrradianceInfo.sampler = lutSampler;
-
-        // Cloud Map LUT binding (Paraboloid projection)
-        VkDescriptorImageInfo cloudMapInfo{};
-        cloudMapInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        cloudMapInfo.imageView = cloudMapLUTView;
-        cloudMapInfo.sampler = lutSampler;
-
-        std::array<VkWriteDescriptorSet, 7> descriptorWrites{};
-
-        descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[0].dstSet = skyDescriptorSets[i];
-        descriptorWrites[0].dstBinding = 0;
-        descriptorWrites[0].dstArrayElement = 0;
-        descriptorWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        descriptorWrites[0].descriptorCount = 1;
-        descriptorWrites[0].pBufferInfo = &bufferInfo;
-
-        descriptorWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[1].dstSet = skyDescriptorSets[i];
-        descriptorWrites[1].dstBinding = 1;
-        descriptorWrites[1].dstArrayElement = 0;
-        descriptorWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[1].descriptorCount = 1;
-        descriptorWrites[1].pImageInfo = &transmittanceInfo;
-
-        descriptorWrites[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[2].dstSet = skyDescriptorSets[i];
-        descriptorWrites[2].dstBinding = 2;
-        descriptorWrites[2].dstArrayElement = 0;
-        descriptorWrites[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[2].descriptorCount = 1;
-        descriptorWrites[2].pImageInfo = &multiScatterInfo;
-
-        descriptorWrites[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[3].dstSet = skyDescriptorSets[i];
-        descriptorWrites[3].dstBinding = 3;
-        descriptorWrites[3].dstArrayElement = 0;
-        descriptorWrites[3].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[3].descriptorCount = 1;
-        descriptorWrites[3].pImageInfo = &skyViewInfo;
-
-        descriptorWrites[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[4].dstSet = skyDescriptorSets[i];
-        descriptorWrites[4].dstBinding = 4;
-        descriptorWrites[4].dstArrayElement = 0;
-        descriptorWrites[4].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[4].descriptorCount = 1;
-        descriptorWrites[4].pImageInfo = &rayleighIrradianceInfo;
-
-        descriptorWrites[5].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[5].dstSet = skyDescriptorSets[i];
-        descriptorWrites[5].dstBinding = 5;
-        descriptorWrites[5].dstArrayElement = 0;
-        descriptorWrites[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[5].descriptorCount = 1;
-        descriptorWrites[5].pImageInfo = &mieIrradianceInfo;
-
-        descriptorWrites[6].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        descriptorWrites[6].dstSet = skyDescriptorSets[i];
-        descriptorWrites[6].dstBinding = 6;
-        descriptorWrites[6].dstArrayElement = 0;
-        descriptorWrites[6].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        descriptorWrites[6].descriptorCount = 1;
-        descriptorWrites[6].pImageInfo = &cloudMapInfo;
-
-        vkUpdateDescriptorSets(device, static_cast<uint32_t>(descriptorWrites.size()),
-                               descriptorWrites.data(), 0, nullptr);
-    }
-
-    SDL_Log("Sky descriptor sets created with atmosphere LUTs (including cloud map)");
-    return true;
-}
-
 bool Renderer::createGraphicsPipeline() {
     auto vertShaderCode = ShaderLoader::readFile(resourcePath + "/shaders/shader.vert.spv");
     auto fragShaderCode = ShaderLoader::readFile(resourcePath + "/shaders/shader.frag.spv");
@@ -1999,123 +1789,6 @@ bool Renderer::createGraphicsPipeline() {
 
     if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &graphicsPipeline) != VK_SUCCESS) {
         SDL_Log("Failed to create graphics pipeline");
-        return false;
-    }
-
-    vkDestroyShaderModule(device, fragShaderModule, nullptr);
-    vkDestroyShaderModule(device, vertShaderModule, nullptr);
-
-    return true;
-}
-
-bool Renderer::createSkyPipeline() {
-    auto vertShaderCode = ShaderLoader::readFile(resourcePath + "/shaders/sky.vert.spv");
-    auto fragShaderCode = ShaderLoader::readFile(resourcePath + "/shaders/sky.frag.spv");
-
-    if (vertShaderCode.empty() || fragShaderCode.empty()) {
-        SDL_Log("Failed to load sky shader files");
-        return false;
-    }
-
-    VkShaderModule vertShaderModule = ShaderLoader::createShaderModule(device, vertShaderCode);
-    VkShaderModule fragShaderModule = ShaderLoader::createShaderModule(device, fragShaderCode);
-
-    VkPipelineShaderStageCreateInfo vertShaderStageInfo{};
-    vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    vertShaderStageInfo.module = vertShaderModule;
-    vertShaderStageInfo.pName = "main";
-
-    VkPipelineShaderStageCreateInfo fragShaderStageInfo{};
-    fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    fragShaderStageInfo.module = fragShaderModule;
-    fragShaderStageInfo.pName = "main";
-
-    VkPipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragShaderStageInfo};
-
-    VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
-    vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertexInputInfo.vertexBindingDescriptionCount = 0;
-    vertexInputInfo.pVertexBindingDescriptions = nullptr;
-    vertexInputInfo.vertexAttributeDescriptionCount = 0;
-    vertexInputInfo.pVertexAttributeDescriptions = nullptr;
-
-    VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
-    inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-    inputAssembly.primitiveRestartEnable = VK_FALSE;
-
-    VkViewport viewport{};
-    viewport.x = 0.0f;
-    viewport.y = 0.0f;
-    viewport.width = static_cast<float>(swapchainExtent.width);
-    viewport.height = static_cast<float>(swapchainExtent.height);
-    viewport.minDepth = 0.0f;
-    viewport.maxDepth = 1.0f;
-
-    VkRect2D scissor{};
-    scissor.offset = {0, 0};
-    scissor.extent = swapchainExtent;
-
-    VkPipelineViewportStateCreateInfo viewportState{};
-    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    viewportState.viewportCount = 1;
-    viewportState.pViewports = &viewport;
-    viewportState.scissorCount = 1;
-    viewportState.pScissors = &scissor;
-
-    VkPipelineRasterizationStateCreateInfo rasterizer{};
-    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    rasterizer.depthClampEnable = VK_FALSE;
-    rasterizer.rasterizerDiscardEnable = VK_FALSE;
-    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
-    rasterizer.lineWidth = 1.0f;
-    rasterizer.cullMode = VK_CULL_MODE_NONE;
-    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-    rasterizer.depthBiasEnable = VK_FALSE;
-
-    VkPipelineMultisampleStateCreateInfo multisampling{};
-    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    multisampling.sampleShadingEnable = VK_FALSE;
-    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-
-    VkPipelineDepthStencilStateCreateInfo depthStencil{};
-    depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    depthStencil.depthTestEnable = VK_FALSE;
-    depthStencil.depthWriteEnable = VK_FALSE;
-    depthStencil.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-    depthStencil.depthBoundsTestEnable = VK_FALSE;
-    depthStencil.stencilTestEnable = VK_FALSE;
-
-    VkPipelineColorBlendAttachmentState colorBlendAttachment{};
-    colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-    colorBlendAttachment.blendEnable = VK_FALSE;
-
-    VkPipelineColorBlendStateCreateInfo colorBlending{};
-    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    colorBlending.logicOpEnable = VK_FALSE;
-    colorBlending.attachmentCount = 1;
-    colorBlending.pAttachments = &colorBlendAttachment;
-
-    VkGraphicsPipelineCreateInfo pipelineInfo{};
-    pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pipelineInfo.stageCount = 2;
-    pipelineInfo.pStages = shaderStages;
-    pipelineInfo.pVertexInputState = &vertexInputInfo;
-    pipelineInfo.pInputAssemblyState = &inputAssembly;
-    pipelineInfo.pViewportState = &viewportState;
-    pipelineInfo.pRasterizationState = &rasterizer;
-    pipelineInfo.pMultisampleState = &multisampling;
-    pipelineInfo.pDepthStencilState = &depthStencil;
-    pipelineInfo.pColorBlendState = &colorBlending;
-    pipelineInfo.layout = skyPipelineLayout;  // Use dedicated sky pipeline layout with LUT bindings
-    pipelineInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    pipelineInfo.subpass = 0;
-
-    if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &skyPipeline) != VK_SUCCESS) {
-        SDL_Log("Failed to create sky pipeline");
         return false;
     }
 
@@ -2866,10 +2539,7 @@ void Renderer::recordHDRPass(VkCommandBuffer cmd, uint32_t frameIndex, float gra
     vkCmdBeginRenderPass(cmd, &hdrPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     // Draw sky (with atmosphere LUT bindings)
-    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, skyPipeline);
-    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                            skyPipelineLayout, 0, 1, &skyDescriptorSets[frameIndex], 0, nullptr);
-    vkCmdDraw(cmd, 3, 1, 0, 0);
+    skySystem.recordDraw(cmd, frameIndex);
 
     // Draw terrain (LEB adaptive tessellation)
     terrainSystem.recordDraw(cmd, frameIndex);

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -19,6 +19,7 @@
 #include "BloomSystem.h"
 #include "FroxelSystem.h"
 #include "AtmosphereLUTSystem.h"
+#include "SkySystem.h"
 #include "SceneManager.h"
 #include "TerrainSystem.h"
 #include "SnowMaskSystem.h"
@@ -157,10 +158,7 @@ private:
     bool createCommandBuffers();
     bool createSyncObjects();
     bool createDescriptorSetLayout();
-    bool createSkyDescriptorSetLayout();
-    bool createSkyDescriptorSets();
     bool createGraphicsPipeline();
-    bool createSkyPipeline();
     bool createUniformBuffers();
     bool createDescriptorPool();
     bool createDescriptorSets();
@@ -228,13 +226,8 @@ private:
     VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
     VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
     VkPipeline graphicsPipeline = VK_NULL_HANDLE;
-    VkPipeline skyPipeline = VK_NULL_HANDLE;
 
-    // Sky-specific descriptor set layout and pipeline layout (for atmosphere LUTs)
-    VkDescriptorSetLayout skyDescriptorSetLayout = VK_NULL_HANDLE;
-    VkPipelineLayout skyPipelineLayout = VK_NULL_HANDLE;
-    std::vector<VkDescriptorSet> skyDescriptorSets;
-
+    SkySystem skySystem;
     GrassSystem grassSystem;
     WindSystem windSystem;
     WeatherSystem weatherSystem;

--- a/src/SkySystem.cpp
+++ b/src/SkySystem.cpp
@@ -1,0 +1,382 @@
+#include "SkySystem.h"
+#include "AtmosphereLUTSystem.h"
+#include "ShaderLoader.h"
+#include "BindingBuilder.h"
+#include "UBOs.h"
+#include <SDL3/SDL.h>
+#include <array>
+
+bool SkySystem::init(const InitInfo& info) {
+    device = info.device;
+    descriptorPool = info.descriptorPool;
+    shaderPath = info.shaderPath;
+    framesInFlight = info.framesInFlight;
+    extent = info.extent;
+    hdrRenderPass = info.hdrRenderPass;
+
+    if (!createDescriptorSetLayout()) return false;
+    if (!createPipeline()) return false;
+
+    return true;
+}
+
+void SkySystem::destroy(VkDevice device, VmaAllocator allocator) {
+    if (pipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device, pipeline, nullptr);
+        pipeline = VK_NULL_HANDLE;
+    }
+    if (pipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+        pipelineLayout = VK_NULL_HANDLE;
+    }
+    if (descriptorSetLayout != VK_NULL_HANDLE) {
+        vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+        descriptorSetLayout = VK_NULL_HANDLE;
+    }
+    // Descriptor sets are freed when the pool is destroyed
+    descriptorSets.clear();
+}
+
+bool SkySystem::createDescriptorSetLayout() {
+    // Sky shader bindings:
+    // 0: UBO (same as main shader)
+    // 1: Transmittance LUT sampler
+    // 2: Multi-scatter LUT sampler
+    // 3: Sky-view LUT sampler (updated per-frame)
+    // 4: Rayleigh Irradiance LUT sampler (Phase 4.1.9)
+    // 5: Mie Irradiance LUT sampler (Phase 4.1.9)
+    // 6: Cloud Map LUT sampler (Paraboloid projection, updated per-frame)
+
+    auto uboBinding = BindingBuilder()
+        .setBinding(0)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto transmittanceLUTBinding = BindingBuilder()
+        .setBinding(1)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto multiScatterLUTBinding = BindingBuilder()
+        .setBinding(2)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto skyViewLUTBinding = BindingBuilder()
+        .setBinding(3)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto rayleighIrradianceLUTBinding = BindingBuilder()
+        .setBinding(4)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto mieIrradianceLUTBinding = BindingBuilder()
+        .setBinding(5)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    auto cloudMapLUTBinding = BindingBuilder()
+        .setBinding(6)
+        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        .build();
+
+    std::array<VkDescriptorSetLayoutBinding, 7> bindings = {
+        uboBinding, transmittanceLUTBinding, multiScatterLUTBinding, skyViewLUTBinding,
+        rayleighIrradianceLUTBinding, mieIrradianceLUTBinding, cloudMapLUTBinding
+    };
+
+    VkDescriptorSetLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+    layoutInfo.pBindings = bindings.data();
+
+    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS) {
+        SDL_Log("Failed to create sky descriptor set layout");
+        return false;
+    }
+
+    // Create pipeline layout for sky shader
+    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
+    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipelineLayoutInfo.setLayoutCount = 1;
+    pipelineLayoutInfo.pSetLayouts = &descriptorSetLayout;
+    pipelineLayoutInfo.pushConstantRangeCount = 0;
+    pipelineLayoutInfo.pPushConstantRanges = nullptr;
+
+    if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
+        SDL_Log("Failed to create sky pipeline layout");
+        return false;
+    }
+
+    return true;
+}
+
+bool SkySystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
+                                      VkDeviceSize uniformBufferSize,
+                                      AtmosphereLUTSystem& atmosphereLUTSystem) {
+    // Allocate sky descriptor sets (one per frame in flight)
+    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, descriptorSetLayout);
+
+    VkDescriptorSetAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocInfo.descriptorPool = descriptorPool;
+    allocInfo.descriptorSetCount = framesInFlight;
+    allocInfo.pSetLayouts = layouts.data();
+
+    descriptorSets.resize(framesInFlight);
+    if (vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()) != VK_SUCCESS) {
+        SDL_Log("Failed to allocate sky descriptor sets");
+        return false;
+    }
+
+    // Get LUT views and sampler from atmosphere system
+    VkImageView transmittanceLUTView = atmosphereLUTSystem.getTransmittanceLUTView();
+    VkImageView multiScatterLUTView = atmosphereLUTSystem.getMultiScatterLUTView();
+    VkImageView skyViewLUTView = atmosphereLUTSystem.getSkyViewLUTView();
+    VkImageView rayleighIrradianceLUTView = atmosphereLUTSystem.getRayleighIrradianceLUTView();
+    VkImageView mieIrradianceLUTView = atmosphereLUTSystem.getMieIrradianceLUTView();
+    VkImageView cloudMapLUTView = atmosphereLUTSystem.getCloudMapLUTView();
+    VkSampler lutSampler = atmosphereLUTSystem.getLUTSampler();
+
+    // Update each descriptor set
+    for (size_t i = 0; i < framesInFlight; i++) {
+        // UBO binding
+        VkDescriptorBufferInfo bufferInfo{};
+        bufferInfo.buffer = uniformBuffers[i];
+        bufferInfo.offset = 0;
+        bufferInfo.range = uniformBufferSize;
+
+        // Transmittance LUT binding
+        VkDescriptorImageInfo transmittanceInfo{};
+        transmittanceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        transmittanceInfo.imageView = transmittanceLUTView;
+        transmittanceInfo.sampler = lutSampler;
+
+        // Multi-scatter LUT binding
+        VkDescriptorImageInfo multiScatterInfo{};
+        multiScatterInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        multiScatterInfo.imageView = multiScatterLUTView;
+        multiScatterInfo.sampler = lutSampler;
+
+        // Sky-view LUT binding (updated per-frame with sun direction)
+        VkDescriptorImageInfo skyViewInfo{};
+        skyViewInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        skyViewInfo.imageView = skyViewLUTView;
+        skyViewInfo.sampler = lutSampler;
+
+        // Rayleigh Irradiance LUT binding (Phase 4.1.9)
+        VkDescriptorImageInfo rayleighIrradianceInfo{};
+        rayleighIrradianceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        rayleighIrradianceInfo.imageView = rayleighIrradianceLUTView;
+        rayleighIrradianceInfo.sampler = lutSampler;
+
+        // Mie Irradiance LUT binding (Phase 4.1.9)
+        VkDescriptorImageInfo mieIrradianceInfo{};
+        mieIrradianceInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        mieIrradianceInfo.imageView = mieIrradianceLUTView;
+        mieIrradianceInfo.sampler = lutSampler;
+
+        // Cloud Map LUT binding (Paraboloid projection)
+        VkDescriptorImageInfo cloudMapInfo{};
+        cloudMapInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        cloudMapInfo.imageView = cloudMapLUTView;
+        cloudMapInfo.sampler = lutSampler;
+
+        std::array<VkWriteDescriptorSet, 7> descriptorWrites{};
+
+        descriptorWrites[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[0].dstSet = descriptorSets[i];
+        descriptorWrites[0].dstBinding = 0;
+        descriptorWrites[0].dstArrayElement = 0;
+        descriptorWrites[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        descriptorWrites[0].descriptorCount = 1;
+        descriptorWrites[0].pBufferInfo = &bufferInfo;
+
+        descriptorWrites[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[1].dstSet = descriptorSets[i];
+        descriptorWrites[1].dstBinding = 1;
+        descriptorWrites[1].dstArrayElement = 0;
+        descriptorWrites[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[1].descriptorCount = 1;
+        descriptorWrites[1].pImageInfo = &transmittanceInfo;
+
+        descriptorWrites[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[2].dstSet = descriptorSets[i];
+        descriptorWrites[2].dstBinding = 2;
+        descriptorWrites[2].dstArrayElement = 0;
+        descriptorWrites[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[2].descriptorCount = 1;
+        descriptorWrites[2].pImageInfo = &multiScatterInfo;
+
+        descriptorWrites[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[3].dstSet = descriptorSets[i];
+        descriptorWrites[3].dstBinding = 3;
+        descriptorWrites[3].dstArrayElement = 0;
+        descriptorWrites[3].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[3].descriptorCount = 1;
+        descriptorWrites[3].pImageInfo = &skyViewInfo;
+
+        descriptorWrites[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[4].dstSet = descriptorSets[i];
+        descriptorWrites[4].dstBinding = 4;
+        descriptorWrites[4].dstArrayElement = 0;
+        descriptorWrites[4].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[4].descriptorCount = 1;
+        descriptorWrites[4].pImageInfo = &rayleighIrradianceInfo;
+
+        descriptorWrites[5].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[5].dstSet = descriptorSets[i];
+        descriptorWrites[5].dstBinding = 5;
+        descriptorWrites[5].dstArrayElement = 0;
+        descriptorWrites[5].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[5].descriptorCount = 1;
+        descriptorWrites[5].pImageInfo = &mieIrradianceInfo;
+
+        descriptorWrites[6].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        descriptorWrites[6].dstSet = descriptorSets[i];
+        descriptorWrites[6].dstBinding = 6;
+        descriptorWrites[6].dstArrayElement = 0;
+        descriptorWrites[6].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        descriptorWrites[6].descriptorCount = 1;
+        descriptorWrites[6].pImageInfo = &cloudMapInfo;
+
+        vkUpdateDescriptorSets(device, static_cast<uint32_t>(descriptorWrites.size()),
+                               descriptorWrites.data(), 0, nullptr);
+    }
+
+    SDL_Log("Sky descriptor sets created with atmosphere LUTs (including cloud map)");
+    return true;
+}
+
+bool SkySystem::createPipeline() {
+    auto vertShaderCode = ShaderLoader::readFile(shaderPath + "/sky.vert.spv");
+    auto fragShaderCode = ShaderLoader::readFile(shaderPath + "/sky.frag.spv");
+
+    if (vertShaderCode.empty() || fragShaderCode.empty()) {
+        SDL_Log("Failed to load sky shader files");
+        return false;
+    }
+
+    VkShaderModule vertShaderModule = ShaderLoader::createShaderModule(device, vertShaderCode);
+    VkShaderModule fragShaderModule = ShaderLoader::createShaderModule(device, fragShaderCode);
+
+    VkPipelineShaderStageCreateInfo vertShaderStageInfo{};
+    vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    vertShaderStageInfo.module = vertShaderModule;
+    vertShaderStageInfo.pName = "main";
+
+    VkPipelineShaderStageCreateInfo fragShaderStageInfo{};
+    fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    fragShaderStageInfo.module = fragShaderModule;
+    fragShaderStageInfo.pName = "main";
+
+    VkPipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragShaderStageInfo};
+
+    VkPipelineVertexInputStateCreateInfo vertexInputInfo{};
+    vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertexInputInfo.vertexBindingDescriptionCount = 0;
+    vertexInputInfo.pVertexBindingDescriptions = nullptr;
+    vertexInputInfo.vertexAttributeDescriptionCount = 0;
+    vertexInputInfo.pVertexAttributeDescriptions = nullptr;
+
+    VkPipelineInputAssemblyStateCreateInfo inputAssembly{};
+    inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    inputAssembly.primitiveRestartEnable = VK_FALSE;
+
+    VkViewport viewport{};
+    viewport.x = 0.0f;
+    viewport.y = 0.0f;
+    viewport.width = static_cast<float>(extent.width);
+    viewport.height = static_cast<float>(extent.height);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+
+    VkRect2D scissor{};
+    scissor.offset = {0, 0};
+    scissor.extent = extent;
+
+    VkPipelineViewportStateCreateInfo viewportState{};
+    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewportState.viewportCount = 1;
+    viewportState.pViewports = &viewport;
+    viewportState.scissorCount = 1;
+    viewportState.pScissors = &scissor;
+
+    VkPipelineRasterizationStateCreateInfo rasterizer{};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.depthClampEnable = VK_FALSE;
+    rasterizer.rasterizerDiscardEnable = VK_FALSE;
+    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterizer.lineWidth = 1.0f;
+    rasterizer.cullMode = VK_CULL_MODE_NONE;
+    rasterizer.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterizer.depthBiasEnable = VK_FALSE;
+
+    VkPipelineMultisampleStateCreateInfo multisampling{};
+    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampling.sampleShadingEnable = VK_FALSE;
+    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo depthStencil{};
+    depthStencil.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    depthStencil.depthTestEnable = VK_FALSE;
+    depthStencil.depthWriteEnable = VK_FALSE;
+    depthStencil.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+    depthStencil.depthBoundsTestEnable = VK_FALSE;
+    depthStencil.stencilTestEnable = VK_FALSE;
+
+    VkPipelineColorBlendAttachmentState colorBlendAttachment{};
+    colorBlendAttachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    colorBlendAttachment.blendEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo colorBlending{};
+    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    colorBlending.logicOpEnable = VK_FALSE;
+    colorBlending.attachmentCount = 1;
+    colorBlending.pAttachments = &colorBlendAttachment;
+
+    VkGraphicsPipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipelineInfo.stageCount = 2;
+    pipelineInfo.pStages = shaderStages;
+    pipelineInfo.pVertexInputState = &vertexInputInfo;
+    pipelineInfo.pInputAssemblyState = &inputAssembly;
+    pipelineInfo.pViewportState = &viewportState;
+    pipelineInfo.pRasterizationState = &rasterizer;
+    pipelineInfo.pMultisampleState = &multisampling;
+    pipelineInfo.pDepthStencilState = &depthStencil;
+    pipelineInfo.pColorBlendState = &colorBlending;
+    pipelineInfo.layout = pipelineLayout;
+    pipelineInfo.renderPass = hdrRenderPass;
+    pipelineInfo.subpass = 0;
+
+    if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline) != VK_SUCCESS) {
+        SDL_Log("Failed to create sky pipeline");
+        return false;
+    }
+
+    vkDestroyShaderModule(device, fragShaderModule, nullptr);
+    vkDestroyShaderModule(device, vertShaderModule, nullptr);
+
+    return true;
+}
+
+void SkySystem::recordDraw(VkCommandBuffer cmd, uint32_t frameIndex) {
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            pipelineLayout, 0, 1, &descriptorSets[frameIndex], 0, nullptr);
+    vkCmdDraw(cmd, 3, 1, 0, 0);
+}

--- a/src/SkySystem.h
+++ b/src/SkySystem.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <vector>
+#include <string>
+
+class AtmosphereLUTSystem;
+
+class SkySystem {
+public:
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        VkDescriptorPool descriptorPool;
+        std::string shaderPath;
+        uint32_t framesInFlight;
+        VkExtent2D extent;
+        VkRenderPass hdrRenderPass;
+    };
+
+    SkySystem() = default;
+    ~SkySystem() = default;
+
+    bool init(const InitInfo& info);
+    void destroy(VkDevice device, VmaAllocator allocator);
+
+    // Create descriptor sets after uniform buffers and LUTs are ready
+    bool createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
+                              VkDeviceSize uniformBufferSize,
+                              AtmosphereLUTSystem& atmosphereLUTSystem);
+
+    // Record sky rendering commands
+    void recordDraw(VkCommandBuffer cmd, uint32_t frameIndex);
+
+private:
+    bool createDescriptorSetLayout();
+    bool createPipeline();
+
+    VkDevice device = VK_NULL_HANDLE;
+    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    std::string shaderPath;
+    uint32_t framesInFlight = 0;
+    VkExtent2D extent = {0, 0};
+    VkRenderPass hdrRenderPass = VK_NULL_HANDLE;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSet> descriptorSets;
+};


### PR DESCRIPTION
Move sky-related code from Renderer into a dedicated SkySystem class:
- createSkyDescriptorSetLayout() (~80 lines)
- createSkyDescriptorSets() (~135 lines)
- createSkyPipeline() (~117 lines)
- Sky descriptor sets and pipeline layout members

The SkySystem follows the existing system pattern in the codebase with InitInfo struct, init(), destroy(), and recordDraw() methods.

This removes approximately 300 lines from Renderer.cpp and improves code organization by encapsulating sky rendering concerns.