### PR TITLE
Fix terrain subdivision frame oscillation bug

### DIFF
--- a/shaders/terrain/terrain_subdivision.comp
+++ b/shaders/terrain/terrain_subdivision.comp
@@ -13,6 +13,11 @@
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
+// Push constants for update mode
+layout(push_constant) uniform PushConstants {
+    uint updateMode;  // 0 = split only, 1 = merge only
+};
+
 // Height map sampler
 layout(binding = 3) uniform sampler2D heightMap;
 
@@ -186,26 +191,29 @@ void main() {
     // Frustum culling
     bool culled = frustumCullAABB(minBound, maxBound);
 
-    if (culled) {
-        // If culled and not at minimum depth, try to merge
-        if (depth > MIN_DEPTH) {
+    // Compute screen-space edge length (needed for both modes)
+    float edgeLengthPixels = computeTriangleLOD(v0, v1, v2);
+
+    // Ping-pong between split and merge frames to avoid race conditions
+    // This ensures that multiple threads don't simultaneously try to split and merge
+    // related nodes, which could create inconsistent tree states
+    if (updateMode == 0u) {
+        // Split-only frame
+        if (!culled && edgeLengthPixels > SPLIT_THRESHOLD && depth < MAX_DEPTH) {
+            leb_SplitNode_Square(node);
+        }
+    } else {
+        // Merge-only frame
+        if (culled) {
+            // If culled and not at minimum depth, merge
+            if (depth > MIN_DEPTH) {
+                leb_DiamondParent diamond = leb_DecodeDiamondParent_Square(node);
+                leb_MergeNode_Square(node, diamond);
+            }
+        } else if (edgeLengthPixels < MERGE_THRESHOLD && depth > MIN_DEPTH) {
+            // Merge: combine with sibling
             leb_DiamondParent diamond = leb_DecodeDiamondParent_Square(node);
             leb_MergeNode_Square(node, diamond);
         }
-        return;
     }
-
-    // Compute screen-space edge length
-    float edgeLengthPixels = computeTriangleLOD(v0, v1, v2);
-
-    // LOD decision with hysteresis
-    if (edgeLengthPixels > SPLIT_THRESHOLD && depth < MAX_DEPTH) {
-        // Split: create two child leaves
-        leb_SplitNode_Square(node);
-    } else if (edgeLengthPixels < MERGE_THRESHOLD && depth > MIN_DEPTH) {
-        // Merge: combine with sibling
-        leb_DiamondParent diamond = leb_DecodeDiamondParent_Square(node);
-        leb_MergeNode_Square(node, diamond);
-    }
-    // else: keep current state
 }

--- a/src/TerrainSystem.h
+++ b/src/TerrainSystem.h
@@ -36,6 +36,11 @@ struct TerrainSumReductionPushConstants {
     int passID;
 };
 
+// Push constants for subdivision compute shader
+struct TerrainSubdivisionPushConstants {
+    uint32_t updateMode;  // 0 = split only, 1 = merge only
+};
+
 // Terrain configuration (outside class to avoid C++17 default argument issues)
 struct TerrainConfig {
     float size = 500.0f;              // Terrain size in world units
@@ -207,6 +212,7 @@ private:
 
     // Runtime state
     uint32_t currentNodeCount = 2;  // Start with 2 root triangles
+    uint32_t subdivisionFrameCount = 0;  // Frame counter for split/merge ping-pong
 
     // Constants
     static constexpr uint32_t SUBDIVISION_WORKGROUP_SIZE = 64;


### PR DESCRIPTION
Add frame-based alternation between split and merge operations in the terrain CBT subdivision to avoid race conditions. Previously, both split and merge could occur in the same frame, potentially causing concurrent threads to create inconsistent tree states when modifying related nodes.

Changes:
- Add TerrainSubdivisionPushConstants with updateMode field
- Add subdivisionFrameCount to track ping-pong frames
- Pass push constant to subdivision shader for mode selection
- Modify shader to only split on even frames, only merge on odd frames