### PR TITLE
Add ShaderLoader API note to prevent incorrect method calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,4 @@
 - compile with `cmake --preset debug && cmake --build build/debug`
 - run with `./run-debug.sh` do not attempt to combine with timeouts or sleeps
 - Prefer composition over inheritance - assume pretty much all of the time you want to use inheritance you are wrong.
+- ShaderLoader API: use `ShaderLoader::loadShaderModule(device, path)` or the two-step `readFile` + `createShaderModule`. There is NO `loadShader` method.


### PR DESCRIPTION
Document the correct ShaderLoader methods (loadShaderModule, readFile, createShaderModule) to avoid calling the non-existent loadShader method.