### PR TITLE
Implement hierarchical z buffers for occlusion culling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     src/AnimatedCharacter.cpp
     src/AnimationStateMachine.cpp
     src/FBXLoader.cpp
+    src/HiZSystem.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
@@ -158,6 +159,8 @@ set(SHADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/histogram_reduce.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/snow_accumulation.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/volumetric_snow.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/hiz_downsample.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/hiz_culling.comp.spv
 )
 
 set(TERRAIN_SHADER_FILES
@@ -217,6 +220,7 @@ if(SHADER_COMPILE_CMD)
         leaf.comp leaf.vert leaf.frag
         histogram_build.comp histogram_reduce.comp
         snow_accumulation.comp
+        hiz_downsample.comp hiz_culling.comp
     )
 
     foreach(SHADER ${SIMPLE_SHADERS})
@@ -387,6 +391,8 @@ if(SHADER_COMPILE_CMD)
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/histogram_reduce.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/snow_accumulation.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/volumetric_snow.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/hiz_downsample.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/hiz_culling.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_dispatcher.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_subdivision.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_sum_reduction_prepass.comp.spv

--- a/shaders/hiz_culling.comp
+++ b/shaders/hiz_culling.comp
@@ -1,0 +1,248 @@
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+// Hi-Z Occlusion Culling Compute Shader
+// Performs frustum culling followed by hierarchical z-buffer occlusion culling
+// Outputs visible objects to an indirect draw buffer
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+// Object data structure (matches CullObjectData in C++)
+struct CullObjectData {
+    vec4 boundingSphere;    // xyz = center (world space), w = radius
+    vec4 aabbMin;           // xyz = min corner (world space), w = unused
+    vec4 aabbMax;           // xyz = max corner (world space), w = unused
+    uint meshIndex;         // Index into mesh data for indirect draw
+    uint firstIndex;        // First index in index buffer
+    uint indexCount;        // Number of indices
+    uint vertexOffset;      // Vertex offset
+};
+
+// Indirect draw command (matches VkDrawIndexedIndirectCommand)
+struct DrawIndexedIndirectCommand {
+    uint indexCount;
+    uint instanceCount;
+    uint firstIndex;
+    int  vertexOffset;
+    uint firstInstance;
+};
+
+// Culling uniforms
+layout(std140, binding = 0) uniform HiZCullUniforms {
+    mat4 viewMatrix;
+    mat4 projMatrix;
+    mat4 viewProjMatrix;
+    vec4 frustumPlanes[6];      // Frustum planes for culling
+    vec4 cameraPosition;        // xyz = camera pos, w = unused
+    vec4 screenParams;          // x = width, y = height, z = 1/width, w = 1/height
+    vec4 depthParams;           // x = near, y = far, z = numMipLevels, w = unused
+    uint objectCount;           // Number of objects to cull
+    uint enableHiZ;             // 1 = use Hi-Z, 0 = frustum only
+    uint padding[2];
+} uniforms;
+
+// Input: Object data
+layout(std430, binding = 1) readonly buffer ObjectDataBuffer {
+    CullObjectData objects[];
+};
+
+// Output: Indirect draw commands
+layout(std430, binding = 2) writeonly buffer IndirectDrawBuffer {
+    DrawIndexedIndirectCommand drawCommands[];
+};
+
+// Output: Draw count (atomic counter)
+layout(std430, binding = 3) buffer DrawCountBuffer {
+    uint drawCount;
+};
+
+// Hi-Z pyramid texture
+layout(binding = 4) uniform sampler2D hiZPyramid;
+
+// Check if AABB is completely outside a plane
+bool isOutsidePlane(vec4 plane, vec3 aabbMin, vec3 aabbMax) {
+    // Find the corner most in the direction of the plane normal
+    vec3 pVertex = vec3(
+        plane.x > 0.0 ? aabbMax.x : aabbMin.x,
+        plane.y > 0.0 ? aabbMax.y : aabbMin.y,
+        plane.z > 0.0 ? aabbMax.z : aabbMin.z
+    );
+
+    // If the positive vertex is behind the plane, the AABB is completely outside
+    return dot(vec4(pVertex, 1.0), plane) < 0.0;
+}
+
+// Frustum culling test for AABB
+bool frustumCullAABB(vec3 aabbMin, vec3 aabbMax) {
+    // Test against all 6 frustum planes
+    for (int i = 0; i < 6; i++) {
+        if (isOutsidePlane(uniforms.frustumPlanes[i], aabbMin, aabbMax)) {
+            return true;  // Culled
+        }
+    }
+    return false;  // Visible
+}
+
+// Frustum culling test for bounding sphere (faster but less precise)
+bool frustumCullSphere(vec3 center, float radius) {
+    for (int i = 0; i < 6; i++) {
+        float dist = dot(vec4(center, 1.0), uniforms.frustumPlanes[i]);
+        if (dist < -radius) {
+            return true;  // Completely outside
+        }
+    }
+    return false;  // At least partially visible
+}
+
+// Project AABB to screen space and get bounding rectangle
+// Returns: xy = min screen coord, zw = max screen coord (in pixels)
+vec4 projectAABBToScreen(vec3 aabbMin, vec3 aabbMax) {
+    // Project all 8 corners
+    vec3 corners[8];
+    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
+    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
+    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
+    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
+    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
+    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
+    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
+    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
+
+    vec2 minScreen = vec2(1e10);
+    vec2 maxScreen = vec2(-1e10);
+    float closestZ = 1.0;  // Closest depth (largest value in reversed-Z)
+
+    for (int i = 0; i < 8; i++) {
+        vec4 clipPos = uniforms.viewProjMatrix * vec4(corners[i], 1.0);
+
+        // Handle behind camera
+        if (clipPos.w <= 0.0) {
+            // Corner is behind camera, expand to full screen
+            return vec4(0.0, 0.0, uniforms.screenParams.x, uniforms.screenParams.y);
+        }
+
+        // Perspective divide
+        vec3 ndc = clipPos.xyz / clipPos.w;
+
+        // Convert to screen coordinates
+        vec2 screen = (ndc.xy * 0.5 + 0.5) * uniforms.screenParams.xy;
+
+        minScreen = min(minScreen, screen);
+        maxScreen = max(maxScreen, screen);
+
+        // Track closest depth (for reversed-Z, closest = largest value)
+        closestZ = max(closestZ, ndc.z);
+    }
+
+    // Clamp to screen bounds
+    minScreen = max(minScreen, vec2(0.0));
+    maxScreen = min(maxScreen, uniforms.screenParams.xy);
+
+    return vec4(minScreen, maxScreen);
+}
+
+// Get the closest (maximum in reversed-Z) depth value of the AABB
+float getClosestDepth(vec3 aabbMin, vec3 aabbMax) {
+    // Project all 8 corners and find closest
+    vec3 corners[8];
+    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
+    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
+    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
+    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
+    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
+    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
+    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
+    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
+
+    float closestZ = 0.0;  // Farthest in reversed-Z
+
+    for (int i = 0; i < 8; i++) {
+        vec4 clipPos = uniforms.viewProjMatrix * vec4(corners[i], 1.0);
+        if (clipPos.w > 0.0) {
+            float ndcZ = clipPos.z / clipPos.w;
+            closestZ = max(closestZ, ndcZ);
+        }
+    }
+
+    return closestZ;
+}
+
+// Hi-Z occlusion test
+// Returns true if object is occluded (should be culled)
+bool hiZOcclusionTest(vec3 aabbMin, vec3 aabbMax) {
+    // Project AABB to screen
+    vec4 screenRect = projectAABBToScreen(aabbMin, aabbMax);
+
+    // Check if completely off screen
+    if (screenRect.x >= screenRect.z || screenRect.y >= screenRect.w) {
+        return true;  // Culled (off screen)
+    }
+
+    // Calculate the size of the projected rectangle
+    vec2 rectSize = screenRect.zw - screenRect.xy;
+
+    // Choose mip level based on rectangle size
+    // We want a mip where the rect covers roughly 2x2 texels
+    float maxDim = max(rectSize.x, rectSize.y);
+    float mipLevel = max(0.0, log2(maxDim) - 1.0);
+    mipLevel = min(mipLevel, uniforms.depthParams.z - 1.0);
+
+    // Sample Hi-Z at the center of the rectangle
+    vec2 centerUV = (screenRect.xy + screenRect.zw) * 0.5 * uniforms.screenParams.zw;
+
+    // Sample the Hi-Z pyramid
+    float hiZDepth = textureLod(hiZPyramid, centerUV, mipLevel).r;
+
+    // Get closest depth of the AABB
+    float objectDepth = getClosestDepth(aabbMin, aabbMax);
+
+    // In reversed-Z: larger depth = closer to camera
+    // Object is occluded if its closest point is farther than the Hi-Z depth
+    // (objectDepth < hiZDepth means object is behind what's in the depth buffer)
+    return objectDepth < hiZDepth;
+}
+
+void main() {
+    uint objectIndex = gl_GlobalInvocationID.x;
+
+    // Early out if beyond object count
+    if (objectIndex >= uniforms.objectCount) {
+        return;
+    }
+
+    // Load object data
+    CullObjectData obj = objects[objectIndex];
+    vec3 aabbMin = obj.aabbMin.xyz;
+    vec3 aabbMax = obj.aabbMax.xyz;
+
+    // Step 1: Frustum culling (fast rejection)
+    // Use sphere test first for quick rejection
+    vec3 sphereCenter = obj.boundingSphere.xyz;
+    float sphereRadius = obj.boundingSphere.w;
+
+    if (frustumCullSphere(sphereCenter, sphereRadius)) {
+        return;  // Culled by frustum (sphere)
+    }
+
+    // More precise AABB frustum test
+    if (frustumCullAABB(aabbMin, aabbMax)) {
+        return;  // Culled by frustum (AABB)
+    }
+
+    // Step 2: Hi-Z occlusion culling (if enabled)
+    if (uniforms.enableHiZ != 0) {
+        if (hiZOcclusionTest(aabbMin, aabbMax)) {
+            return;  // Occluded
+        }
+    }
+
+    // Object is visible - add to draw buffer
+    uint drawIndex = atomicAdd(drawCount, 1);
+
+    // Write indirect draw command
+    drawCommands[drawIndex].indexCount = obj.indexCount;
+    drawCommands[drawIndex].instanceCount = 1;
+    drawCommands[drawIndex].firstIndex = obj.firstIndex;
+    drawCommands[drawIndex].vertexOffset = int(obj.vertexOffset);
+    drawCommands[drawIndex].firstInstance = objectIndex;  // Pass object index for per-instance data
+}

--- a/shaders/hiz_downsample.comp
+++ b/shaders/hiz_downsample.comp
@@ -1,0 +1,91 @@
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+// Hi-Z Pyramid Downsample Compute Shader
+// Generates a hierarchical depth buffer by taking the maximum depth of 2x2 regions
+// Uses max instead of min because we use reversed-Z depth (0 = far, 1 = near)
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+// Push constants for mip level info
+layout(push_constant) uniform PushConstants {
+    uvec2 srcSize;      // Size of source mip level
+    uvec2 dstSize;      // Size of destination mip level
+    uint srcMipLevel;   // Source mip level (0 = original depth buffer)
+    uint isFirstPass;   // 1 if reading from depth buffer, 0 if reading from previous mip
+} pc;
+
+// Source textures
+layout(binding = 0) uniform sampler2D srcDepthBuffer;   // Original depth buffer (for first pass)
+layout(binding = 1) uniform sampler2D srcHiZMip;        // Previous Hi-Z mip level
+
+// Destination storage image
+layout(binding = 2, r32f) uniform writeonly image2D dstHiZMip;
+
+void main() {
+    ivec2 dstCoord = ivec2(gl_GlobalInvocationID.xy);
+
+    // Early out if outside destination bounds
+    if (dstCoord.x >= int(pc.dstSize.x) || dstCoord.y >= int(pc.dstSize.y)) {
+        return;
+    }
+
+    // Calculate source coordinates (2x2 region in source maps to 1 pixel in dest)
+    ivec2 srcCoord = dstCoord * 2;
+
+    float maxDepth;
+
+    if (pc.isFirstPass == 1) {
+        // Reading from original depth buffer
+        // Sample 2x2 region and take maximum (for reversed-Z, max = closest)
+        vec2 srcTexelSize = 1.0 / vec2(pc.srcSize);
+        vec2 srcUV = (vec2(srcCoord) + 0.5) * srcTexelSize;
+
+        // Sample all 4 texels in the 2x2 region
+        float d00 = texture(srcDepthBuffer, srcUV).r;
+        float d10 = texture(srcDepthBuffer, srcUV + vec2(srcTexelSize.x, 0.0)).r;
+        float d01 = texture(srcDepthBuffer, srcUV + vec2(0.0, srcTexelSize.y)).r;
+        float d11 = texture(srcDepthBuffer, srcUV + srcTexelSize).r;
+
+        // Take minimum for standard depth, maximum for reversed-Z
+        // We use MIN here because we want the CLOSEST depth (largest value in reversed-Z = closest)
+        // Actually for occlusion culling we want the FARTHEST depth in the region
+        // If any pixel is farther than the object, the object might be visible
+        // So we take MIN (farthest in reversed-Z)
+        maxDepth = min(min(d00, d10), min(d01, d11));
+    } else {
+        // Reading from previous Hi-Z mip level
+        vec2 srcTexelSize = 1.0 / vec2(pc.srcSize);
+        vec2 srcUV = (vec2(srcCoord) + 0.5) * srcTexelSize;
+
+        float d00 = texture(srcHiZMip, srcUV).r;
+        float d10 = texture(srcHiZMip, srcUV + vec2(srcTexelSize.x, 0.0)).r;
+        float d01 = texture(srcHiZMip, srcUV + vec2(0.0, srcTexelSize.y)).r;
+        float d11 = texture(srcHiZMip, srcUV + srcTexelSize).r;
+
+        // Same logic: min for farthest depth
+        maxDepth = min(min(d00, d10), min(d01, d11));
+    }
+
+    // Handle edge cases where source is odd-sized (extra row/column)
+    if (srcCoord.x + 1 >= int(pc.srcSize.x)) {
+        // Only one column to sample
+        if (pc.isFirstPass == 1) {
+            vec2 srcTexelSize = 1.0 / vec2(pc.srcSize);
+            float d0 = texture(srcDepthBuffer, (vec2(srcCoord) + 0.5) * srcTexelSize).r;
+            float d1 = texture(srcDepthBuffer, (vec2(srcCoord) + vec2(0.5, 1.5)) * srcTexelSize).r;
+            maxDepth = min(d0, d1);
+        }
+    }
+    if (srcCoord.y + 1 >= int(pc.srcSize.y)) {
+        // Only one row to sample
+        if (pc.isFirstPass == 1) {
+            vec2 srcTexelSize = 1.0 / vec2(pc.srcSize);
+            float d0 = texture(srcDepthBuffer, (vec2(srcCoord) + 0.5) * srcTexelSize).r;
+            float d1 = texture(srcDepthBuffer, (vec2(srcCoord) + vec2(1.5, 0.5)) * srcTexelSize).r;
+            maxDepth = min(d0, d1);
+        }
+    }
+
+    imageStore(dstHiZMip, dstCoord, vec4(maxDepth, 0.0, 0.0, 0.0));
+}

--- a/src/HiZSystem.cpp
+++ b/src/HiZSystem.cpp
@@ -1,0 +1,816 @@
+#include "HiZSystem.h"
+#include "ShaderLoader.h"
+#include <SDL3/SDL_log.h>
+#include <cstring>
+#include <algorithm>
+
+bool HiZSystem::init(const InitInfo& info) {
+    device = info.device;
+    allocator = info.allocator;
+    descriptorPool = info.descriptorPool;
+    extent = info.extent;
+    shaderPath = info.shaderPath;
+    framesInFlight = info.framesInFlight;
+    depthFormat = info.depthFormat;
+
+    if (!createHiZPyramid()) {
+        SDL_Log("HiZSystem: Failed to create Hi-Z pyramid");
+        return false;
+    }
+
+    if (!createPyramidPipeline()) {
+        SDL_Log("HiZSystem: Failed to create pyramid pipeline");
+        return false;
+    }
+
+    if (!createCullingPipeline()) {
+        SDL_Log("HiZSystem: Failed to create culling pipeline");
+        return false;
+    }
+
+    if (!createBuffers()) {
+        SDL_Log("HiZSystem: Failed to create buffers");
+        return false;
+    }
+
+    if (!createDescriptorSets()) {
+        SDL_Log("HiZSystem: Failed to create descriptor sets");
+        return false;
+    }
+
+    SDL_Log("HiZSystem: Initialized with %u mip levels", mipLevelCount);
+    return true;
+}
+
+void HiZSystem::destroy() {
+    destroyDescriptorSets();
+    destroyBuffers();
+    destroyPipelines();
+    destroyHiZPyramid();
+}
+
+void HiZSystem::resize(VkExtent2D newExtent) {
+    if (newExtent.width == extent.width && newExtent.height == extent.height) {
+        return;
+    }
+
+    vkDeviceWaitIdle(device);
+
+    extent = newExtent;
+
+    // Recreate Hi-Z pyramid with new size
+    destroyHiZPyramid();
+    createHiZPyramid();
+
+    // Recreate descriptor sets (they reference the pyramid)
+    destroyDescriptorSets();
+    createDescriptorSets();
+}
+
+bool HiZSystem::createHiZPyramid() {
+    mipLevelCount = calculateMipLevels(extent);
+
+    // Create Hi-Z pyramid image
+    VkImageCreateInfo imageInfo{};
+    imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    imageInfo.imageType = VK_IMAGE_TYPE_2D;
+    imageInfo.format = HIZ_FORMAT;
+    imageInfo.extent = {extent.width, extent.height, 1};
+    imageInfo.mipLevels = mipLevelCount;
+    imageInfo.arrayLayers = 1;
+    imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+    imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+    if (vmaCreateImage(allocator, &imageInfo, &allocInfo, &hiZPyramidImage,
+                       &hiZPyramidAllocation, nullptr) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create Hi-Z pyramid image");
+        return false;
+    }
+
+    // Create full image view (all mip levels)
+    VkImageViewCreateInfo viewInfo{};
+    viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    viewInfo.image = hiZPyramidImage;
+    viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    viewInfo.format = HIZ_FORMAT;
+    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.baseMipLevel = 0;
+    viewInfo.subresourceRange.levelCount = mipLevelCount;
+    viewInfo.subresourceRange.baseArrayLayer = 0;
+    viewInfo.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(device, &viewInfo, nullptr, &hiZPyramidView) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create Hi-Z pyramid view");
+        return false;
+    }
+
+    // Create per-mip-level views for compute writes
+    hiZMipViews.resize(mipLevelCount);
+    for (uint32_t i = 0; i < mipLevelCount; ++i) {
+        viewInfo.subresourceRange.baseMipLevel = i;
+        viewInfo.subresourceRange.levelCount = 1;
+
+        if (vkCreateImageView(device, &viewInfo, nullptr, &hiZMipViews[i]) != VK_SUCCESS) {
+            SDL_Log("HiZSystem: Failed to create Hi-Z mip view %u", i);
+            return false;
+        }
+    }
+
+    // Create sampler for Hi-Z reads
+    VkSamplerCreateInfo samplerInfo{};
+    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samplerInfo.magFilter = VK_FILTER_NEAREST;
+    samplerInfo.minFilter = VK_FILTER_NEAREST;
+    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samplerInfo.minLod = 0.0f;
+    samplerInfo.maxLod = static_cast<float>(mipLevelCount);
+    samplerInfo.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+
+    if (vkCreateSampler(device, &samplerInfo, nullptr, &hiZSampler) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create Hi-Z sampler");
+        return false;
+    }
+
+    return true;
+}
+
+void HiZSystem::destroyHiZPyramid() {
+    if (hiZSampler != VK_NULL_HANDLE) {
+        vkDestroySampler(device, hiZSampler, nullptr);
+        hiZSampler = VK_NULL_HANDLE;
+    }
+
+    for (auto view : hiZMipViews) {
+        if (view != VK_NULL_HANDLE) {
+            vkDestroyImageView(device, view, nullptr);
+        }
+    }
+    hiZMipViews.clear();
+
+    if (hiZPyramidView != VK_NULL_HANDLE) {
+        vkDestroyImageView(device, hiZPyramidView, nullptr);
+        hiZPyramidView = VK_NULL_HANDLE;
+    }
+
+    if (hiZPyramidImage != VK_NULL_HANDLE) {
+        vmaDestroyImage(allocator, hiZPyramidImage, hiZPyramidAllocation);
+        hiZPyramidImage = VK_NULL_HANDLE;
+        hiZPyramidAllocation = VK_NULL_HANDLE;
+    }
+}
+
+bool HiZSystem::createPyramidPipeline() {
+    // Descriptor set layout for pyramid generation
+    // Binding 0: Source depth buffer (sampler2D)
+    // Binding 1: Source Hi-Z mip (sampler2D) - for subsequent passes
+    // Binding 2: Destination Hi-Z mip (storage image)
+    auto layoutBuilder = DescriptorManager::LayoutBuilder(device)
+        .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT)   // 0: src depth
+        .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT)   // 1: src Hi-Z mip
+        .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT);          // 2: dst Hi-Z mip
+
+    pyramidDescSetLayout = layoutBuilder.build();
+    if (pyramidDescSetLayout == VK_NULL_HANDLE) {
+        SDL_Log("HiZSystem: Failed to create pyramid descriptor set layout");
+        return false;
+    }
+
+    // Push constant range
+    VkPushConstantRange pushConstantRange{};
+    pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    pushConstantRange.offset = 0;
+    pushConstantRange.size = sizeof(uint32_t) * 6;  // srcSize, dstSize, srcMipLevel, isFirstPass
+
+    // Pipeline layout
+    VkPipelineLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layoutInfo.setLayoutCount = 1;
+    layoutInfo.pSetLayouts = &pyramidDescSetLayout;
+    layoutInfo.pushConstantRangeCount = 1;
+    layoutInfo.pPushConstantRanges = &pushConstantRange;
+
+    if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &pyramidPipelineLayout) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create pyramid pipeline layout");
+        return false;
+    }
+
+    // Load compute shader
+    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(
+        device, shaderPath + "/hiz_downsample.comp.spv");
+    if (shaderModule == VK_NULL_HANDLE) {
+        SDL_Log("HiZSystem: Failed to load hiz_downsample.comp.spv");
+        return false;
+    }
+
+    VkPipelineShaderStageCreateInfo stageInfo{};
+    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    stageInfo.module = shaderModule;
+    stageInfo.pName = "main";
+
+    VkComputePipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipelineInfo.stage = stageInfo;
+    pipelineInfo.layout = pyramidPipelineLayout;
+
+    VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo,
+                                                nullptr, &pyramidPipeline);
+    vkDestroyShaderModule(device, shaderModule, nullptr);
+
+    if (result != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create pyramid compute pipeline");
+        return false;
+    }
+
+    return true;
+}
+
+bool HiZSystem::createCullingPipeline() {
+    // Descriptor set layout for culling
+    // Binding 0: Uniforms (UBO)
+    // Binding 1: Object data (SSBO, read-only)
+    // Binding 2: Indirect draw buffer (SSBO, write)
+    // Binding 3: Draw count buffer (SSBO, atomic)
+    // Binding 4: Hi-Z pyramid (sampler2D)
+    auto layoutBuilder = DescriptorManager::LayoutBuilder(device)
+        .addUniformBuffer(VK_SHADER_STAGE_COMPUTE_BIT)          // 0: uniforms
+        .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT)          // 1: objects
+        .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT)          // 2: indirect draw
+        .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT)          // 3: draw count
+        .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT);  // 4: Hi-Z pyramid
+
+    cullingDescSetLayout = layoutBuilder.build();
+    if (cullingDescSetLayout == VK_NULL_HANDLE) {
+        SDL_Log("HiZSystem: Failed to create culling descriptor set layout");
+        return false;
+    }
+
+    // Pipeline layout (no push constants needed)
+    VkPipelineLayoutCreateInfo layoutInfo{};
+    layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layoutInfo.setLayoutCount = 1;
+    layoutInfo.pSetLayouts = &cullingDescSetLayout;
+
+    if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &cullingPipelineLayout) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create culling pipeline layout");
+        return false;
+    }
+
+    // Load compute shader
+    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(
+        device, shaderPath + "/hiz_culling.comp.spv");
+    if (shaderModule == VK_NULL_HANDLE) {
+        SDL_Log("HiZSystem: Failed to load hiz_culling.comp.spv");
+        return false;
+    }
+
+    VkPipelineShaderStageCreateInfo stageInfo{};
+    stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    stageInfo.module = shaderModule;
+    stageInfo.pName = "main";
+
+    VkComputePipelineCreateInfo pipelineInfo{};
+    pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    pipelineInfo.stage = stageInfo;
+    pipelineInfo.layout = cullingPipelineLayout;
+
+    VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo,
+                                                nullptr, &cullingPipeline);
+    vkDestroyShaderModule(device, shaderModule, nullptr);
+
+    if (result != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create culling compute pipeline");
+        return false;
+    }
+
+    return true;
+}
+
+void HiZSystem::destroyPipelines() {
+    if (cullingPipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device, cullingPipeline, nullptr);
+        cullingPipeline = VK_NULL_HANDLE;
+    }
+    if (cullingPipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device, cullingPipelineLayout, nullptr);
+        cullingPipelineLayout = VK_NULL_HANDLE;
+    }
+    if (cullingDescSetLayout != VK_NULL_HANDLE) {
+        vkDestroyDescriptorSetLayout(device, cullingDescSetLayout, nullptr);
+        cullingDescSetLayout = VK_NULL_HANDLE;
+    }
+
+    if (pyramidPipeline != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device, pyramidPipeline, nullptr);
+        pyramidPipeline = VK_NULL_HANDLE;
+    }
+    if (pyramidPipelineLayout != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device, pyramidPipelineLayout, nullptr);
+        pyramidPipelineLayout = VK_NULL_HANDLE;
+    }
+    if (pyramidDescSetLayout != VK_NULL_HANDLE) {
+        vkDestroyDescriptorSetLayout(device, pyramidDescSetLayout, nullptr);
+        pyramidDescSetLayout = VK_NULL_HANDLE;
+    }
+}
+
+bool HiZSystem::createBuffers() {
+    VkDeviceSize objectBufferSize = sizeof(CullObjectData) * MAX_OBJECTS;
+
+    // Create object data buffer
+    VkBufferCreateInfo bufferInfo{};
+    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufferInfo.size = objectBufferSize;
+    bufferInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    if (vmaCreateBuffer(allocator, &bufferInfo, &allocInfo, &objectDataBuffer,
+                        &objectDataAllocation, nullptr) != VK_SUCCESS) {
+        SDL_Log("HiZSystem: Failed to create object data buffer");
+        return false;
+    }
+    objectBufferCapacity = MAX_OBJECTS;
+
+    // Create indirect draw buffers (per frame)
+    VkDeviceSize indirectBufferSize = sizeof(DrawIndexedIndirectCommand) * MAX_OBJECTS;
+    bool success = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator)
+        .setFrameCount(framesInFlight)
+        .setSize(indirectBufferSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
+        .setAllocationFlags(0)  // GPU-only
+        .build(indirectDrawBuffers);
+
+    if (!success) {
+        SDL_Log("HiZSystem: Failed to create indirect draw buffers");
+        return false;
+    }
+
+    // Create draw count buffers (per frame)
+    success = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator)
+        .setFrameCount(framesInFlight)
+        .setSize(sizeof(uint32_t))
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
+                  VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .setAllocationFlags(VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT)
+        .build(drawCountBuffers);
+
+    if (!success) {
+        SDL_Log("HiZSystem: Failed to create draw count buffers");
+        return false;
+    }
+
+    // Create uniform buffers (per frame)
+    success = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator)
+        .setFrameCount(framesInFlight)
+        .setSize(sizeof(HiZCullUniforms))
+        .setUsage(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+        .build(uniformBuffers);
+
+    if (!success) {
+        SDL_Log("HiZSystem: Failed to create uniform buffers");
+        return false;
+    }
+
+    return true;
+}
+
+void HiZSystem::destroyBuffers() {
+    BufferUtils::destroyBuffers(allocator, uniformBuffers);
+    BufferUtils::destroyBuffers(allocator, drawCountBuffers);
+    BufferUtils::destroyBuffers(allocator, indirectDrawBuffers);
+
+    if (objectDataBuffer != VK_NULL_HANDLE) {
+        vmaDestroyBuffer(allocator, objectDataBuffer, objectDataAllocation);
+        objectDataBuffer = VK_NULL_HANDLE;
+    }
+}
+
+bool HiZSystem::createDescriptorSets() {
+    // Allocate pyramid descriptor sets (one per mip level)
+    pyramidDescSets.resize(mipLevelCount);
+    VkDescriptorSetAllocateInfo allocInfo{};
+    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    allocInfo.descriptorPool = descriptorPool;
+    allocInfo.descriptorSetCount = 1;
+    allocInfo.pSetLayouts = &pyramidDescSetLayout;
+
+    for (uint32_t i = 0; i < mipLevelCount; ++i) {
+        if (vkAllocateDescriptorSets(device, &allocInfo, &pyramidDescSets[i]) != VK_SUCCESS) {
+            SDL_Log("HiZSystem: Failed to allocate pyramid descriptor set %u", i);
+            return false;
+        }
+    }
+
+    // Allocate culling descriptor sets (one per frame)
+    cullingDescSets.resize(framesInFlight);
+    allocInfo.pSetLayouts = &cullingDescSetLayout;
+
+    for (uint32_t i = 0; i < framesInFlight; ++i) {
+        if (vkAllocateDescriptorSets(device, &allocInfo, &cullingDescSets[i]) != VK_SUCCESS) {
+            SDL_Log("HiZSystem: Failed to allocate culling descriptor set %u", i);
+            return false;
+        }
+
+        // Update culling descriptor set
+        VkDescriptorBufferInfo uniformInfo{};
+        uniformInfo.buffer = uniformBuffers.buffers[i];
+        uniformInfo.offset = 0;
+        uniformInfo.range = sizeof(HiZCullUniforms);
+
+        VkDescriptorBufferInfo objectInfo{};
+        objectInfo.buffer = objectDataBuffer;
+        objectInfo.offset = 0;
+        objectInfo.range = VK_WHOLE_SIZE;
+
+        VkDescriptorBufferInfo indirectInfo{};
+        indirectInfo.buffer = indirectDrawBuffers.buffers[i];
+        indirectInfo.offset = 0;
+        indirectInfo.range = VK_WHOLE_SIZE;
+
+        VkDescriptorBufferInfo countInfo{};
+        countInfo.buffer = drawCountBuffers.buffers[i];
+        countInfo.offset = 0;
+        countInfo.range = sizeof(uint32_t);
+
+        VkDescriptorImageInfo hiZInfo{};
+        hiZInfo.sampler = hiZSampler;
+        hiZInfo.imageView = hiZPyramidView;
+        hiZInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        std::array<VkWriteDescriptorSet, 5> writes{};
+
+        writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[0].dstSet = cullingDescSets[i];
+        writes[0].dstBinding = 0;
+        writes[0].descriptorCount = 1;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].pBufferInfo = &uniformInfo;
+
+        writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1].dstSet = cullingDescSets[i];
+        writes[1].dstBinding = 1;
+        writes[1].descriptorCount = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[1].pBufferInfo = &objectInfo;
+
+        writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[2].dstSet = cullingDescSets[i];
+        writes[2].dstBinding = 2;
+        writes[2].descriptorCount = 1;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[2].pBufferInfo = &indirectInfo;
+
+        writes[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[3].dstSet = cullingDescSets[i];
+        writes[3].dstBinding = 3;
+        writes[3].descriptorCount = 1;
+        writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[3].pBufferInfo = &countInfo;
+
+        writes[4].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[4].dstSet = cullingDescSets[i];
+        writes[4].dstBinding = 4;
+        writes[4].descriptorCount = 1;
+        writes[4].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[4].pImageInfo = &hiZInfo;
+
+        vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+    }
+
+    return true;
+}
+
+void HiZSystem::destroyDescriptorSets() {
+    // Descriptor sets are freed when the pool is destroyed/reset
+    pyramidDescSets.clear();
+    cullingDescSets.clear();
+}
+
+void HiZSystem::setDepthBuffer(VkImageView depthView, VkSampler depthSampler) {
+    sourceDepthView = depthView;
+    sourceDepthSampler = depthSampler;
+
+    // Update pyramid descriptor sets with the depth buffer
+    if (pyramidDescSets.empty() || hiZMipViews.empty()) {
+        return;
+    }
+
+    for (uint32_t mip = 0; mip < mipLevelCount; ++mip) {
+        VkDescriptorImageInfo srcDepthInfo{};
+        srcDepthInfo.sampler = sourceDepthSampler;
+        srcDepthInfo.imageView = sourceDepthView;
+        srcDepthInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        VkDescriptorImageInfo srcMipInfo{};
+        srcMipInfo.sampler = hiZSampler;
+        srcMipInfo.imageView = mip > 0 ? hiZMipViews[mip - 1] : hiZMipViews[0];
+        srcMipInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        VkDescriptorImageInfo dstMipInfo{};
+        dstMipInfo.imageView = hiZMipViews[mip];
+        dstMipInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+        std::array<VkWriteDescriptorSet, 3> writes{};
+
+        writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[0].dstSet = pyramidDescSets[mip];
+        writes[0].dstBinding = 0;
+        writes[0].descriptorCount = 1;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[0].pImageInfo = &srcDepthInfo;
+
+        writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1].dstSet = pyramidDescSets[mip];
+        writes[1].dstBinding = 1;
+        writes[1].descriptorCount = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[1].pImageInfo = &srcMipInfo;
+
+        writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[2].dstSet = pyramidDescSets[mip];
+        writes[2].dstBinding = 2;
+        writes[2].descriptorCount = 1;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[2].pImageInfo = &dstMipInfo;
+
+        vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+    }
+}
+
+void HiZSystem::updateUniforms(uint32_t frameIndex, const glm::mat4& view, const glm::mat4& proj,
+                                const glm::vec3& cameraPos, float nearPlane, float farPlane) {
+    HiZCullUniforms uniforms{};
+    uniforms.viewMatrix = view;
+    uniforms.projMatrix = proj;
+    uniforms.viewProjMatrix = proj * view;
+    uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
+    uniforms.screenParams = glm::vec4(
+        static_cast<float>(extent.width),
+        static_cast<float>(extent.height),
+        1.0f / static_cast<float>(extent.width),
+        1.0f / static_cast<float>(extent.height)
+    );
+    uniforms.depthParams = glm::vec4(nearPlane, farPlane, static_cast<float>(mipLevelCount), 0.0f);
+    uniforms.objectCount = objectCount;
+    uniforms.enableHiZ = hiZEnabled ? 1 : 0;
+
+    // Extract frustum planes
+    extractFrustumPlanes(uniforms.viewProjMatrix, uniforms.frustumPlanes);
+
+    // Copy to GPU
+    memcpy(uniformBuffers.mappedPointers[frameIndex], &uniforms, sizeof(HiZCullUniforms));
+}
+
+void HiZSystem::updateObjectData(const std::vector<CullObjectData>& objects) {
+    objectCount = static_cast<uint32_t>(objects.size());
+
+    if (objectCount == 0) {
+        return;
+    }
+
+    // Ensure buffer is large enough
+    if (objectCount > objectBufferCapacity) {
+        SDL_Log("HiZSystem: Object count %u exceeds capacity %u", objectCount, objectBufferCapacity);
+        objectCount = objectBufferCapacity;
+    }
+
+    // Map and copy data
+    void* mappedData;
+    vmaMapMemory(allocator, objectDataAllocation, &mappedData);
+    memcpy(mappedData, objects.data(), sizeof(CullObjectData) * objectCount);
+    vmaUnmapMemory(allocator, objectDataAllocation);
+}
+
+void HiZSystem::recordPyramidGeneration(VkCommandBuffer cmd, uint32_t frameIndex) {
+    if (sourceDepthView == VK_NULL_HANDLE) {
+        return;
+    }
+
+    // Transition Hi-Z pyramid to general for writing
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcAccessMask = 0;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = hiZPyramidImage;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = mipLevelCount;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.layerCount = 1;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pyramidPipeline);
+
+    // Generate each mip level
+    uint32_t srcWidth = extent.width;
+    uint32_t srcHeight = extent.height;
+
+    for (uint32_t mip = 0; mip < mipLevelCount; ++mip) {
+        uint32_t dstWidth = std::max(1u, srcWidth >> 1);
+        uint32_t dstHeight = std::max(1u, srcHeight >> 1);
+
+        // First mip reads from depth buffer, subsequent mips read from previous level
+        if (mip == 0) {
+            dstWidth = srcWidth;
+            dstHeight = srcHeight;
+        }
+
+        // Push constants
+        struct {
+            uint32_t srcWidth, srcHeight;
+            uint32_t dstWidth, dstHeight;
+            uint32_t srcMipLevel;
+            uint32_t isFirstPass;
+        } pushConstants = {
+            srcWidth, srcHeight,
+            dstWidth, dstHeight,
+            mip > 0 ? mip - 1 : 0,
+            mip == 0 ? 1u : 0u
+        };
+
+        vkCmdPushConstants(cmd, pyramidPipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(pushConstants), &pushConstants);
+
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                                pyramidPipelineLayout, 0, 1, &pyramidDescSets[mip], 0, nullptr);
+
+        // Dispatch
+        uint32_t groupsX = (dstWidth + 7) / 8;
+        uint32_t groupsY = (dstHeight + 7) / 8;
+        vkCmdDispatch(cmd, groupsX, groupsY, 1);
+
+        // Barrier between mip levels
+        if (mip < mipLevelCount - 1) {
+            barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+            barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            barrier.subresourceRange.baseMipLevel = mip;
+            barrier.subresourceRange.levelCount = 1;
+
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &barrier);
+        }
+
+        srcWidth = dstWidth;
+        srcHeight = dstHeight;
+    }
+
+    // Transition entire pyramid to shader read for culling
+    barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.levelCount = mipLevelCount;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+void HiZSystem::recordCulling(VkCommandBuffer cmd, uint32_t frameIndex) {
+    if (objectCount == 0) {
+        return;
+    }
+
+    // Reset draw count to zero
+    vkCmdFillBuffer(cmd, drawCountBuffers.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+
+    // Barrier to ensure fill is complete before compute
+    VkMemoryBarrier memBarrier{};
+    memBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    memBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+    // Bind culling pipeline and descriptor set
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, cullingPipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                            cullingPipelineLayout, 0, 1, &cullingDescSets[frameIndex], 0, nullptr);
+
+    // Dispatch
+    uint32_t groupCount = (objectCount + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+    vkCmdDispatch(cmd, groupCount, 1, 1);
+
+    // Barrier before indirect draw
+    memBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+}
+
+VkBuffer HiZSystem::getIndirectDrawBuffer(uint32_t frameIndex) const {
+    return indirectDrawBuffers.buffers[frameIndex];
+}
+
+VkBuffer HiZSystem::getDrawCountBuffer(uint32_t frameIndex) const {
+    return drawCountBuffers.buffers[frameIndex];
+}
+
+uint32_t HiZSystem::getVisibleCount(uint32_t frameIndex) const {
+    if (drawCountBuffers.mappedPointers.empty()) {
+        return 0;
+    }
+    return *static_cast<uint32_t*>(drawCountBuffers.mappedPointers[frameIndex]);
+}
+
+VkImageView HiZSystem::getHiZMipView(uint32_t mipLevel) const {
+    if (mipLevel < hiZMipViews.size()) {
+        return hiZMipViews[mipLevel];
+    }
+    return VK_NULL_HANDLE;
+}
+
+void HiZSystem::extractFrustumPlanes(const glm::mat4& viewProj, glm::vec4 planes[6]) {
+    // Left plane
+    planes[0] = glm::vec4(
+        viewProj[0][3] + viewProj[0][0],
+        viewProj[1][3] + viewProj[1][0],
+        viewProj[2][3] + viewProj[2][0],
+        viewProj[3][3] + viewProj[3][0]
+    );
+
+    // Right plane
+    planes[1] = glm::vec4(
+        viewProj[0][3] - viewProj[0][0],
+        viewProj[1][3] - viewProj[1][0],
+        viewProj[2][3] - viewProj[2][0],
+        viewProj[3][3] - viewProj[3][0]
+    );
+
+    // Bottom plane
+    planes[2] = glm::vec4(
+        viewProj[0][3] + viewProj[0][1],
+        viewProj[1][3] + viewProj[1][1],
+        viewProj[2][3] + viewProj[2][1],
+        viewProj[3][3] + viewProj[3][1]
+    );
+
+    // Top plane
+    planes[3] = glm::vec4(
+        viewProj[0][3] - viewProj[0][1],
+        viewProj[1][3] - viewProj[1][1],
+        viewProj[2][3] - viewProj[2][1],
+        viewProj[3][3] - viewProj[3][1]
+    );
+
+    // Near plane
+    planes[4] = glm::vec4(
+        viewProj[0][3] + viewProj[0][2],
+        viewProj[1][3] + viewProj[1][2],
+        viewProj[2][3] + viewProj[2][2],
+        viewProj[3][3] + viewProj[3][2]
+    );
+
+    // Far plane
+    planes[5] = glm::vec4(
+        viewProj[0][3] - viewProj[0][2],
+        viewProj[1][3] - viewProj[1][2],
+        viewProj[2][3] - viewProj[2][2],
+        viewProj[3][3] - viewProj[3][2]
+    );
+
+    // Normalize planes
+    for (int i = 0; i < 6; ++i) {
+        float len = glm::length(glm::vec3(planes[i]));
+        if (len > 0.0001f) {
+            planes[i] /= len;
+        }
+    }
+}

--- a/src/HiZSystem.h
+++ b/src/HiZSystem.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <glm/glm.hpp>
+#include <vector>
+#include <string>
+#include <cmath>
+
+#include "BufferUtils.h"
+#include "DescriptorManager.h"
+#include "Mesh.h"
+
+// GPU-side object data for culling (matches shader struct)
+struct alignas(16) CullObjectData {
+    glm::vec4 boundingSphere;   // xyz = center (world space), w = radius
+    glm::vec4 aabbMin;          // xyz = min corner (world space), w = unused
+    glm::vec4 aabbMax;          // xyz = max corner (world space), w = unused
+    uint32_t meshIndex;         // Index into mesh data for indirect draw
+    uint32_t firstIndex;        // First index in index buffer
+    uint32_t indexCount;        // Number of indices
+    uint32_t vertexOffset;      // Vertex offset
+};
+
+// Indirect draw command (matches VkDrawIndexedIndirectCommand)
+struct DrawIndexedIndirectCommand {
+    uint32_t indexCount;
+    uint32_t instanceCount;
+    uint32_t firstIndex;
+    int32_t  vertexOffset;
+    uint32_t firstInstance;
+};
+
+// Hi-Z culling uniforms (matches shader UBO)
+struct alignas(16) HiZCullUniforms {
+    glm::mat4 viewMatrix;
+    glm::mat4 projMatrix;
+    glm::mat4 viewProjMatrix;
+    glm::vec4 frustumPlanes[6];     // Frustum planes for culling
+    glm::vec4 cameraPosition;       // xyz = camera pos, w = unused
+    glm::vec4 screenParams;         // x = width, y = height, z = 1/width, w = 1/height
+    glm::vec4 depthParams;          // x = near, y = far, z = numMipLevels, w = unused
+    uint32_t objectCount;           // Number of objects to cull
+    uint32_t enableHiZ;             // 1 = use Hi-Z, 0 = frustum only
+    uint32_t padding[2];
+};
+
+// Hierarchical Z-Buffer Occlusion Culling System
+// Generates a depth pyramid from the depth buffer and uses it to cull objects
+class HiZSystem {
+public:
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        VkDescriptorPool descriptorPool;
+        VkExtent2D extent;
+        std::string shaderPath;
+        uint32_t framesInFlight;
+        VkFormat depthFormat;       // Format of the source depth buffer
+    };
+
+    HiZSystem() = default;
+    ~HiZSystem() = default;
+
+    bool init(const InitInfo& info);
+    void destroy();
+    void resize(VkExtent2D newExtent);
+
+    // Update the source depth buffer view for pyramid generation
+    void setDepthBuffer(VkImageView depthView, VkSampler depthSampler);
+
+    // Update culling uniforms (call before recording culling)
+    void updateUniforms(uint32_t frameIndex, const glm::mat4& view, const glm::mat4& proj,
+                        const glm::vec3& cameraPos, float nearPlane, float farPlane);
+
+    // Submit objects to be culled (call once when scene changes)
+    void updateObjectData(const std::vector<CullObjectData>& objects);
+
+    // Record Hi-Z pyramid generation compute pass
+    // Call AFTER the main depth pass completes
+    void recordPyramidGeneration(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    // Record occlusion culling compute pass
+    // Call AFTER pyramid generation
+    void recordCulling(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    // Get the indirect draw buffer for rendering
+    VkBuffer getIndirectDrawBuffer(uint32_t frameIndex) const;
+
+    // Get the draw count buffer (for indirect count draws)
+    VkBuffer getDrawCountBuffer(uint32_t frameIndex) const;
+
+    // Get current object count (for draw limits)
+    uint32_t getObjectCount() const { return objectCount; }
+
+    // Get actual draw count after culling (read back for debugging)
+    uint32_t getVisibleCount(uint32_t frameIndex) const;
+
+    // Hi-Z pyramid access (for debugging/visualization)
+    VkImageView getHiZPyramidView() const { return hiZPyramidView; }
+    VkImageView getHiZMipView(uint32_t mipLevel) const;
+    uint32_t getMipLevelCount() const { return mipLevelCount; }
+
+    // Enable/disable Hi-Z culling (falls back to frustum-only)
+    void setHiZEnabled(bool enabled) { hiZEnabled = enabled; }
+    bool isHiZEnabled() const { return hiZEnabled; }
+
+    // Statistics
+    struct CullingStats {
+        uint32_t totalObjects;
+        uint32_t visibleObjects;
+        uint32_t frustumCulled;
+        uint32_t occlusionCulled;
+    };
+    CullingStats getStats() const { return stats; }
+
+private:
+    // Hi-Z pyramid resources
+    bool createHiZPyramid();
+    void destroyHiZPyramid();
+
+    // Compute pipelines
+    bool createPyramidPipeline();
+    bool createCullingPipeline();
+    void destroyPipelines();
+
+    // Descriptor sets
+    bool createDescriptorSets();
+    void destroyDescriptorSets();
+
+    // Buffers
+    bool createBuffers();
+    void destroyBuffers();
+
+    // Calculate number of mip levels for given extent
+    static uint32_t calculateMipLevels(VkExtent2D extent) {
+        uint32_t maxDim = std::max(extent.width, extent.height);
+        return static_cast<uint32_t>(std::floor(std::log2(maxDim))) + 1;
+    }
+
+    // Extract frustum planes from view-projection matrix
+    static void extractFrustumPlanes(const glm::mat4& viewProj, glm::vec4 planes[6]);
+
+    VkDevice device = VK_NULL_HANDLE;
+    VmaAllocator allocator = VK_NULL_HANDLE;
+    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    VkExtent2D extent = {0, 0};
+    std::string shaderPath;
+    uint32_t framesInFlight = 0;
+    VkFormat depthFormat = VK_FORMAT_D32_SFLOAT;
+
+    // Hi-Z pyramid texture (R32_SFLOAT for max depth values)
+    static constexpr VkFormat HIZ_FORMAT = VK_FORMAT_R32_SFLOAT;
+    VkImage hiZPyramidImage = VK_NULL_HANDLE;
+    VmaAllocation hiZPyramidAllocation = VK_NULL_HANDLE;
+    VkImageView hiZPyramidView = VK_NULL_HANDLE;         // View of all mip levels
+    std::vector<VkImageView> hiZMipViews;                // Individual mip level views
+    VkSampler hiZSampler = VK_NULL_HANDLE;               // Sampler for Hi-Z reads
+    uint32_t mipLevelCount = 0;
+
+    // Source depth buffer reference
+    VkImageView sourceDepthView = VK_NULL_HANDLE;
+    VkSampler sourceDepthSampler = VK_NULL_HANDLE;
+
+    // Pyramid generation pipeline
+    VkDescriptorSetLayout pyramidDescSetLayout = VK_NULL_HANDLE;
+    VkPipelineLayout pyramidPipelineLayout = VK_NULL_HANDLE;
+    VkPipeline pyramidPipeline = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSet> pyramidDescSets;  // One per mip level
+
+    // Culling pipeline
+    VkDescriptorSetLayout cullingDescSetLayout = VK_NULL_HANDLE;
+    VkPipelineLayout cullingPipelineLayout = VK_NULL_HANDLE;
+    VkPipeline cullingPipeline = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSet> cullingDescSets;  // Per frame
+
+    // Object data buffer (input to culling)
+    VkBuffer objectDataBuffer = VK_NULL_HANDLE;
+    VmaAllocation objectDataAllocation = VK_NULL_HANDLE;
+    uint32_t objectCount = 0;
+    uint32_t objectBufferCapacity = 0;
+
+    // Indirect draw buffer (output from culling)
+    BufferUtils::PerFrameBufferSet indirectDrawBuffers;
+
+    // Draw count buffer (for vkCmdDrawIndexedIndirectCount)
+    BufferUtils::PerFrameBufferSet drawCountBuffers;
+
+    // Culling uniforms (per frame)
+    BufferUtils::PerFrameBufferSet uniformBuffers;
+
+    // State
+    bool hiZEnabled = true;
+    CullingStats stats = {};
+
+    static constexpr uint32_t MAX_OBJECTS = 4096;
+    static constexpr uint32_t WORKGROUP_SIZE = 64;
+};

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -129,6 +129,13 @@ namespace {
     };
 }
 
+void Mesh::calculateBounds() {
+    bounds = AABB();  // Reset to default
+    for (const auto& vertex : vertices) {
+        bounds.expand(vertex.position);
+    }
+}
+
 void Mesh::createPlane(float width, float depth) {
     float hw = width * 0.5f;
     float hd = depth * 0.5f;
@@ -144,6 +151,7 @@ void Mesh::createPlane(float width, float depth) {
     };
 
     indices = {0, 1, 2, 2, 3, 0};
+    calculateBounds();
 }
 
 void Mesh::createDisc(float radius, int segments, float uvScale) {
@@ -175,6 +183,7 @@ void Mesh::createDisc(float radius, int segments, float uvScale) {
         indices.push_back(i + 1);       // Next edge vertex
         indices.push_back(i);           // Current edge vertex
     }
+    calculateBounds();
 }
 
 void Mesh::createSphere(float radius, int stacks, int slices) {
@@ -222,6 +231,7 @@ void Mesh::createSphere(float radius, int stacks, int slices) {
             indices.push_back(second + 1);
         }
     }
+    calculateBounds();
 }
 
 void Mesh::createCapsule(float radius, float height, int stacks, int slices) {
@@ -323,6 +333,7 @@ void Mesh::createCapsule(float radius, float height, int stacks, int slices) {
             indices.push_back(second + 1);
         }
     }
+    calculateBounds();
 }
 
 void Mesh::createCube() {
@@ -380,11 +391,13 @@ void Mesh::createCube() {
         16, 17, 18, 18, 19, 16,  // Right
         20, 21, 22, 22, 23, 20   // Left
     };
+    calculateBounds();
 }
 
 void Mesh::setCustomGeometry(const std::vector<Vertex>& verts, const std::vector<uint32_t>& inds) {
     vertices = verts;
     indices = inds;
+    calculateBounds();
 }
 
 void Mesh::createCylinder(float radius, float height, int segments) {
@@ -467,6 +480,7 @@ void Mesh::createCylinder(float radius, float height, int segments) {
         indices.push_back(bottomCenterIdx + ((i + 1) % segments) + 1);
         indices.push_back(bottomCenterIdx + i + 1);
     }
+    calculateBounds();
 }
 
 void Mesh::createRock(float baseRadius, int subdivisions, uint32_t seed, float roughness, float asymmetry) {
@@ -638,6 +652,7 @@ void Mesh::createRock(float baseRadius, int subdivisions, uint32_t seed, float r
     }
 
     indices = std::move(tempIndices);
+    calculateBounds();
 }
 
 void Mesh::upload(VmaAllocator allocator, VkDevice device, VkCommandPool commandPool, VkQueue queue) {

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -34,6 +34,7 @@
 #include "RockSystem.h"
 #include "CloudShadowSystem.h"
 #include "SkinnedMesh.h"
+#include "HiZSystem.h"
 
 struct PushConstants {
     glm::mat4 model;
@@ -175,6 +176,12 @@ public:
     int getCurrentDay() const { return currentDay; }
     const CelestialCalculator& getCelestialCalculator() const { return celestialCalculator; }
 
+    // Hi-Z occlusion culling control
+    void setHiZCullingEnabled(bool enabled) { hiZSystem.setHiZEnabled(enabled); }
+    bool isHiZCullingEnabled() const { return hiZSystem.isHiZEnabled(); }
+    HiZSystem::CullingStats getHiZCullingStats() const { return hiZSystem.getStats(); }
+    uint32_t getVisibleObjectCount() const { return hiZSystem.getVisibleCount(currentFrame); }
+
 private:
     bool createRenderPass();
     void destroyRenderResources();
@@ -247,6 +254,7 @@ private:
     VolumetricSnowSystem volumetricSnowSystem;
     RockSystem rockSystem;
     CloudShadowSystem cloudShadowSystem;
+    HiZSystem hiZSystem;
     EnvironmentSettings environmentSettings;
     bool useVolumetricSnow = true;  // Use new volumetric system by default
 
@@ -257,6 +265,7 @@ private:
     VkImage depthImage = VK_NULL_HANDLE;
     VmaAllocation depthImageAllocation = VK_NULL_HANDLE;
     VkImageView depthImageView = VK_NULL_HANDLE;
+    VkSampler depthSampler = VK_NULL_HANDLE;  // For Hi-Z pyramid generation
     VkFormat depthFormat = VK_FORMAT_UNDEFINED;
 
     // Shadow system (CSM + dynamic shadows)
@@ -325,4 +334,7 @@ private:
     bool createSkinnedDescriptorSets();
     void updateBoneMatrices(uint32_t currentImage);
     void recordSkinnedCharacter(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    // Hi-Z occlusion culling
+    void updateHiZObjectData();
 };


### PR DESCRIPTION
- Add AABB struct and bounding box computation to Mesh class
- Create HiZSystem for GPU-driven occlusion culling
- Add hiz_downsample.comp shader for depth pyramid generation
- Add hiz_culling.comp shader for frustum and Hi-Z occlusion tests
- Modify Renderer depth buffer to support sampling for Hi-Z
- Integrate Hi-Z system initialization and object data updates
- Update CMakeLists.txt with new source files and shaders

The Hi-Z system generates a hierarchical depth pyramid from the main depth buffer after rendering, then uses compute shaders to test object bounding boxes against both frustum planes and the depth pyramid for efficient occlusion culling.