### PR TITLE
Fix black box rendering in player view

### DIFF
--- a/shaders/shader.vert
+++ b/shaders/shader.vert
@@ -27,6 +27,9 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     float roughness;
     float metallic;
+    float emissiveIntensity;
+    float opacity;  // For camera occlusion fading (1.0 = fully visible)
+    vec4 emissiveColor;
 } push;
 
 layout(location = 0) in vec3 inPosition;

--- a/shaders/skinned.vert
+++ b/shaders/skinned.vert
@@ -32,6 +32,9 @@ layout(push_constant) uniform PushConstants {
     mat4 model;
     float roughness;
     float metallic;
+    float emissiveIntensity;
+    float opacity;  // For camera occlusion fading (1.0 = fully visible)
+    vec4 emissiveColor;
 } push;
 
 layout(location = 0) in vec3 inPosition;


### PR DESCRIPTION
The vertex shaders (shader.vert, skinned.vert) only declared 3 fields in their PushConstants struct (model, roughness, metallic), but the fragment shader (shader.frag) and C++ code expect 6 fields including emissiveIntensity, opacity, and emissiveColor.

This mismatch caused undefined behavior where the fragment shader could read garbage values for opacity, resulting in a black rectangle covering most of the screen when rendering the player character.

Fixed by adding the missing fields to both vertex shaders to match the fragment shader's PushConstants structure.