### PR TITLE
Add profiling tools for frame time analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ set(SOURCES
     src/AnimationStateMachine.cpp
     src/FBXLoader.cpp
     src/HiZSystem.cpp
+    src/GpuProfiler.cpp
+    src/CpuProfiler.cpp
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/src/CpuProfiler.cpp
+++ b/src/CpuProfiler.cpp
@@ -1,0 +1,104 @@
+#include "CpuProfiler.h"
+#include <SDL3/SDL.h>
+#include <algorithm>
+
+void CpuProfiler::beginFrame() {
+    if (!enabled) return;
+
+    frameStartTime = Clock::now();
+    activeZones.clear();
+    currentFrameZoneOrder.clear();
+}
+
+void CpuProfiler::endFrame() {
+    if (!enabled) return;
+
+    auto frameEndTime = Clock::now();
+    float frameTimeMs = std::chrono::duration<float, std::milli>(frameEndTime - frameStartTime).count();
+
+    // Build results for this frame
+    lastFrameStats.totalCpuTimeMs = frameTimeMs;
+    lastFrameStats.zones.clear();
+    zoneNames.clear();
+
+    for (const auto& zoneName : currentFrameZoneOrder) {
+        auto it = activeZones.find(zoneName);
+        if (it != activeZones.end()) {
+            TimingResult result;
+            result.name = zoneName;
+            result.cpuTimeMs = it->second.accumulatedMs;
+            result.percentOfFrame = (frameTimeMs > 0.0f) ? (result.cpuTimeMs / frameTimeMs * 100.0f) : 0.0f;
+
+            lastFrameStats.zones.push_back(result);
+            zoneNames.push_back(zoneName);
+        }
+    }
+
+    // Update smoothed stats
+    if (smoothedStats.zones.empty()) {
+        // First frame - initialize with current values
+        smoothedStats = lastFrameStats;
+    } else {
+        // Exponential moving average
+        smoothedStats.totalCpuTimeMs = smoothedStats.totalCpuTimeMs * SMOOTHING_FACTOR +
+                                        lastFrameStats.totalCpuTimeMs * (1.0f - SMOOTHING_FACTOR);
+
+        // Update zones (match by name)
+        for (auto& smoothedZone : smoothedStats.zones) {
+            for (const auto& currentZone : lastFrameStats.zones) {
+                if (smoothedZone.name == currentZone.name) {
+                    smoothedZone.cpuTimeMs = smoothedZone.cpuTimeMs * SMOOTHING_FACTOR +
+                                              currentZone.cpuTimeMs * (1.0f - SMOOTHING_FACTOR);
+                    smoothedZone.percentOfFrame = smoothedZone.percentOfFrame * SMOOTHING_FACTOR +
+                                                   currentZone.percentOfFrame * (1.0f - SMOOTHING_FACTOR);
+                    break;
+                }
+            }
+        }
+
+        // Add any new zones that don't exist in smoothed stats yet
+        for (const auto& currentZone : lastFrameStats.zones) {
+            bool found = false;
+            for (const auto& smoothedZone : smoothedStats.zones) {
+                if (smoothedZone.name == currentZone.name) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                smoothedStats.zones.push_back(currentZone);
+            }
+        }
+    }
+}
+
+void CpuProfiler::beginZone(const char* zoneName) {
+    if (!enabled) return;
+
+    auto it = activeZones.find(zoneName);
+    if (it == activeZones.end()) {
+        // New zone for this frame
+        ZoneData data;
+        data.startTime = Clock::now();
+        data.accumulatedMs = 0.0f;
+        activeZones[zoneName] = data;
+        currentFrameZoneOrder.push_back(zoneName);
+    } else {
+        // Zone already exists (nested or repeated call)
+        it->second.startTime = Clock::now();
+    }
+}
+
+void CpuProfiler::endZone(const char* zoneName) {
+    if (!enabled) return;
+
+    auto it = activeZones.find(zoneName);
+    if (it == activeZones.end()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "CPU Profiler: endZone called without beginZone for '%s'", zoneName);
+        return;
+    }
+
+    auto endTime = Clock::now();
+    float elapsedMs = std::chrono::duration<float, std::milli>(endTime - it->second.startTime).count();
+    it->second.accumulatedMs += elapsedMs;
+}

--- a/src/CpuProfiler.h
+++ b/src/CpuProfiler.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+/**
+ * CPU Profiler for measuring CPU-side frame time breakdown.
+ *
+ * Uses high-resolution clock to measure time spent in various CPU operations
+ * like culling, uniform updates, command buffer recording, etc.
+ *
+ * Usage:
+ *   profiler.beginFrame();
+ *   {
+ *       CpuProfiler::ScopedZone zone(profiler, "UniformUpdate");
+ *       // ... update uniforms ...
+ *   }
+ *   profiler.endFrame();
+ */
+class CpuProfiler {
+public:
+    struct TimingResult {
+        std::string name;
+        float cpuTimeMs;       // CPU time in milliseconds
+        float percentOfFrame;  // Percentage of total frame CPU time
+    };
+
+    struct FrameStats {
+        float totalCpuTimeMs;
+        std::vector<TimingResult> zones;
+    };
+
+    /**
+     * RAII helper for scoped CPU timing zones.
+     */
+    class ScopedZone {
+    public:
+        ScopedZone(CpuProfiler& profiler, const char* zoneName)
+            : profiler(profiler), name(zoneName) {
+            profiler.beginZone(name);
+        }
+
+        ~ScopedZone() {
+            profiler.endZone(name);
+        }
+
+        // Non-copyable, non-movable
+        ScopedZone(const ScopedZone&) = delete;
+        ScopedZone& operator=(const ScopedZone&) = delete;
+        ScopedZone(ScopedZone&&) = delete;
+        ScopedZone& operator=(ScopedZone&&) = delete;
+
+    private:
+        CpuProfiler& profiler;
+        const char* name;
+    };
+
+    CpuProfiler() = default;
+    ~CpuProfiler() = default;
+
+    /**
+     * Call at the start of CPU-side frame processing.
+     */
+    void beginFrame();
+
+    /**
+     * Call at the end of CPU-side frame processing.
+     */
+    void endFrame();
+
+    /**
+     * Begin a named profiling zone.
+     */
+    void beginZone(const char* zoneName);
+
+    /**
+     * End a named profiling zone.
+     */
+    void endZone(const char* zoneName);
+
+    /**
+     * Get profiling results from the last completed frame.
+     */
+    const FrameStats& getResults() const { return lastFrameStats; }
+
+    /**
+     * Check if profiling is enabled.
+     */
+    bool isEnabled() const { return enabled; }
+    void setEnabled(bool e) { enabled = e; }
+
+    /**
+     * Get the list of zone names (for GUI display).
+     */
+    const std::vector<std::string>& getZoneNames() const { return zoneNames; }
+
+    /**
+     * Get smoothed frame stats (averaged over multiple frames).
+     */
+    const FrameStats& getSmoothedResults() const { return smoothedStats; }
+
+private:
+    using Clock = std::chrono::high_resolution_clock;
+    using TimePoint = Clock::time_point;
+
+    struct ZoneData {
+        TimePoint startTime;
+        float accumulatedMs = 0.0f;
+    };
+
+    bool enabled = true;
+
+    // Current frame state
+    TimePoint frameStartTime;
+    std::unordered_map<std::string, ZoneData> activeZones;
+    std::vector<std::string> currentFrameZoneOrder;
+
+    // Results
+    FrameStats lastFrameStats;
+    FrameStats smoothedStats;
+    std::vector<std::string> zoneNames;
+
+    // Smoothing factor (0.0 = no smoothing, 1.0 = infinite smoothing)
+    static constexpr float SMOOTHING_FACTOR = 0.9f;
+};
+
+// Macro for convenient scoped profiling
+#define CPU_PROFILE_ZONE(profiler, name) \
+    CpuProfiler::ScopedZone _cpuZone##__LINE__(profiler, name)

--- a/src/GpuProfiler.cpp
+++ b/src/GpuProfiler.cpp
@@ -1,0 +1,193 @@
+#include "GpuProfiler.h"
+#include <SDL3/SDL.h>
+#include <algorithm>
+#include <cstring>
+
+bool GpuProfiler::init(VkDevice dev, VkPhysicalDevice physicalDevice, uint32_t framesInFlight_, uint32_t maxZones_) {
+    device = dev;
+    framesInFlight = framesInFlight_;
+    maxZones = maxZones_;
+
+    // Query timestamp period from physical device
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(physicalDevice, &props);
+    timestampPeriod = props.limits.timestampPeriod;
+
+    if (timestampPeriod == 0.0f) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "GPU timestamps not supported on this device");
+        enabled = false;
+        return true;  // Not a fatal error, just disable profiling
+    }
+
+    SDL_Log("GPU Profiler: timestamp period = %.2f ns", timestampPeriod);
+
+    // Create query pools (one per frame in flight)
+    // Each zone needs 2 queries (start + end), plus 2 for frame start/end
+    uint32_t queriesPerFrame = (maxZones * QUERIES_PER_ZONE) + 2;
+
+    queryPools.resize(framesInFlight);
+    for (uint32_t i = 0; i < framesInFlight; i++) {
+        VkQueryPoolCreateInfo poolInfo{};
+        poolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+        poolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        poolInfo.queryCount = queriesPerFrame;
+
+        VkResult result = vkCreateQueryPool(device, &poolInfo, nullptr, &queryPools[i]);
+        if (result != VK_SUCCESS) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create GPU profiler query pool %d", i);
+            shutdown();
+            return false;
+        }
+    }
+
+    initialized = true;
+    SDL_Log("GPU Profiler initialized: %d zones max, %d frames in flight", maxZones, framesInFlight);
+    return true;
+}
+
+void GpuProfiler::shutdown() {
+    if (device != VK_NULL_HANDLE) {
+        for (auto& pool : queryPools) {
+            if (pool != VK_NULL_HANDLE) {
+                vkDestroyQueryPool(device, pool, nullptr);
+                pool = VK_NULL_HANDLE;
+            }
+        }
+    }
+    queryPools.clear();
+    initialized = false;
+}
+
+void GpuProfiler::beginFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
+    if (!enabled || !initialized) return;
+
+    // Collect results from previous frame first (before reset)
+    collectResults(frameIndex);
+
+    // Reset state for this frame
+    currentQueryIndex = 0;
+    activeZones.clear();
+    currentFrameZoneOrder.clear();
+    currentFrameIndex = frameIndex;
+
+    // Reset the query pool for this frame
+    vkCmdResetQueryPool(cmd, queryPools[frameIndex], 0, (maxZones * QUERIES_PER_ZONE) + 2);
+
+    // Write frame start timestamp
+    frameStartQuery = currentQueryIndex++;
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, queryPools[frameIndex], frameStartQuery);
+}
+
+void GpuProfiler::endFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
+    if (!enabled || !initialized) return;
+
+    // Write frame end timestamp
+    frameEndQuery = currentQueryIndex++;
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, queryPools[frameIndex], frameEndQuery);
+
+    // Store the query count and zone order for this frame for later collection
+    frameQueryCounts[frameIndex] = currentQueryIndex;
+    frameZoneOrders[frameIndex] = currentFrameZoneOrder;
+}
+
+void GpuProfiler::beginZone(VkCommandBuffer cmd, const char* zoneName) {
+    if (!enabled || !initialized) return;
+
+    if (currentQueryIndex >= (maxZones * QUERIES_PER_ZONE)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "GPU Profiler: max zones exceeded");
+        return;
+    }
+
+    ZoneInfo zone;
+    zone.startQueryIndex = currentQueryIndex++;
+    activeZones[zoneName] = zone;
+    currentFrameZoneOrder.push_back(zoneName);
+
+    // Write start timestamp
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                        queryPools[currentFrameIndex], zone.startQueryIndex);
+}
+
+void GpuProfiler::endZone(VkCommandBuffer cmd, const char* zoneName) {
+    if (!enabled || !initialized) return;
+
+    auto it = activeZones.find(zoneName);
+    if (it == activeZones.end()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "GPU Profiler: endZone called without beginZone for '%s'", zoneName);
+        return;
+    }
+
+    it->second.endQueryIndex = currentQueryIndex++;
+
+    // Write end timestamp
+    vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                        queryPools[currentFrameIndex], it->second.endQueryIndex);
+}
+
+void GpuProfiler::collectResults(uint32_t frameIndex) {
+    if (!enabled || !initialized) return;
+
+    // We collect from the frame we're about to overwrite (previous use of this pool)
+    // On first few frames, there won't be valid data
+    if (frameQueryCounts.find(frameIndex) == frameQueryCounts.end()) {
+        return;  // No data for this frame yet
+    }
+
+    uint32_t queryCount = frameQueryCounts[frameIndex];
+    if (queryCount < 2) return;  // Need at least frame start/end
+
+    // Allocate buffer for results
+    std::vector<uint64_t> timestamps(queryCount);
+
+    // Get query results - use VK_QUERY_RESULT_64_BIT for timestamps
+    // Don't use WAIT_BIT since we're in the middle of frame setup
+    VkResult result = vkGetQueryPoolResults(
+        device,
+        queryPools[frameIndex],
+        0,
+        queryCount,
+        timestamps.size() * sizeof(uint64_t),
+        timestamps.data(),
+        sizeof(uint64_t),
+        VK_QUERY_RESULT_64_BIT
+    );
+
+    if (result != VK_SUCCESS) {
+        // Results not ready or error - this is normal for first frames
+        return;
+    }
+
+    // Calculate frame total time
+    uint64_t frameStartTs = timestamps[0];
+    uint64_t frameEndTs = timestamps[queryCount - 1];
+    float frameTimeNs = static_cast<float>(frameEndTs - frameStartTs) * timestampPeriod;
+    float frameTimeMs = frameTimeNs / 1000000.0f;
+
+    lastFrameStats.totalGpuTimeMs = frameTimeMs;
+    lastFrameStats.zones.clear();
+    zoneNames.clear();
+
+    // Calculate per-zone timings using stored zone order
+    const auto& zoneOrder = frameZoneOrders[frameIndex];
+    uint32_t queryIdx = 1;  // Skip frame start query
+
+    for (const auto& zoneName : zoneOrder) {
+        if (queryIdx + 1 >= queryCount - 1) break;  // Don't go past frame end
+
+        uint64_t startTs = timestamps[queryIdx];
+        uint64_t endTs = timestamps[queryIdx + 1];
+
+        float zoneTimeNs = static_cast<float>(endTs - startTs) * timestampPeriod;
+        float zoneTimeMs = zoneTimeNs / 1000000.0f;
+
+        TimingResult timing;
+        timing.name = zoneName;
+        timing.gpuTimeMs = zoneTimeMs;
+        timing.percentOfFrame = (frameTimeMs > 0.0f) ? (zoneTimeMs / frameTimeMs * 100.0f) : 0.0f;
+
+        lastFrameStats.zones.push_back(timing);
+        zoneNames.push_back(zoneName);
+
+        queryIdx += 2;  // Each zone has start + end query
+    }
+}

--- a/src/GpuProfiler.h
+++ b/src/GpuProfiler.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <array>
+
+/**
+ * GPU Profiler using Vulkan timestamp queries.
+ *
+ * Measures GPU execution time for individual render passes and compute dispatches.
+ * Uses double-buffered query pools to avoid pipeline stalls.
+ *
+ * Usage:
+ *   profiler.beginFrame(cmd, frameIndex);
+ *   profiler.beginZone(cmd, "ShadowPass");
+ *   // ... shadow pass commands ...
+ *   profiler.endZone(cmd, "ShadowPass");
+ *   profiler.endFrame(cmd, frameIndex);
+ *   // Results available next frame via getResults()
+ */
+class GpuProfiler {
+public:
+    struct TimingResult {
+        std::string name;
+        float gpuTimeMs;       // GPU time in milliseconds
+        float percentOfFrame;  // Percentage of total frame GPU time
+    };
+
+    struct FrameStats {
+        float totalGpuTimeMs;
+        std::vector<TimingResult> zones;
+    };
+
+    GpuProfiler() = default;
+    ~GpuProfiler() = default;
+
+    // Non-copyable
+    GpuProfiler(const GpuProfiler&) = delete;
+    GpuProfiler& operator=(const GpuProfiler&) = delete;
+
+    /**
+     * Initialize the profiler with Vulkan handles.
+     * @param device Vulkan logical device
+     * @param physicalDevice For querying timestamp period
+     * @param framesInFlight Number of frames in flight (for query pool double-buffering)
+     * @param maxZones Maximum number of profiling zones per frame
+     */
+    bool init(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t framesInFlight, uint32_t maxZones = 32);
+    void shutdown();
+
+    /**
+     * Call at the start of frame command buffer recording.
+     * Resets query pool for this frame and writes initial timestamp.
+     */
+    void beginFrame(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    /**
+     * Call at the end of frame command buffer recording.
+     * Writes final timestamp and triggers result collection from previous frame.
+     */
+    void endFrame(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    /**
+     * Begin a named profiling zone.
+     * Writes a timestamp at the top of the GPU pipeline.
+     */
+    void beginZone(VkCommandBuffer cmd, const char* zoneName);
+
+    /**
+     * End a named profiling zone.
+     * Writes a timestamp at the bottom of the GPU pipeline.
+     */
+    void endZone(VkCommandBuffer cmd, const char* zoneName);
+
+    /**
+     * Get profiling results from the previous frame.
+     * Results are only valid after at least 2 frames have been rendered.
+     */
+    const FrameStats& getResults() const { return lastFrameStats; }
+
+    /**
+     * Check if profiling is enabled.
+     */
+    bool isEnabled() const { return enabled; }
+    void setEnabled(bool e) { enabled = e; }
+
+    /**
+     * Get the list of available zone names (for GUI display).
+     */
+    const std::vector<std::string>& getZoneNames() const { return zoneNames; }
+
+private:
+    static constexpr uint32_t QUERIES_PER_ZONE = 2;  // Start + end timestamp
+
+    struct ZoneInfo {
+        uint32_t startQueryIndex;
+        uint32_t endQueryIndex;
+    };
+
+    VkDevice device = VK_NULL_HANDLE;
+    std::vector<VkQueryPool> queryPools;  // One per frame in flight
+
+    float timestampPeriod = 0.0f;  // Nanoseconds per timestamp tick
+    uint32_t maxZones = 0;
+    uint32_t framesInFlight = 0;
+    bool enabled = true;
+    bool initialized = false;
+
+    // Current frame state
+    uint32_t currentQueryIndex = 0;
+    uint32_t currentFrameIndex = 0;
+    std::unordered_map<std::string, ZoneInfo> activeZones;
+    std::vector<std::string> currentFrameZoneOrder;
+
+    // Per-frame data for result collection
+    std::unordered_map<uint32_t, uint32_t> frameQueryCounts;
+    std::unordered_map<uint32_t, std::vector<std::string>> frameZoneOrders;
+
+    // Results from previous frame
+    FrameStats lastFrameStats;
+    std::vector<std::string> zoneNames;
+
+    // Frame start/end query indices
+    uint32_t frameStartQuery = 0;
+    uint32_t frameEndQuery = 0;
+
+    void collectResults(uint32_t frameIndex);
+};

--- a/src/GuiSystem.cpp
+++ b/src/GuiSystem.cpp
@@ -261,6 +261,10 @@ void GuiSystem::render(Renderer& renderer, float deltaTime, float fps) {
                 renderDebugSection(renderer);
                 ImGui::EndTabItem();
             }
+            if (ImGui::BeginTabItem("Profiler")) {
+                renderProfilerSection(renderer);
+                ImGui::EndTabItem();
+            }
             ImGui::EndTabBar();
         }
     }
@@ -758,6 +762,161 @@ void GuiSystem::renderDebugSection(Renderer& renderer) {
     ImGui::BulletText("[ ] - Fog density");
     ImGui::BulletText("\\ - Toggle fog");
     ImGui::BulletText("F - Spawn confetti");
+}
+
+void GuiSystem::renderProfilerSection(Renderer& renderer) {
+    ImGui::Spacing();
+
+    auto& profiler = renderer.getProfiler();
+
+    // Enable/disable toggle
+    bool enabled = profiler.isEnabled();
+    if (ImGui::Checkbox("Enable Profiling", &enabled)) {
+        profiler.setEnabled(enabled);
+    }
+
+    if (!enabled) {
+        ImGui::TextDisabled("Profiling disabled");
+        return;
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // GPU Profiling Section
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.8f, 1.0f, 1.0f));
+    ImGui::Text("GPU TIMING");
+    ImGui::PopStyleColor();
+
+    const auto& gpuStats = profiler.getGpuResults();
+
+    if (gpuStats.zones.empty()) {
+        ImGui::TextDisabled("No GPU data yet (waiting for frames)");
+    } else {
+        // Total GPU time
+        ImGui::Text("Total GPU: %.2f ms", gpuStats.totalGpuTimeMs);
+
+        ImGui::Spacing();
+
+        // GPU timing breakdown table
+        if (ImGui::BeginTable("GPUTimings", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+            ImGui::TableSetupColumn("Pass", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Time (ms)", ImGuiTableColumnFlags_WidthFixed, 70.0f);
+            ImGui::TableSetupColumn("%", ImGuiTableColumnFlags_WidthFixed, 50.0f);
+            ImGui::TableHeadersRow();
+
+            for (const auto& zone : gpuStats.zones) {
+                ImGui::TableNextRow();
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", zone.name.c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%.2f", zone.gpuTimeMs);
+
+                ImGui::TableNextColumn();
+                // Color code by percentage
+                if (zone.percentOfFrame > 30.0f) {
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
+                } else if (zone.percentOfFrame > 15.0f) {
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.4f, 1.0f));
+                } else {
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 1.0f, 0.4f, 1.0f));
+                }
+                ImGui::Text("%.1f%%", zone.percentOfFrame);
+                ImGui::PopStyleColor();
+            }
+
+            ImGui::EndTable();
+        }
+
+        // Visual bar chart of GPU zones
+        ImGui::Spacing();
+        float maxTime = gpuStats.totalGpuTimeMs;
+        for (const auto& zone : gpuStats.zones) {
+            float fraction = (maxTime > 0.0f) ? (zone.gpuTimeMs / maxTime) : 0.0f;
+            ImGui::ProgressBar(fraction, ImVec2(-1, 0), zone.name.c_str());
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // CPU Profiling Section
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.4f, 1.0f));
+    ImGui::Text("CPU TIMING");
+    ImGui::PopStyleColor();
+
+    const auto& cpuStats = profiler.getSmoothedCpuResults();
+
+    if (cpuStats.zones.empty()) {
+        ImGui::TextDisabled("No CPU data yet");
+    } else {
+        // Total CPU time
+        ImGui::Text("Total CPU: %.2f ms", cpuStats.totalCpuTimeMs);
+
+        ImGui::Spacing();
+
+        // CPU timing breakdown table
+        if (ImGui::BeginTable("CPUTimings", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg)) {
+            ImGui::TableSetupColumn("Zone", ImGuiTableColumnFlags_WidthStretch);
+            ImGui::TableSetupColumn("Time (ms)", ImGuiTableColumnFlags_WidthFixed, 70.0f);
+            ImGui::TableSetupColumn("%", ImGuiTableColumnFlags_WidthFixed, 50.0f);
+            ImGui::TableHeadersRow();
+
+            for (const auto& zone : cpuStats.zones) {
+                ImGui::TableNextRow();
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%s", zone.name.c_str());
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%.3f", zone.cpuTimeMs);
+
+                ImGui::TableNextColumn();
+                ImGui::Text("%.1f%%", zone.percentOfFrame);
+            }
+
+            ImGui::EndTable();
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    // Frame budget indicator
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.8f, 0.8f, 1.0f, 1.0f));
+    ImGui::Text("FRAME BUDGET");
+    ImGui::PopStyleColor();
+
+    float targetMs = 16.67f;  // 60 FPS target
+    float gpuTime = gpuStats.totalGpuTimeMs;
+    float cpuTime = cpuStats.totalCpuTimeMs;
+    float maxTime = std::max(gpuTime, cpuTime);
+
+    // Budget bar
+    float budgetUsed = maxTime / targetMs;
+    ImVec4 budgetColor;
+    if (budgetUsed < 0.8f) {
+        budgetColor = ImVec4(0.4f, 1.0f, 0.4f, 1.0f);  // Green
+    } else if (budgetUsed < 1.0f) {
+        budgetColor = ImVec4(1.0f, 0.8f, 0.4f, 1.0f);  // Yellow
+    } else {
+        budgetColor = ImVec4(1.0f, 0.4f, 0.4f, 1.0f);  // Red
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_PlotHistogram, budgetColor);
+    char budgetText[64];
+    snprintf(budgetText, sizeof(budgetText), "%.1f / %.1f ms (%.0f%%)",
+             maxTime, targetMs, budgetUsed * 100.0f);
+    ImGui::ProgressBar(std::min(budgetUsed, 1.5f) / 1.5f, ImVec2(-1, 20), budgetText);
+    ImGui::PopStyleColor();
+
+    ImGui::Text("GPU Bound: %s", (gpuTime > cpuTime) ? "Yes" : "No");
+    ImGui::Text("CPU Bound: %s", (cpuTime > gpuTime) ? "Yes" : "No");
 }
 
 void GuiSystem::renderHelpOverlay() {

--- a/src/GuiSystem.h
+++ b/src/GuiSystem.h
@@ -36,6 +36,7 @@ private:
     void renderPostProcessSection(Renderer& renderer);
     void renderTerrainSection(Renderer& renderer);
     void renderDebugSection(Renderer& renderer);
+    void renderProfilerSection(Renderer& renderer);
     void renderHelpOverlay();
 
     VkDescriptorPool imguiPool = VK_NULL_HANDLE;

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "GpuProfiler.h"
+#include "CpuProfiler.h"
+
+/**
+ * Unified Profiler combining GPU timestamp queries and CPU timing.
+ *
+ * Provides a single interface for frame profiling with both GPU and CPU breakdown.
+ * Results are accessible for GUI display.
+ */
+class Profiler {
+public:
+    Profiler() = default;
+    ~Profiler() = default;
+
+    /**
+     * Initialize the profiler.
+     */
+    bool init(VkDevice device, VkPhysicalDevice physicalDevice, uint32_t framesInFlight) {
+        return gpuProfiler.init(device, physicalDevice, framesInFlight);
+    }
+
+    void shutdown() {
+        gpuProfiler.shutdown();
+    }
+
+    /**
+     * Begin frame profiling (call after fence wait, before command buffer recording).
+     */
+    void beginFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
+        cpuProfiler.beginFrame();
+        gpuProfiler.beginFrame(cmd, frameIndex);
+    }
+
+    /**
+     * End frame profiling (call after command buffer recording, before submit).
+     */
+    void endFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
+        gpuProfiler.endFrame(cmd, frameIndex);
+        cpuProfiler.endFrame();
+    }
+
+    /**
+     * Begin a GPU profiling zone.
+     */
+    void beginGpuZone(VkCommandBuffer cmd, const char* zoneName) {
+        gpuProfiler.beginZone(cmd, zoneName);
+    }
+
+    /**
+     * End a GPU profiling zone.
+     */
+    void endGpuZone(VkCommandBuffer cmd, const char* zoneName) {
+        gpuProfiler.endZone(cmd, zoneName);
+    }
+
+    /**
+     * Begin a CPU profiling zone.
+     */
+    void beginCpuZone(const char* zoneName) {
+        cpuProfiler.beginZone(zoneName);
+    }
+
+    /**
+     * End a CPU profiling zone.
+     */
+    void endCpuZone(const char* zoneName) {
+        cpuProfiler.endZone(zoneName);
+    }
+
+    /**
+     * RAII helper for scoped CPU zones.
+     */
+    CpuProfiler::ScopedZone scopedCpuZone(const char* zoneName) {
+        return CpuProfiler::ScopedZone(cpuProfiler, zoneName);
+    }
+
+    // Results access
+    const GpuProfiler::FrameStats& getGpuResults() const { return gpuProfiler.getResults(); }
+    const CpuProfiler::FrameStats& getCpuResults() const { return cpuProfiler.getResults(); }
+    const CpuProfiler::FrameStats& getSmoothedCpuResults() const { return cpuProfiler.getSmoothedResults(); }
+
+    // Enable/disable
+    bool isGpuProfilingEnabled() const { return gpuProfiler.isEnabled(); }
+    bool isCpuProfilingEnabled() const { return cpuProfiler.isEnabled(); }
+    void setGpuProfilingEnabled(bool e) { gpuProfiler.setEnabled(e); }
+    void setCpuProfilingEnabled(bool e) { cpuProfiler.setEnabled(e); }
+
+    void setEnabled(bool e) {
+        gpuProfiler.setEnabled(e);
+        cpuProfiler.setEnabled(e);
+    }
+
+    bool isEnabled() const {
+        return gpuProfiler.isEnabled() || cpuProfiler.isEnabled();
+    }
+
+    // Direct access to profilers
+    GpuProfiler& getGpuProfiler() { return gpuProfiler; }
+    CpuProfiler& getCpuProfiler() { return cpuProfiler; }
+    const GpuProfiler& getGpuProfiler() const { return gpuProfiler; }
+    const CpuProfiler& getCpuProfiler() const { return cpuProfiler; }
+
+private:
+    GpuProfiler gpuProfiler;
+    CpuProfiler cpuProfiler;
+};
+
+/**
+ * RAII helper for GPU profiling zones.
+ */
+class ScopedGpuZone {
+public:
+    ScopedGpuZone(Profiler& profiler, VkCommandBuffer cmd, const char* zoneName)
+        : profiler(profiler), cmd(cmd), name(zoneName) {
+        profiler.beginGpuZone(cmd, name);
+    }
+
+    ~ScopedGpuZone() {
+        profiler.endGpuZone(cmd, name);
+    }
+
+    ScopedGpuZone(const ScopedGpuZone&) = delete;
+    ScopedGpuZone& operator=(const ScopedGpuZone&) = delete;
+
+private:
+    Profiler& profiler;
+    VkCommandBuffer cmd;
+    const char* name;
+};
+
+// Macros for convenient profiling
+#define PROFILE_GPU_ZONE(profiler, cmd, name) \
+    ScopedGpuZone _gpuZone##__LINE__(profiler, cmd, name)
+
+#define PROFILE_CPU_ZONE(profiler, name) \
+    CpuProfiler::ScopedZone _cpuZone##__LINE__(profiler.getCpuProfiler(), name)

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -40,6 +40,7 @@
 #include "RenderContext.h"
 #include "RenderPipeline.h"
 #include "GlobalBufferManager.h"
+#include "Profiler.h"
 
 struct PushConstants {
     glm::mat4 model;
@@ -187,6 +188,12 @@ public:
     HiZSystem::CullingStats getHiZCullingStats() const { return hiZSystem.getStats(); }
     uint32_t getVisibleObjectCount() const { return hiZSystem.getVisibleCount(currentFrame); }
 
+    // Profiling access
+    Profiler& getProfiler() { return profiler; }
+    const Profiler& getProfiler() const { return profiler; }
+    void setProfilingEnabled(bool enabled) { profiler.setEnabled(enabled); }
+    bool isProfilingEnabled() const { return profiler.isEnabled(); }
+
 private:
     bool createRenderPass();
     void destroyRenderResources();
@@ -267,6 +274,7 @@ private:
     CloudShadowSystem cloudShadowSystem;
     HiZSystem hiZSystem;
     EnvironmentSettings environmentSettings;
+    Profiler profiler;
     bool useVolumetricSnow = true;  // Use new volumetric system by default
 
     // Render pipeline (stages abstraction - for future refactoring)


### PR DESCRIPTION
Implements comprehensive profiling system to identify frame time bottlenecks:

- GpuProfiler: Vulkan timestamp queries for per-pass GPU timing
  - TerrainCompute, GrassCompute, WeatherCompute, SnowCompute, LeafCompute
  - CloudShadow, ShadowPass, Atmosphere, HDRPass, HiZPyramid, Bloom, PostProcess
  - Double-buffered query pools to avoid pipeline stalls

- CpuProfiler: High-resolution clock timing for CPU operations
  - UniformUpdates, SystemUpdates zones
  - RAII ScopedZone helper for automatic timing
  - Exponential smoothing for stable readings

- Profiler: Unified interface combining both profilers

- GUI: New "Profiler" tab showing:
  - GPU timing breakdown table with color-coded percentages
  - Visual progress bars for each render pass
  - CPU timing breakdown
  - Frame budget indicator (16.67ms target)
  - GPU/CPU bound detection