### PR TITLE
Fix descriptor allocation consistency across systems

### DIFF
--- a/src/AtmosphereLUTSystem.cpp
+++ b/src/AtmosphereLUTSystem.cpp
@@ -684,15 +684,10 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 }
 
 bool AtmosphereLUTSystem::createDescriptorSets() {
-    // Allocate transmittance descriptor set
+    // Allocate transmittance descriptor set using managed pool
     {
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = 1;
-        allocInfo.pSetLayouts = &transmittanceDescriptorSetLayout;
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, &transmittanceDescriptorSet) != VK_SUCCESS) {
+        transmittanceDescriptorSet = descriptorPool->allocateSingle(transmittanceDescriptorSetLayout);
+        if (transmittanceDescriptorSet == VK_NULL_HANDLE) {
             SDL_Log("Failed to allocate transmittance descriptor set");
             return false;
         }
@@ -727,15 +722,10 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
     }
 
-    // Allocate multi-scatter descriptor set
+    // Allocate multi-scatter descriptor set using managed pool
     {
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = 1;
-        allocInfo.pSetLayouts = &multiScatterDescriptorSetLayout;
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, &multiScatterDescriptorSet) != VK_SUCCESS) {
+        multiScatterDescriptorSet = descriptorPool->allocateSingle(multiScatterDescriptorSetLayout);
+        if (multiScatterDescriptorSet == VK_NULL_HANDLE) {
             SDL_Log("Failed to allocate multi-scatter descriptor set");
             return false;
         }
@@ -783,18 +773,10 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
     }
 
-    // Allocate per-frame sky-view descriptor sets (double-buffered)
+    // Allocate per-frame sky-view descriptor sets (double-buffered) using managed pool
     {
-        skyViewDescriptorSets.resize(framesInFlight);
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, skyViewDescriptorSetLayout);
-
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, skyViewDescriptorSets.data()) != VK_SUCCESS) {
+        skyViewDescriptorSets = descriptorPool->allocate(skyViewDescriptorSetLayout, framesInFlight);
+        if (skyViewDescriptorSets.empty()) {
             SDL_Log("Failed to allocate sky-view descriptor sets");
             return false;
         }
@@ -858,15 +840,10 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         }
     }
 
-    // Allocate irradiance descriptor set
+    // Allocate irradiance descriptor set using managed pool
     {
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = 1;
-        allocInfo.pSetLayouts = &irradianceDescriptorSetLayout;
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, &irradianceDescriptorSet) != VK_SUCCESS) {
+        irradianceDescriptorSet = descriptorPool->allocateSingle(irradianceDescriptorSetLayout);
+        if (irradianceDescriptorSet == VK_NULL_HANDLE) {
             SDL_Log("Failed to allocate irradiance descriptor set");
             return false;
         }
@@ -926,18 +903,10 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
     }
 
-    // Allocate per-frame cloud map descriptor sets (double-buffered)
+    // Allocate per-frame cloud map descriptor sets (double-buffered) using managed pool
     {
-        cloudMapDescriptorSets.resize(framesInFlight);
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, cloudMapDescriptorSetLayout);
-
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, cloudMapDescriptorSets.data()) != VK_SUCCESS) {
+        cloudMapDescriptorSets = descriptorPool->allocate(cloudMapDescriptorSetLayout, framesInFlight);
+        if (cloudMapDescriptorSets.empty()) {
             SDL_Log("Failed to allocate cloud map descriptor sets");
             return false;
         }

--- a/src/AtmosphereLUTSystem.h
+++ b/src/AtmosphereLUTSystem.h
@@ -7,6 +7,7 @@
 #include <string>
 #include "UBOs.h"
 #include "BufferUtils.h"
+#include "DescriptorManager.h"
 
 // Atmosphere LUT system for physically-based sky rendering (Phase 4.1)
 // Precomputes transmittance and multi-scatter LUTs for efficient atmospheric scattering
@@ -65,7 +66,7 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         std::string shaderPath;
         uint32_t framesInFlight;
     };
@@ -138,7 +139,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     std::string shaderPath;
     uint32_t framesInFlight = 0;
 

--- a/src/BloomSystem.h
+++ b/src/BloomSystem.h
@@ -4,13 +4,14 @@
 #include <vk_mem_alloc.h>
 #include <vector>
 #include <string>
+#include "DescriptorManager.h"
 
 class BloomSystem {
 public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         std::string shaderPath;
     };
@@ -52,7 +53,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkExtent2D extent = {0, 0};
     std::string shaderPath;
 

--- a/src/CatmullClarkSystem.cpp
+++ b/src/CatmullClarkSystem.cpp
@@ -264,36 +264,18 @@ bool CatmullClarkSystem::createRenderDescriptorSetLayout() {
 }
 
 bool CatmullClarkSystem::createDescriptorSets() {
-    // Allocate compute descriptor sets
-    {
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, computeDescriptorSetLayout);
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        computeDescriptorSets.resize(framesInFlight);
-        if (vkAllocateDescriptorSets(device, &allocInfo, computeDescriptorSets.data()) != VK_SUCCESS) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate compute descriptor sets");
-            return false;
-        }
+    // Allocate compute descriptor sets using managed pool
+    computeDescriptorSets = descriptorPool->allocate(computeDescriptorSetLayout, framesInFlight);
+    if (computeDescriptorSets.size() != framesInFlight) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate compute descriptor sets");
+        return false;
     }
 
-    // Allocate render descriptor sets
-    {
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, renderDescriptorSetLayout);
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        renderDescriptorSets.resize(framesInFlight);
-        if (vkAllocateDescriptorSets(device, &allocInfo, renderDescriptorSets.data()) != VK_SUCCESS) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate render descriptor sets");
-            return false;
-        }
+    // Allocate render descriptor sets using managed pool
+    renderDescriptorSets = descriptorPool->allocate(renderDescriptorSetLayout, framesInFlight);
+    if (renderDescriptorSets.size() != framesInFlight) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate render descriptor sets");
+        return false;
     }
 
     return true;

--- a/src/CatmullClarkSystem.h
+++ b/src/CatmullClarkSystem.h
@@ -8,6 +8,7 @@
 #include "UBOs.h"
 #include "CatmullClarkCBT.h"
 #include "CatmullClarkMesh.h"
+#include "DescriptorManager.h"
 
 // Push constants for rendering
 struct CatmullClarkPushConstants {
@@ -40,7 +41,7 @@ public:
         VkPhysicalDevice physicalDevice;
         VmaAllocator allocator;
         VkRenderPass renderPass;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         std::string shaderPath;
         uint32_t framesInFlight;
@@ -95,7 +96,7 @@ private:
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
     VkRenderPass renderPass = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkExtent2D extent = {0, 0};
     std::string shaderPath;
     uint32_t framesInFlight = 0;

--- a/src/CloudShadowSystem.cpp
+++ b/src/CloudShadowSystem.cpp
@@ -201,17 +201,9 @@ bool CloudShadowSystem::createDescriptorSetLayout() {
 }
 
 bool CloudShadowSystem::createDescriptorSets() {
-    descriptorSets.resize(framesInFlight);
-
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, descriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
-
-    if (vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()) != VK_SUCCESS) {
+    // Allocate descriptor sets using managed pool
+    descriptorSets = descriptorPool->allocate(descriptorSetLayout, framesInFlight);
+    if (descriptorSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate cloud shadow descriptor sets");
         return false;
     }

--- a/src/CloudShadowSystem.h
+++ b/src/CloudShadowSystem.h
@@ -5,6 +5,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 #include <string>
+#include "DescriptorManager.h"
 
 // Cloud Shadow System
 // Generates a world-space cloud shadow map by ray-marching through the cloud layer
@@ -29,7 +30,7 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         std::string shaderPath;
         uint32_t framesInFlight;
         VkImageView cloudMapLUTView;  // From AtmosphereLUTSystem
@@ -95,7 +96,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     std::string shaderPath;
     uint32_t framesInFlight = 0;
 

--- a/src/FroxelSystem.cpp
+++ b/src/FroxelSystem.cpp
@@ -280,16 +280,9 @@ bool FroxelSystem::createUniformBuffers() {
 }
 
 bool FroxelSystem::createDescriptorSets() {
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, froxelDescriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
-
-    froxelDescriptorSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &allocInfo, froxelDescriptorSets.data()) != VK_SUCCESS) {
+    // Allocate froxel descriptor sets using managed pool
+    froxelDescriptorSets = descriptorPool->allocate(froxelDescriptorSetLayout, framesInFlight);
+    if (froxelDescriptorSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate froxel descriptor sets");
         return false;
     }

--- a/src/FroxelSystem.h
+++ b/src/FroxelSystem.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include "UBOs.h"
+#include "DescriptorManager.h"
 
 // Froxel-based volumetric fog system (Phase 4.3)
 // Implements frustum-aligned voxel grid for efficient volumetric rendering
@@ -17,7 +18,7 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         std::string shaderPath;
         uint32_t framesInFlight;
@@ -113,7 +114,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkExtent2D extent = {0, 0};
     std::string shaderPath;
     uint32_t framesInFlight = 0;

--- a/src/GrassSystem.h
+++ b/src/GrassSystem.h
@@ -92,7 +92,7 @@ private:
     VkDevice getDevice() const { return particleSystem.getDevice(); }
     VmaAllocator getAllocator() const { return particleSystem.getAllocator(); }
     VkRenderPass getRenderPass() const { return particleSystem.getRenderPass(); }
-    VkDescriptorPool getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
     const VkExtent2D& getExtent() const { return particleSystem.getExtent(); }
     const std::string& getShaderPath() const { return particleSystem.getShaderPath(); }
     uint32_t getFramesInFlight() const { return particleSystem.getFramesInFlight(); }

--- a/src/HiZSystem.h
+++ b/src/HiZSystem.h
@@ -52,7 +52,7 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         std::string shaderPath;
         uint32_t framesInFlight;
@@ -143,7 +143,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkExtent2D extent = {0, 0};
     std::string shaderPath;
     uint32_t framesInFlight = 0;

--- a/src/LeafSystem.h
+++ b/src/LeafSystem.h
@@ -105,7 +105,7 @@ private:
     VkDevice getDevice() const { return particleSystem.getDevice(); }
     VmaAllocator getAllocator() const { return particleSystem.getAllocator(); }
     VkRenderPass getRenderPass() const { return particleSystem.getRenderPass(); }
-    VkDescriptorPool getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
     const VkExtent2D& getExtent() const { return particleSystem.getExtent(); }
     const std::string& getShaderPath() const { return particleSystem.getShaderPath(); }
     uint32_t getFramesInFlight() const { return particleSystem.getFramesInFlight(); }

--- a/src/ParticleSystem.cpp
+++ b/src/ParticleSystem.cpp
@@ -32,31 +32,21 @@ void ParticleSystem::setGraphicsDescriptorSet(uint32_t index, VkDescriptorSet se
 }
 
 bool ParticleSystem::createStandardDescriptorSets() {
-    // Allocate descriptor sets for both buffer sets
+    // Allocate descriptor sets for both buffer sets using managed pool
     for (uint32_t set = 0; set < bufferSetCount; set++) {
         // Compute descriptor set
-        VkDescriptorSetAllocateInfo computeAllocInfo{};
-        computeAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        computeAllocInfo.descriptorPool = getDescriptorPool();
-        computeAllocInfo.descriptorSetCount = 1;
-        computeAllocInfo.pSetLayouts = &getComputePipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet computeSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &computeAllocInfo, &computeSet) != VK_SUCCESS) {
+        VkDescriptorSet computeSet = getDescriptorPool()->allocateSingle(
+            getComputePipelineHandles().descriptorSetLayout);
+        if (computeSet == VK_NULL_HANDLE) {
             SDL_Log("Failed to allocate particle system compute descriptor set (set %u)", set);
             return false;
         }
         setComputeDescriptorSet(set, computeSet);
 
         // Graphics descriptor set
-        VkDescriptorSetAllocateInfo graphicsAllocInfo{};
-        graphicsAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        graphicsAllocInfo.descriptorPool = getDescriptorPool();
-        graphicsAllocInfo.descriptorSetCount = 1;
-        graphicsAllocInfo.pSetLayouts = &getGraphicsPipelineHandles().descriptorSetLayout;
-
-        VkDescriptorSet graphicsSet = VK_NULL_HANDLE;
-        if (vkAllocateDescriptorSets(getDevice(), &graphicsAllocInfo, &graphicsSet) != VK_SUCCESS) {
+        VkDescriptorSet graphicsSet = getDescriptorPool()->allocateSingle(
+            getGraphicsPipelineHandles().descriptorSetLayout);
+        if (graphicsSet == VK_NULL_HANDLE) {
             SDL_Log("Failed to allocate particle system graphics descriptor set (set %u)", set);
             return false;
         }

--- a/src/ParticleSystem.h
+++ b/src/ParticleSystem.h
@@ -35,7 +35,7 @@ public:
     VkDevice getDevice() const { return lifecycle.getDevice(); }
     VmaAllocator getAllocator() const { return lifecycle.getAllocator(); }
     VkRenderPass getRenderPass() const { return lifecycle.getRenderPass(); }
-    VkDescriptorPool getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
     const VkExtent2D& getExtent() const { return lifecycle.getExtent(); }
     const std::string& getShaderPath() const { return lifecycle.getShaderPath(); }
     uint32_t getFramesInFlight() const { return lifecycle.getFramesInFlight(); }

--- a/src/PostProcessSystem.cpp
+++ b/src/PostProcessSystem.cpp
@@ -383,16 +383,9 @@ bool PostProcessSystem::createUniformBuffers() {
 }
 
 bool PostProcessSystem::createDescriptorSets() {
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, compositeDescriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
-
-    compositeDescriptorSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &allocInfo, compositeDescriptorSets.data()) != VK_SUCCESS) {
+    // Allocate composite descriptor sets using managed pool
+    compositeDescriptorSets = descriptorPool->allocate(compositeDescriptorSetLayout, framesInFlight);
+    if (compositeDescriptorSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate composite descriptor sets");
         return false;
     }
@@ -920,30 +913,16 @@ bool PostProcessSystem::createHistogramPipelines() {
 }
 
 bool PostProcessSystem::createHistogramDescriptorSets() {
-    // Allocate histogram build descriptor sets
-    std::vector<VkDescriptorSetLayout> buildLayouts(framesInFlight, histogramBuildDescLayout);
-    VkDescriptorSetAllocateInfo buildAllocInfo{};
-    buildAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    buildAllocInfo.descriptorPool = descriptorPool;
-    buildAllocInfo.descriptorSetCount = framesInFlight;
-    buildAllocInfo.pSetLayouts = buildLayouts.data();
-
-    histogramBuildDescSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &buildAllocInfo, histogramBuildDescSets.data()) != VK_SUCCESS) {
+    // Allocate histogram build descriptor sets using managed pool
+    histogramBuildDescSets = descriptorPool->allocate(histogramBuildDescLayout, framesInFlight);
+    if (histogramBuildDescSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate histogram build descriptor sets");
         return false;
     }
 
-    // Allocate histogram reduce descriptor sets
-    std::vector<VkDescriptorSetLayout> reduceLayouts(framesInFlight, histogramReduceDescLayout);
-    VkDescriptorSetAllocateInfo reduceAllocInfo{};
-    reduceAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    reduceAllocInfo.descriptorPool = descriptorPool;
-    reduceAllocInfo.descriptorSetCount = framesInFlight;
-    reduceAllocInfo.pSetLayouts = reduceLayouts.data();
-
-    histogramReduceDescSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &reduceAllocInfo, histogramReduceDescSets.data()) != VK_SUCCESS) {
+    // Allocate histogram reduce descriptor sets using managed pool
+    histogramReduceDescSets = descriptorPool->allocate(histogramReduceDescLayout, framesInFlight);
+    if (histogramReduceDescSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate histogram reduce descriptor sets");
         return false;
     }

--- a/src/PostProcessSystem.h
+++ b/src/PostProcessSystem.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <functional>
 #include "UBOs.h"
+#include "DescriptorManager.h"
 
 // Alias for compatibility with existing code
 using HistogramBuildParams = HistogramParams;
@@ -41,7 +42,7 @@ public:
         VkDevice device;
         VmaAllocator allocator;
         VkRenderPass outputRenderPass;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         VkFormat swapchainFormat;
         std::string shaderPath;
@@ -126,7 +127,7 @@ private:
 
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkRenderPass outputRenderPass = VK_NULL_HANDLE;
     VkExtent2D extent = {0, 0};
     VkFormat swapchainFormat = VK_FORMAT_UNDEFINED;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -41,7 +41,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     postProcessInfo.device = device;
     postProcessInfo.allocator = allocator;
     postProcessInfo.outputRenderPass = renderPass;
-    postProcessInfo.descriptorPool = descriptorPool;
+    postProcessInfo.descriptorPool = &*descriptorManagerPool;
     postProcessInfo.extent = swapchainExtent;
     postProcessInfo.swapchainFormat = swapchainImageFormat;
     postProcessInfo.shaderPath = resourcePath + "/shaders";
@@ -53,7 +53,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     BloomSystem::InitInfo bloomInfo{};
     bloomInfo.device = device;
     bloomInfo.allocator = allocator;
-    bloomInfo.descriptorPool = descriptorPool;
+    bloomInfo.descriptorPool = &*descriptorManagerPool;
     bloomInfo.extent = swapchainExtent;
     bloomInfo.shaderPath = resourcePath + "/shaders";
 
@@ -73,7 +73,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     SkySystem::InitInfo skyInfo{};
     skyInfo.device = device;
     skyInfo.allocator = allocator;
-    skyInfo.descriptorPool = descriptorPool;
+    skyInfo.descriptorPool = &*descriptorManagerPool;
     skyInfo.shaderPath = resourcePath + "/shaders";
     skyInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
     skyInfo.extent = swapchainExtent;
@@ -89,7 +89,6 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     shadowInfo.device = device;
     shadowInfo.physicalDevice = physicalDevice;
     shadowInfo.allocator = allocator;
-    shadowInfo.descriptorPool = descriptorPool;
     shadowInfo.mainDescriptorSetLayout = descriptorSetLayout;
     shadowInfo.skinnedDescriptorSetLayout = skinnedDescriptorSetLayout;  // For skinned shadow pipeline
     shadowInfo.shaderPath = resourcePath + "/shaders";
@@ -131,7 +130,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     terrainInfo.allocator = allocator;
     terrainInfo.renderPass = postProcessSystem.getHDRRenderPass();
     terrainInfo.shadowRenderPass = shadowSystem.getShadowRenderPass();
-    terrainInfo.descriptorPool = descriptorPool;
+    terrainInfo.descriptorPool = &*descriptorManagerPool;
     terrainInfo.extent = swapchainExtent;
     terrainInfo.shadowMapSize = shadowSystem.getShadowMapSize();
     terrainInfo.shaderPath = resourcePath + "/shaders";
@@ -176,7 +175,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     snowMaskInfo.device = device;
     snowMaskInfo.allocator = allocator;
     snowMaskInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    snowMaskInfo.descriptorPool = descriptorPool;
+    snowMaskInfo.descriptorPool = &*descriptorManagerPool;
     snowMaskInfo.extent = swapchainExtent;
     snowMaskInfo.shaderPath = resourcePath + "/shaders";
     snowMaskInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -188,7 +187,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     volumetricSnowInfo.device = device;
     volumetricSnowInfo.allocator = allocator;
     volumetricSnowInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    volumetricSnowInfo.descriptorPool = descriptorPool;
+    volumetricSnowInfo.descriptorPool = &*descriptorManagerPool;
     volumetricSnowInfo.extent = swapchainExtent;
     volumetricSnowInfo.shaderPath = resourcePath + "/shaders";
     volumetricSnowInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -204,7 +203,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     grassInfo.allocator = allocator;
     grassInfo.renderPass = postProcessSystem.getHDRRenderPass();
     grassInfo.shadowRenderPass = shadowSystem.getShadowRenderPass();
-    grassInfo.descriptorPool = descriptorPool;
+    grassInfo.descriptorPool = &*descriptorManagerPool;
     grassInfo.extent = swapchainExtent;
     grassInfo.shadowMapSize = shadowSystem.getShadowMapSize();
     grassInfo.shaderPath = resourcePath + "/shaders";
@@ -216,7 +215,6 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     WindSystem::InitInfo windInfo{};
     windInfo.device = device;
     windInfo.allocator = allocator;
-    windInfo.descriptorPool = descriptorPool;
     windInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
 
     if (!windSystem.init(windInfo)) return false;
@@ -300,7 +298,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     weatherInfo.device = device;
     weatherInfo.allocator = allocator;
     weatherInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    weatherInfo.descriptorPool = descriptorPool;
+    weatherInfo.descriptorPool = &*descriptorManagerPool;
     weatherInfo.extent = swapchainExtent;
     weatherInfo.shaderPath = resourcePath + "/shaders";
     weatherInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -332,7 +330,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     leafInfo.device = device;
     leafInfo.allocator = allocator;
     leafInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    leafInfo.descriptorPool = descriptorPool;
+    leafInfo.descriptorPool = &*descriptorManagerPool;
     leafInfo.extent = swapchainExtent;
     leafInfo.shaderPath = resourcePath + "/shaders";
     leafInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -351,7 +349,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     FroxelSystem::InitInfo froxelInfo{};
     froxelInfo.device = device;
     froxelInfo.allocator = allocator;
-    froxelInfo.descriptorPool = descriptorPool;
+    froxelInfo.descriptorPool = &*descriptorManagerPool;
     froxelInfo.extent = swapchainExtent;
     froxelInfo.shaderPath = resourcePath + "/shaders";
     froxelInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -374,7 +372,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     AtmosphereLUTSystem::InitInfo atmosphereInfo{};
     atmosphereInfo.device = device;
     atmosphereInfo.allocator = allocator;
-    atmosphereInfo.descriptorPool = descriptorPool;
+    atmosphereInfo.descriptorPool = &*descriptorManagerPool;
     atmosphereInfo.shaderPath = resourcePath + "/shaders";
     atmosphereInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
 
@@ -428,7 +426,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     CloudShadowSystem::InitInfo cloudShadowInfo{};
     cloudShadowInfo.device = device;
     cloudShadowInfo.allocator = allocator;
-    cloudShadowInfo.descriptorPool = descriptorPool;
+    cloudShadowInfo.descriptorPool = &*descriptorManagerPool;
     cloudShadowInfo.shaderPath = resourcePath + "/shaders";
     cloudShadowInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
     cloudShadowInfo.cloudMapLUTView = atmosphereLUTSystem.getCloudMapLUTView();
@@ -466,7 +464,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     catmullClarkInfo.physicalDevice = physicalDevice;
     catmullClarkInfo.allocator = allocator;
     catmullClarkInfo.renderPass = postProcessSystem.getHDRRenderPass();
-    catmullClarkInfo.descriptorPool = descriptorPool;
+    catmullClarkInfo.descriptorPool = &*descriptorManagerPool;
     catmullClarkInfo.extent = swapchainExtent;
     catmullClarkInfo.shaderPath = resourcePath + "/shaders";
     catmullClarkInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -496,7 +494,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     HiZSystem::InitInfo hiZInfo{};
     hiZInfo.device = device;
     hiZInfo.allocator = allocator;
-    hiZInfo.descriptorPool = descriptorPool;
+    hiZInfo.descriptorPool = &*descriptorManagerPool;
     hiZInfo.extent = swapchainExtent;
     hiZInfo.shaderPath = resourcePath + "/shaders";
     hiZInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -524,7 +522,7 @@ bool Renderer::init(SDL_Window* win, const std::string& resPath) {
     waterInfo.device = device;
     waterInfo.physicalDevice = physicalDevice;
     waterInfo.allocator = allocator;
-    waterInfo.descriptorPool = descriptorPool;
+    waterInfo.descriptorPool = &*descriptorManagerPool;
     waterInfo.hdrRenderPass = postProcessSystem.getHDRRenderPass();
     waterInfo.shaderPath = resourcePath + "/shaders";
     waterInfo.framesInFlight = MAX_FRAMES_IN_FLIGHT;
@@ -580,8 +578,6 @@ void Renderer::shutdown() {
         }
 
         sceneManager.destroy(allocator, device);
-
-        vkDestroyDescriptorPool(device, descriptorPool, nullptr);
 
         // Clean up the auto-growing descriptor pool
         if (descriptorManagerPool.has_value()) {
@@ -1138,37 +1134,10 @@ void Renderer::updateLightBuffer(uint32_t currentImage, const Camera& camera) {
 bool Renderer::createDescriptorPool() {
     VkDevice device = vulkanContext.getDevice();
 
-    // Create the new auto-growing descriptor pool
+    // Create the auto-growing descriptor pool
     // Initial capacity of 64 sets per pool, will automatically grow if exhausted
+    // All subsystems now use this managed pool for consistent descriptor allocation
     descriptorManagerPool.emplace(device, 64);
-
-    // Legacy pool for systems not yet migrated to DescriptorManager
-    // This pool is still needed for: GrassSystem, WeatherSystem, LeafSystem, HiZSystem, etc.
-    // HiZ system needs: ~11 pyramid descriptor sets (one per mip level) + 2 culling sets
-    //   - Combined image samplers: 2 per pyramid set + 1 per culling set = ~24
-    //   - Storage images: 1 per pyramid set = ~11
-    //   - Storage buffers: 3 per culling set = ~6
-    //   - Uniform buffers: 1 per culling set = ~2
-    std::array<VkDescriptorPoolSize, 4> poolSizes{};
-    poolSizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    poolSizes[0].descriptorCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT * 20);
-    poolSizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    poolSizes[1].descriptorCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT * 50);
-    poolSizes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    poolSizes[2].descriptorCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT * 40);
-    poolSizes[3].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    poolSizes[3].descriptorCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT * 24);
-
-    VkDescriptorPoolCreateInfo poolInfo{};
-    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
-    poolInfo.pPoolSizes = poolSizes.data();
-    poolInfo.maxSets = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT * 42);
-
-    if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &descriptorPool) != VK_SUCCESS) {
-        SDL_Log("Failed to create legacy descriptor pool");
-        return false;
-    }
 
     return true;
 }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -325,7 +325,6 @@ private:
     std::vector<VmaAllocation> lightBufferAllocations;
     std::vector<void*> lightBuffersMapped;
 
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;  // Legacy pool (for systems not yet migrated)
     std::optional<DescriptorManager::Pool> descriptorManagerPool;
     std::vector<VkDescriptorSet> descriptorSets;
     std::vector<VkDescriptorSet> groundDescriptorSets;

--- a/src/ShadowSystem.cpp
+++ b/src/ShadowSystem.cpp
@@ -10,7 +10,6 @@ bool ShadowSystem::init(const InitInfo& info) {
     device = info.device;
     physicalDevice = info.physicalDevice;
     allocator = info.allocator;
-    descriptorPool = info.descriptorPool;
     mainDescriptorSetLayout = info.mainDescriptorSetLayout;
     skinnedDescriptorSetLayout = info.skinnedDescriptorSetLayout;
     shaderPath = info.shaderPath;

--- a/src/ShadowSystem.h
+++ b/src/ShadowSystem.h
@@ -29,7 +29,6 @@ public:
         VkDevice device;
         VkPhysicalDevice physicalDevice;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
         VkDescriptorSetLayout mainDescriptorSetLayout;  // For pipeline compatibility
         VkDescriptorSetLayout skinnedDescriptorSetLayout = VK_NULL_HANDLE;  // For skinned shadow pipeline (optional)
         std::string shaderPath;
@@ -107,7 +106,6 @@ private:
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
     VkDescriptorSetLayout mainDescriptorSetLayout = VK_NULL_HANDLE;
     VkDescriptorSetLayout skinnedDescriptorSetLayout = VK_NULL_HANDLE;
     std::string shaderPath;

--- a/src/SkySystem.cpp
+++ b/src/SkySystem.cpp
@@ -123,17 +123,9 @@ bool SkySystem::createDescriptorSetLayout() {
 bool SkySystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
                                       VkDeviceSize uniformBufferSize,
                                       AtmosphereLUTSystem& atmosphereLUTSystem) {
-    // Allocate sky descriptor sets (one per frame in flight)
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, descriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
-
-    descriptorSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()) != VK_SUCCESS) {
+    // Allocate sky descriptor sets using managed pool
+    descriptorSets = descriptorPool->allocate(descriptorSetLayout, framesInFlight);
+    if (descriptorSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate sky descriptor sets");
         return false;
     }

--- a/src/SkySystem.h
+++ b/src/SkySystem.h
@@ -4,6 +4,7 @@
 #include <vk_mem_alloc.h>
 #include <vector>
 #include <string>
+#include "DescriptorManager.h"
 
 class AtmosphereLUTSystem;
 
@@ -12,7 +13,7 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         std::string shaderPath;
         uint32_t framesInFlight;
         VkExtent2D extent;
@@ -38,7 +39,7 @@ private:
     bool createPipeline();
 
     VkDevice device = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     std::string shaderPath;
     uint32_t framesInFlight = 0;
     VkExtent2D extent = {0, 0};

--- a/src/SnowMaskSystem.cpp
+++ b/src/SnowMaskSystem.cpp
@@ -153,18 +153,10 @@ bool SnowMaskSystem::createComputePipeline() {
 }
 
 bool SnowMaskSystem::createDescriptorSets() {
-    computeDescriptorSets.resize(getFramesInFlight());
-
-    std::vector<VkDescriptorSetLayout> layouts(getFramesInFlight(),
-                                                getComputePipelineHandles().descriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = getDescriptorPool();
-    allocInfo.descriptorSetCount = static_cast<uint32_t>(layouts.size());
-    allocInfo.pSetLayouts = layouts.data();
-
-    if (vkAllocateDescriptorSets(getDevice(), &allocInfo, computeDescriptorSets.data()) != VK_SUCCESS) {
+    // Allocate descriptor sets using managed pool
+    computeDescriptorSets = getDescriptorPool()->allocate(
+        getComputePipelineHandles().descriptorSetLayout, getFramesInFlight());
+    if (computeDescriptorSets.size() != getFramesInFlight()) {
         SDL_Log("Failed to allocate snow mask descriptor sets");
         return false;
     }

--- a/src/SnowMaskSystem.h
+++ b/src/SnowMaskSystem.h
@@ -69,7 +69,7 @@ private:
 
     VkDevice getDevice() const { return lifecycle.getDevice(); }
     VmaAllocator getAllocator() const { return lifecycle.getAllocator(); }
-    VkDescriptorPool getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
     const std::string& getShaderPath() const { return lifecycle.getShaderPath(); }
     uint32_t getFramesInFlight() const { return lifecycle.getFramesInFlight(); }
 

--- a/src/SystemLifecycleHelper.h
+++ b/src/SystemLifecycleHelper.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
+#include "DescriptorManager.h"
 
 class SystemLifecycleHelper {
 public:
@@ -11,7 +12,7 @@ public:
         VkDevice device;
         VmaAllocator allocator;
         VkRenderPass renderPass;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool (preferred)
         VkExtent2D extent;
         std::string shaderPath;
         uint32_t framesInFlight;
@@ -88,7 +89,7 @@ public:
     VkDevice getDevice() const { return initInfo.device; }
     VmaAllocator getAllocator() const { return initInfo.allocator; }
     VkRenderPass getRenderPass() const { return initInfo.renderPass; }
-    VkDescriptorPool getDescriptorPool() const { return initInfo.descriptorPool; }
+    DescriptorManager::Pool* getDescriptorPool() const { return initInfo.descriptorPool; }
     const VkExtent2D& getExtent() const { return initInfo.extent; }
     const std::string& getShaderPath() const { return initInfo.shaderPath; }
     uint32_t getFramesInFlight() const { return initInfo.framesInFlight; }

--- a/src/TerrainSystem.cpp
+++ b/src/TerrainSystem.cpp
@@ -403,34 +403,18 @@ bool TerrainSystem::createRenderDescriptorSetLayout() {
 }
 
 bool TerrainSystem::createDescriptorSets() {
-    // Allocate compute descriptor sets
-    computeDescriptorSets.resize(framesInFlight);
-    {
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, computeDescriptorSetLayout);
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, computeDescriptorSets.data()) != VK_SUCCESS) {
-            return false;
-        }
+    // Allocate compute descriptor sets using managed pool
+    computeDescriptorSets = descriptorPool->allocate(computeDescriptorSetLayout, framesInFlight);
+    if (computeDescriptorSets.size() != framesInFlight) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TerrainSystem: Failed to allocate compute descriptor sets");
+        return false;
     }
 
-    // Allocate render descriptor sets
-    renderDescriptorSets.resize(framesInFlight);
-    {
-        std::vector<VkDescriptorSetLayout> layouts(framesInFlight, renderDescriptorSetLayout);
-        VkDescriptorSetAllocateInfo allocInfo{};
-        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        allocInfo.descriptorPool = descriptorPool;
-        allocInfo.descriptorSetCount = framesInFlight;
-        allocInfo.pSetLayouts = layouts.data();
-
-        if (vkAllocateDescriptorSets(device, &allocInfo, renderDescriptorSets.data()) != VK_SUCCESS) {
-            return false;
-        }
+    // Allocate render descriptor sets using managed pool
+    renderDescriptorSets = descriptorPool->allocate(renderDescriptorSetLayout, framesInFlight);
+    if (renderDescriptorSets.size() != framesInFlight) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TerrainSystem: Failed to allocate render descriptor sets");
+        return false;
     }
 
     // Update compute descriptor sets

--- a/src/TerrainSystem.h
+++ b/src/TerrainSystem.h
@@ -11,6 +11,7 @@
 #include "TerrainTextures.h"
 #include "TerrainCBT.h"
 #include "TerrainMeshlet.h"
+#include "DescriptorManager.h"
 
 class GpuProfiler;
 
@@ -111,7 +112,7 @@ public:
         VmaAllocator allocator;
         VkRenderPass renderPass;
         VkRenderPass shadowRenderPass;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkExtent2D extent;
         uint32_t shadowMapSize;
         std::string shaderPath;
@@ -246,7 +247,7 @@ private:
     VmaAllocator allocator = VK_NULL_HANDLE;
     VkRenderPass renderPass = VK_NULL_HANDLE;
     VkRenderPass shadowRenderPass = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkExtent2D extent = {0, 0};
     uint32_t shadowMapSize = 0;
     std::string shaderPath;

--- a/src/VolumetricSnowSystem.cpp
+++ b/src/VolumetricSnowSystem.cpp
@@ -169,18 +169,10 @@ bool VolumetricSnowSystem::createComputePipeline() {
 }
 
 bool VolumetricSnowSystem::createDescriptorSets() {
-    computeDescriptorSets.resize(getFramesInFlight());
-
-    std::vector<VkDescriptorSetLayout> layouts(getFramesInFlight(),
-                                                getComputePipelineHandles().descriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = getDescriptorPool();
-    allocInfo.descriptorSetCount = static_cast<uint32_t>(layouts.size());
-    allocInfo.pSetLayouts = layouts.data();
-
-    if (vkAllocateDescriptorSets(getDevice(), &allocInfo, computeDescriptorSets.data()) != VK_SUCCESS) {
+    // Allocate descriptor sets using managed pool
+    computeDescriptorSets = getDescriptorPool()->allocate(
+        getComputePipelineHandles().descriptorSetLayout, getFramesInFlight());
+    if (computeDescriptorSets.size() != getFramesInFlight()) {
         SDL_Log("Failed to allocate volumetric snow descriptor sets");
         return false;
     }

--- a/src/VolumetricSnowSystem.h
+++ b/src/VolumetricSnowSystem.h
@@ -129,7 +129,7 @@ private:
 
     VkDevice getDevice() const { return lifecycle.getDevice(); }
     VmaAllocator getAllocator() const { return lifecycle.getAllocator(); }
-    VkDescriptorPool getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return lifecycle.getDescriptorPool(); }
     const std::string& getShaderPath() const { return lifecycle.getShaderPath(); }
     uint32_t getFramesInFlight() const { return lifecycle.getFramesInFlight(); }
 

--- a/src/WaterSystem.cpp
+++ b/src/WaterSystem.cpp
@@ -248,17 +248,9 @@ bool WaterSystem::createUniformBuffers() {
 bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
                                         VkDeviceSize uniformBufferSize,
                                         ShadowSystem& shadowSystem) {
-    // Allocate descriptor sets (one per frame in flight)
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, descriptorSetLayout);
-
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
-
-    descriptorSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()) != VK_SUCCESS) {
+    // Allocate descriptor sets using managed pool
+    descriptorSets = descriptorPool->allocate(descriptorSetLayout, framesInFlight);
+    if (descriptorSets.size() != framesInFlight) {
         SDL_Log("Failed to allocate water descriptor sets");
         return false;
     }

--- a/src/WaterSystem.h
+++ b/src/WaterSystem.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Mesh.h"
+#include "DescriptorManager.h"
 
 class ShadowSystem;
 
@@ -16,7 +17,7 @@ public:
         VkDevice device;
         VkPhysicalDevice physicalDevice;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
+        DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
         VkRenderPass hdrRenderPass;
         std::string shaderPath;
         uint32_t framesInFlight;
@@ -93,7 +94,7 @@ private:
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool = nullptr;
     VkRenderPass hdrRenderPass = VK_NULL_HANDLE;
     std::string shaderPath;
     uint32_t framesInFlight = 0;

--- a/src/WeatherSystem.h
+++ b/src/WeatherSystem.h
@@ -85,7 +85,7 @@ private:
     VkDevice getDevice() const { return particleSystem.getDevice(); }
     VmaAllocator getAllocator() const { return particleSystem.getAllocator(); }
     VkRenderPass getRenderPass() const { return particleSystem.getRenderPass(); }
-    VkDescriptorPool getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
+    DescriptorManager::Pool* getDescriptorPool() const { return particleSystem.getDescriptorPool(); }
     const VkExtent2D& getExtent() const { return particleSystem.getExtent(); }
     const std::string& getShaderPath() const { return particleSystem.getShaderPath(); }
     uint32_t getFramesInFlight() const { return particleSystem.getFramesInFlight(); }

--- a/src/WindSystem.h
+++ b/src/WindSystem.h
@@ -20,7 +20,6 @@ public:
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
-        VkDescriptorPool descriptorPool;
         uint32_t framesInFlight;
     };
 


### PR DESCRIPTION
Migrated all rendering subsystems from legacy fixed-size VkDescriptorPool to the auto-growing DescriptorManager::Pool for consistent and reliable descriptor set allocation.

Changes:
- Updated SystemLifecycleHelper::InitInfo to use DescriptorManager::Pool*
- Migrated 17+ subsystems to use pool->allocate() and pool->allocateSingle()
- Removed legacy VkDescriptorPool member from Renderer
- Removed unused descriptorPool parameter from ShadowSystem and WindSystem
- Fixed all getDescriptorPool() return types to DescriptorManager::Pool*

This eliminates manual pool sizing, reduces allocation failures from pool exhaustion, and provides a consistent allocation pattern across the codebase.