### PR TITLE
Fix FBX import scale and orientation issues

### DIFF
--- a/src/FBXLoader.h
+++ b/src/FBXLoader.h
@@ -1,24 +1,39 @@
 #pragma once
 
 #include "GLTFLoader.h"
+#include "FBXPostProcess.h"
 #include <string>
 #include <optional>
 
 namespace FBXLoader {
     // Load skinned mesh with bone weights and animations from FBX file
     //
-    // This loader is designed for Mixamo FBX files:
+    // This loader is designed for Mixamo FBX files by default:
     // - Handles 'mixamorig:' bone name prefix
     // - Supports Y-up, right-handed coordinate system
     // - Converts Euler angle rotations to quaternions
+    // - Applies post-import processing (scale, coordinate system conversion)
+    //
+    // The settings parameter controls post-import processing:
+    // - Use FBXPresets::Mixamo() for Mixamo files (default)
+    // - Use FBXPresets::BlenderMeters() for Blender exports in meters
+    // - Use FBXPresets::Identity() to skip post-processing
     //
     // Returns nullopt if loading fails
-    std::optional<GLTFSkinnedLoadResult> loadSkinned(const std::string& path);
+    std::optional<GLTFSkinnedLoadResult> loadSkinned(
+        const std::string& path,
+        const FBXImportSettings& settings = FBXPresets::Mixamo());
 
     // Load static mesh without skeleton or animations
-    std::optional<GLTFLoadResult> load(const std::string& path);
+    std::optional<GLTFLoadResult> load(
+        const std::string& path,
+        const FBXImportSettings& settings = FBXPresets::Mixamo());
 
     // Load only animations from an FBX file (for additional animation files)
     // Uses the provided skeleton for bone name mapping
-    std::vector<AnimationClip> loadAnimations(const std::string& path, const Skeleton& skeleton);
+    // Post-processing is applied using the given settings
+    std::vector<AnimationClip> loadAnimations(
+        const std::string& path,
+        const Skeleton& skeleton,
+        const FBXImportSettings& settings = FBXPresets::Mixamo());
 }

--- a/src/FBXPostProcess.cpp
+++ b/src/FBXPostProcess.cpp
@@ -1,0 +1,328 @@
+#include "FBXPostProcess.h"
+#include "GLTFLoader.h"
+#include "SkinnedMesh.h"
+#include "Animation.h"
+#include <SDL3/SDL_log.h>
+#include <glm/gtc/matrix_transform.hpp>
+
+namespace FBXPostProcess {
+
+namespace {
+
+// Convert Euler angles (degrees) to quaternion using XYZ intrinsic order
+glm::quat eulerToQuat(const glm::vec3& eulerDeg) {
+    glm::vec3 eulerRad = glm::radians(eulerDeg);
+    glm::quat qX = glm::angleAxis(eulerRad.x, glm::vec3(1.0f, 0.0f, 0.0f));
+    glm::quat qY = glm::angleAxis(eulerRad.y, glm::vec3(0.0f, 1.0f, 0.0f));
+    glm::quat qZ = glm::angleAxis(eulerRad.z, glm::vec3(0.0f, 0.0f, 1.0f));
+    return qZ * qY * qX;
+}
+
+// Get the rotation matrix for coordinate system conversion
+glm::mat3 getCoordinateSystemRotation(UpAxis sourceUp, ForwardAxis sourceFwd) {
+    // Target coordinate system: Y-up, -Z forward (OpenGL/Vulkan convention)
+    //
+    // We need to build a matrix that transforms from source to target.
+    // This is done by determining which source axis maps to which target axis.
+
+    glm::vec3 targetUp(0.0f, 1.0f, 0.0f);      // +Y
+    glm::vec3 targetFwd(0.0f, 0.0f, -1.0f);    // -Z
+    glm::vec3 targetRight(1.0f, 0.0f, 0.0f);   // +X
+
+    // Determine source up vector in source coordinates
+    glm::vec3 srcUpVec;
+    switch (sourceUp) {
+        case UpAxis::Y_UP:     srcUpVec = glm::vec3(0, 1, 0); break;
+        case UpAxis::Z_UP:     srcUpVec = glm::vec3(0, 0, 1); break;
+        case UpAxis::NEG_Y_UP: srcUpVec = glm::vec3(0, -1, 0); break;
+        case UpAxis::NEG_Z_UP: srcUpVec = glm::vec3(0, 0, -1); break;
+    }
+
+    // Determine source forward vector in source coordinates
+    glm::vec3 srcFwdVec;
+    switch (sourceFwd) {
+        case ForwardAxis::NEG_Z: srcFwdVec = glm::vec3(0, 0, -1); break;
+        case ForwardAxis::Z:     srcFwdVec = glm::vec3(0, 0, 1); break;
+        case ForwardAxis::NEG_Y: srcFwdVec = glm::vec3(0, -1, 0); break;
+        case ForwardAxis::Y:     srcFwdVec = glm::vec3(0, 1, 0); break;
+        case ForwardAxis::X:     srcFwdVec = glm::vec3(1, 0, 0); break;
+        case ForwardAxis::NEG_X: srcFwdVec = glm::vec3(-1, 0, 0); break;
+    }
+
+    // Derive right vector from up and forward
+    glm::vec3 srcRightVec = glm::cross(srcUpVec, srcFwdVec);
+
+    // Handle degenerate case (up and forward parallel)
+    if (glm::length(srcRightVec) < 0.001f) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "FBXPostProcess: Source up and forward axes are parallel, using fallback");
+        // Use a fallback right vector
+        srcRightVec = glm::vec3(1, 0, 0);
+        if (std::abs(glm::dot(srcRightVec, srcUpVec)) > 0.9f) {
+            srcRightVec = glm::vec3(0, 1, 0);
+        }
+    }
+    srcRightVec = glm::normalize(srcRightVec);
+
+    // Re-derive forward to ensure orthogonality
+    srcFwdVec = glm::cross(srcRightVec, srcUpVec);
+    srcFwdVec = glm::normalize(srcFwdVec);
+
+    // Build transformation matrix
+    // Each column tells where each source axis ends up in target space
+    //
+    // If source has Y-up, -Z forward (same as target), result is identity
+    // If source has Z-up, -Y forward, we need:
+    //   Source X -> Target X
+    //   Source Y -> Target -Z
+    //   Source Z -> Target Y
+    //
+    // The transformation matrix M satisfies: target = M * source
+    // Build it by mapping source basis vectors to target positions
+
+    // The matrix maps: [srcRight, srcUp, srcFwd] -> [targetRight, targetUp, targetFwd]
+    // This is achieved by: M = [targetRight | targetUp | targetFwd] * inverse([srcRight | srcUp | srcFwd])
+
+    // Since both are orthonormal bases, inverse = transpose
+    glm::mat3 srcBasis(srcRightVec, srcUpVec, -srcFwdVec);  // Columns: right, up, -forward (standard basis)
+    glm::mat3 targetBasis(targetRight, targetUp, -targetFwd);  // Same convention
+
+    // For a simple axis remapping approach:
+    // Build a matrix where row i tells how source axis i contributes to result
+    // Actually, let's use a more direct approach:
+
+    // If source is Z-up, -Y forward:
+    //   srcUp = (0,0,1) should become targetUp = (0,1,0)
+    //   srcFwd = (0,-1,0) should become targetFwd = (0,0,-1)
+    //   srcRight = (1,0,0) should become targetRight = (1,0,0)
+
+    // Determine the mapping: given a source coord (x,y,z), what is target (x',y',z')?
+    // We want: target_up_component = source dot srcUpVec (how much is in source up direction)
+    // And that should become the target Y component
+
+    // Build transformation by determining where each source axis goes:
+    // Column 0 (source X): where does (1,0,0) go?
+    // Column 1 (source Y): where does (0,1,0) go?
+    // Column 2 (source Z): where does (0,0,1) go?
+
+    // For Y-up, -Z forward (identity case):
+    //   (1,0,0) -> (1,0,0), (0,1,0) -> (0,1,0), (0,0,1) -> (0,0,1)
+
+    // For Z-up, -Y forward (Blender):
+    //   Source X (1,0,0) is right -> stays right (1,0,0) in target
+    //   Source Y (0,1,0) is -forward in source, so it's forward in target space -> (0,0,-1)
+    //   Source Z (0,0,1) is up in source -> becomes Y in target (0,1,0)
+
+    // So the matrix columns are the destination of each source axis
+    glm::vec3 col0, col1, col2;  // Where source X, Y, Z go respectively
+
+    // Source X is always right (assuming right-handed), check the derived srcRightVec
+    // Actually let's compute this more directly:
+
+    // The source coordinate (sx, sy, sz) has:
+    // - Component along source right = sx (if srcRight = +X)
+    // - Component along source up = depends on srcUpVec
+    // - Component along source forward = depends on srcFwdVec
+
+    // We want the component along srcUpVec to become the Y component (target up)
+    // We want the component along srcFwdVec to become the -Z component (target forward = -Z)
+    // We want the component along srcRightVec to become the X component (target right)
+
+    // The transformation is:
+    // target = [dot(srcRight, source), dot(srcUp, source), -dot(srcFwd, source)]
+    // Which is equivalent to the matrix with rows: srcRight, srcUp, -srcFwd
+
+    // But we want the matrix in column form for GLM (column-major)
+    glm::mat3 result;
+    result[0] = srcRightVec;   // First column: where does source contribute to target X
+    result[1] = srcUpVec;      // Second column: where does source contribute to target Y
+    result[2] = -srcFwdVec;    // Third column: where does source contribute to target Z
+
+    // Wait, that's transposed. Let me think again...
+    // If result * srcVec = targetVec, and we want srcUp to become targetUp:
+    // result * srcUpVec = targetUp = (0,1,0)
+
+    // The rows of the result matrix should be:
+    // Row 0: transform that extracts right component -> srcRightVec
+    // Row 1: transform that extracts up component -> srcUpVec
+    // Row 2: transform that extracts forward component (but negated for -Z) -> -srcFwdVec
+
+    // GLM uses column-major, so to set rows we transpose:
+    glm::mat3 transform;
+    transform[0][0] = srcRightVec.x; transform[1][0] = srcRightVec.y; transform[2][0] = srcRightVec.z;
+    transform[0][1] = srcUpVec.x;    transform[1][1] = srcUpVec.y;    transform[2][1] = srcUpVec.z;
+    transform[0][2] = -srcFwdVec.x;  transform[1][2] = -srcFwdVec.y;  transform[2][2] = -srcFwdVec.z;
+
+    return transform;
+}
+
+} // anonymous namespace
+
+glm::mat4 buildTransformMatrix(const FBXImportSettings& settings) {
+    // Start with identity
+    glm::mat4 transform(1.0f);
+
+    // 1. Apply scale
+    transform = glm::scale(transform, glm::vec3(settings.scaleFactor));
+
+    // 2. Apply coordinate system conversion
+    glm::mat3 coordRot = getCoordinateSystemRotation(settings.sourceUpAxis, settings.sourceForwardAxis);
+    transform = glm::mat4(coordRot) * transform;
+
+    // 3. Apply rotation correction
+    if (glm::length(settings.rotationCorrection) > 0.001f) {
+        glm::quat correctionQuat = eulerToQuat(settings.rotationCorrection);
+        glm::mat4 correctionMat = glm::mat4_cast(correctionQuat);
+        transform = correctionMat * transform;
+    }
+
+    return transform;
+}
+
+glm::mat3 buildRotationMatrix(const FBXImportSettings& settings) {
+    // Build rotation-only matrix (no scale) for normals and directions
+    glm::mat3 coordRot = getCoordinateSystemRotation(settings.sourceUpAxis, settings.sourceForwardAxis);
+
+    if (glm::length(settings.rotationCorrection) > 0.001f) {
+        glm::quat correctionQuat = eulerToQuat(settings.rotationCorrection);
+        glm::mat3 correctionMat = glm::mat3_cast(correctionQuat);
+        coordRot = correctionMat * coordRot;
+    }
+
+    return coordRot;
+}
+
+void process(GLTFSkinnedLoadResult& result, const FBXImportSettings& settings) {
+    SDL_Log("FBXPostProcess: Processing skinned mesh with preset '%s' (scale=%.4f)",
+            settings.presetName.c_str(), settings.scaleFactor);
+
+    // Build transformation matrices
+    glm::mat4 transform = buildTransformMatrix(settings);
+    glm::mat3 rotationMat = buildRotationMatrix(settings);
+    glm::mat3 normalMat = glm::transpose(glm::inverse(rotationMat));  // For non-uniform scale safety
+
+    // Process vertices
+    for (auto& vertex : result.vertices) {
+        // Transform position (includes scale and coordinate conversion)
+        glm::vec4 pos4 = transform * glm::vec4(vertex.position, 1.0f);
+        vertex.position = glm::vec3(pos4);
+
+        // Transform normal (rotation only, normalized)
+        vertex.normal = glm::normalize(normalMat * vertex.normal);
+
+        // Transform tangent direction (keep w component for handedness)
+        float tangentW = vertex.tangent.w;
+        glm::vec3 tangentDir = glm::normalize(rotationMat * glm::vec3(vertex.tangent));
+        vertex.tangent = glm::vec4(tangentDir, tangentW);
+    }
+
+    // Process skeleton joints
+    for (auto& joint : result.skeleton.joints) {
+        // Transform local transform
+        // For local transforms, we need to handle the hierarchy properly
+        // The scale should only be applied to root bones' translations
+        // Child bone translations are relative to parent and scaled implicitly
+
+        glm::vec3 localPos = glm::vec3(joint.localTransform[3]);
+        glm::mat3 localRot = glm::mat3(joint.localTransform);
+        glm::vec3 localScale(
+            glm::length(joint.localTransform[0]),
+            glm::length(joint.localTransform[1]),
+            glm::length(joint.localTransform[2])
+        );
+
+        // Apply coordinate system conversion to rotation
+        glm::mat3 newLocalRot = rotationMat * localRot * glm::transpose(rotationMat);
+
+        // Apply scale and coordinate conversion to position
+        glm::vec3 newLocalPos = rotationMat * (localPos * settings.scaleFactor);
+
+        // Rebuild local transform
+        joint.localTransform = glm::mat4(1.0f);
+        joint.localTransform[0] = glm::vec4(glm::normalize(newLocalRot[0]) * localScale.x, 0.0f);
+        joint.localTransform[1] = glm::vec4(glm::normalize(newLocalRot[1]) * localScale.y, 0.0f);
+        joint.localTransform[2] = glm::vec4(glm::normalize(newLocalRot[2]) * localScale.z, 0.0f);
+        joint.localTransform[3] = glm::vec4(newLocalPos, 1.0f);
+
+        // Transform inverse bind matrix
+        // inverseBindMatrix transforms from model space to bone space
+        // After transforming model space, we need: newInvBind * newModelPos = bonePos
+        // Where newModelPos = transform * oldModelPos
+        // So: newInvBind = oldInvBind * inverse(transform)
+        joint.inverseBindMatrix = joint.inverseBindMatrix * glm::inverse(transform);
+
+        // Transform pre-rotation
+        // Pre-rotation is applied in local space, so we need to transform it
+        if (joint.preRotation != glm::quat(1.0f, 0.0f, 0.0f, 0.0f)) {
+            glm::mat3 preRotMat = glm::mat3_cast(joint.preRotation);
+            glm::mat3 newPreRotMat = rotationMat * preRotMat * glm::transpose(rotationMat);
+            joint.preRotation = glm::quat_cast(newPreRotMat);
+        }
+    }
+
+    // Process animations
+    processAnimations(result.animations, result.skeleton, settings);
+
+    SDL_Log("FBXPostProcess: Processed %zu vertices, %zu joints, %zu animations",
+            result.vertices.size(), result.skeleton.joints.size(), result.animations.size());
+}
+
+void process(GLTFLoadResult& result, const FBXImportSettings& settings) {
+    SDL_Log("FBXPostProcess: Processing static mesh with preset '%s' (scale=%.4f)",
+            settings.presetName.c_str(), settings.scaleFactor);
+
+    // Build transformation matrices
+    glm::mat4 transform = buildTransformMatrix(settings);
+    glm::mat3 rotationMat = buildRotationMatrix(settings);
+    glm::mat3 normalMat = glm::transpose(glm::inverse(rotationMat));
+
+    // Process vertices
+    for (auto& vertex : result.vertices) {
+        // Transform position
+        glm::vec4 pos4 = transform * glm::vec4(vertex.position, 1.0f);
+        vertex.position = glm::vec3(pos4);
+
+        // Transform normal
+        vertex.normal = glm::normalize(normalMat * vertex.normal);
+
+        // Transform tangent
+        float tangentW = vertex.tangent.w;
+        glm::vec3 tangentDir = glm::normalize(rotationMat * glm::vec3(vertex.tangent));
+        vertex.tangent = glm::vec4(tangentDir, tangentW);
+    }
+
+    SDL_Log("FBXPostProcess: Processed %zu vertices", result.vertices.size());
+}
+
+void processAnimations(std::vector<AnimationClip>& animations,
+                       const Skeleton& skeleton,
+                       const FBXImportSettings& settings) {
+    glm::mat3 rotationMat = buildRotationMatrix(settings);
+
+    for (auto& clip : animations) {
+        // Transform root motion
+        clip.rootMotionPerCycle = rotationMat * (clip.rootMotionPerCycle * settings.scaleFactor);
+
+        // Transform each channel's keyframes
+        for (auto& channel : clip.channels) {
+            // Transform translation keyframes
+            for (auto& value : channel.translation.values) {
+                value = rotationMat * (value * settings.scaleFactor);
+            }
+
+            // Transform rotation keyframes
+            // Rotations need to be transformed to the new coordinate system
+            for (auto& value : channel.rotation.values) {
+                glm::mat3 rotMat = glm::mat3_cast(value);
+                glm::mat3 newRotMat = rotationMat * rotMat * glm::transpose(rotationMat);
+                value = glm::quat_cast(newRotMat);
+            }
+
+            // Scale keyframes don't need coordinate conversion (scalar per axis)
+            // But if we had non-uniform coordinate swapping, we'd need to remap axes
+            // For now, assume scale is uniform or axis-aligned
+        }
+    }
+}
+
+} // namespace FBXPostProcess

--- a/src/FBXPostProcess.h
+++ b/src/FBXPostProcess.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <string>
+
+// Forward declarations
+struct GLTFSkinnedLoadResult;
+struct GLTFLoadResult;
+struct AnimationClip;
+struct Skeleton;
+
+// Coordinate system axes
+enum class UpAxis {
+    Y_UP,       // Standard for OpenGL/Vulkan (default)
+    Z_UP,       // Common in Blender, some CAD software
+    NEG_Y_UP,   // Inverted Y
+    NEG_Z_UP    // Inverted Z (rare)
+};
+
+enum class ForwardAxis {
+    NEG_Z,      // Standard OpenGL/Vulkan (default)
+    Z,          // Maya, some exporters
+    NEG_Y,      // Some Blender exports
+    Y,          // Rare
+    X,          // Rare
+    NEG_X       // Rare
+};
+
+// Import settings for FBX post-processing
+struct FBXImportSettings {
+    // Scale factor to convert from source units to meters
+    // Examples:
+    //   1.0      = already in meters
+    //   0.01     = centimeters to meters (Mixamo, 3ds Max default)
+    //   0.0254   = inches to meters
+    //   0.3048   = feet to meters
+    float scaleFactor = 1.0f;
+
+    // Source coordinate system
+    UpAxis sourceUpAxis = UpAxis::Y_UP;
+    ForwardAxis sourceForwardAxis = ForwardAxis::NEG_Z;
+
+    // Additional rotation correction (applied after coordinate system conversion)
+    // Euler angles in degrees (applied as XYZ intrinsic rotation)
+    glm::vec3 rotationCorrection = glm::vec3(0.0f);
+
+    // Whether to flip UV V coordinate (handled during FBX load, kept for reference)
+    bool flipUVs = true;
+
+    // Whether to recalculate tangents (handled during FBX load, kept for reference)
+    bool recalculateTangents = true;
+
+    // Name for debugging
+    std::string presetName = "Custom";
+};
+
+// Common presets for different source applications
+namespace FBXPresets {
+    // Mixamo exports: Y-up, cm units
+    inline FBXImportSettings Mixamo() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 0.01f;  // cm to meters
+        settings.sourceUpAxis = UpAxis::Y_UP;
+        settings.sourceForwardAxis = ForwardAxis::NEG_Z;
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "Mixamo";
+        return settings;
+    }
+
+    // Blender FBX export with default settings (Z-up, meters)
+    inline FBXImportSettings BlenderMeters() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 1.0f;  // Already in meters
+        settings.sourceUpAxis = UpAxis::Z_UP;
+        settings.sourceForwardAxis = ForwardAxis::NEG_Y;
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "Blender (Meters)";
+        return settings;
+    }
+
+    // Blender FBX export with cm scale
+    inline FBXImportSettings BlenderCentimeters() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 0.01f;  // cm to meters
+        settings.sourceUpAxis = UpAxis::Z_UP;
+        settings.sourceForwardAxis = ForwardAxis::NEG_Y;
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "Blender (Centimeters)";
+        return settings;
+    }
+
+    // 3ds Max default (Z-up, system units usually inches or generic)
+    inline FBXImportSettings Max3DS() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 0.0254f;  // inches to meters (adjust as needed)
+        settings.sourceUpAxis = UpAxis::Z_UP;
+        settings.sourceForwardAxis = ForwardAxis::NEG_Y;
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "3ds Max";
+        return settings;
+    }
+
+    // Maya default (Y-up, cm)
+    inline FBXImportSettings Maya() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 0.01f;  // cm to meters
+        settings.sourceUpAxis = UpAxis::Y_UP;
+        settings.sourceForwardAxis = ForwardAxis::Z;  // Maya typically exports with +Z forward
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "Maya";
+        return settings;
+    }
+
+    // No transformation (data already in target coordinate system and units)
+    inline FBXImportSettings Identity() {
+        FBXImportSettings settings;
+        settings.scaleFactor = 1.0f;
+        settings.sourceUpAxis = UpAxis::Y_UP;
+        settings.sourceForwardAxis = ForwardAxis::NEG_Z;
+        settings.rotationCorrection = glm::vec3(0.0f);
+        settings.presetName = "Identity";
+        return settings;
+    }
+}
+
+// Post-process FBX data to convert to engine coordinate system
+namespace FBXPostProcess {
+    // Process a skinned mesh result (vertices, skeleton, animations)
+    void process(GLTFSkinnedLoadResult& result, const FBXImportSettings& settings);
+
+    // Process a static mesh result (vertices only)
+    void process(GLTFLoadResult& result, const FBXImportSettings& settings);
+
+    // Process animations only (when loading additional animation files)
+    void processAnimations(std::vector<AnimationClip>& animations,
+                           const Skeleton& skeleton,
+                           const FBXImportSettings& settings);
+
+    // Build transformation matrix from import settings
+    // This includes scale, coordinate system conversion, and rotation correction
+    glm::mat4 buildTransformMatrix(const FBXImportSettings& settings);
+
+    // Build rotation-only matrix (for transforming normals and directions)
+    glm::mat3 buildRotationMatrix(const FBXImportSettings& settings);
+}

--- a/src/SceneBuilder.cpp
+++ b/src/SceneBuilder.cpp
@@ -446,10 +446,9 @@ glm::mat4 SceneBuilder::buildCharacterTransform(const glm::vec3& position, float
     // Character model transform:
     // 1. Translate to world position
     // 2. Apply Y rotation (facing direction)
-    // 3. Scale down (Mixamo FBX uses cm, convert to meters)
+    // Note: Scale is now handled by FBX post-import processing
     glm::mat4 transform = glm::translate(glm::mat4(1.0f), position);
     transform = glm::rotate(transform, yRotation, glm::vec3(0.0f, 1.0f, 0.0f));
-    transform = glm::scale(transform, glm::vec3(CHARACTER_SCALE));
     return transform;
 }
 
@@ -460,12 +459,10 @@ void SceneBuilder::updatePlayerTransform(const glm::mat4& transform) {
             glm::vec3 pos = glm::vec3(transform[3]);
             pos.y -= 0.9f;  // CAPSULE_HEIGHT * 0.5 = 1.8 * 0.5
 
-            // Use the player transform's rotation directly, just adjust position and add model corrections
+            // Use the player transform's rotation directly, just adjust position
+            // Note: Scale is now handled by FBX post-import processing
             glm::mat4 result = transform;
             result[3] = glm::vec4(pos, 1.0f);
-
-            // Apply scale (Mixamo FBX uses cm, convert to meters)
-            result = glm::scale(result, glm::vec3(CHARACTER_SCALE));
 
             sceneObjects[playerObjectIndex].transform = result;
         } else {

--- a/src/SceneBuilder.h
+++ b/src/SceneBuilder.h
@@ -104,9 +104,6 @@ private:
     // Build character model transform from world position and rotation
     glm::mat4 buildCharacterTransform(const glm::vec3& position, float yRotation) const;
 
-    // Character model constants
-    static constexpr float CHARACTER_SCALE = 0.01f;  // Mixamo FBX is in cm, scale to meters
-
     // Terrain height query function
     HeightQueryFunc terrainHeightFunc;
 


### PR DESCRIPTION
…sion

- Create FBXPostProcess module with FBXImportSettings struct
- Support common presets: Mixamo (cm to m), Blender, Maya, 3ds Max
- Transform vertices, skeleton, and animations during import
- Remove CHARACTER_SCALE hack from SceneBuilder
- Remove scale extraction hack from IKSolver foot placement
- All skeleton data now in meters after post-processing