### PR TITLE
Replace binding assignments with defines

### DIFF
--- a/shaders/bindings.h
+++ b/shaders/bindings.h
@@ -224,6 +224,60 @@
 #define BINDING_CC_FACE_BUFFER             4   // Face buffer
 
 // =============================================================================
+// Water System Descriptor Set
+// =============================================================================
+#define BINDING_WATER_UBO                  1   // Water uniforms
+#define BINDING_WATER_SHADOW_MAP           2   // Shadow map array
+#define BINDING_WATER_TERRAIN_HEIGHT       3   // Terrain height map
+#define BINDING_WATER_FLOW_MAP             4   // Flow map
+#define BINDING_WATER_DISPLACEMENT         5   // Displacement map
+#define BINDING_WATER_FOAM_NOISE           6   // Foam noise texture
+#define BINDING_WATER_TEMPORAL_FOAM        7   // Temporal foam map
+#define BINDING_WATER_CAUSTICS             8   // Caustics texture
+#define BINDING_WATER_SSR                  9   // SSR texture
+#define BINDING_WATER_SCENE_DEPTH         10   // Scene depth texture
+
+// =============================================================================
+// Water Displacement Compute Descriptor Set
+// =============================================================================
+#define BINDING_WATER_DISP_OUTPUT          0   // Displacement output image
+#define BINDING_WATER_DISP_PREV            1   // Previous displacement map
+#define BINDING_WATER_DISP_PARTICLES       2   // Splash particle buffer
+
+// =============================================================================
+// Water Tile Cull Compute Descriptor Set
+// =============================================================================
+#define BINDING_WATER_CULL_DEPTH           0   // Depth texture
+#define BINDING_WATER_CULL_TILES           1   // Tile buffer output
+#define BINDING_WATER_CULL_COUNTER         2   // Visible count buffer
+#define BINDING_WATER_CULL_INDIRECT        3   // Indirect draw buffer
+
+// =============================================================================
+// Foam Blur Compute Descriptor Set
+// =============================================================================
+#define BINDING_FOAM_OUTPUT                0   // Foam buffer output
+#define BINDING_FOAM_INPUT                 1   // Previous foam buffer
+#define BINDING_FOAM_FLOW_MAP              2   // Flow map for advection
+#define BINDING_FOAM_WAKE_DATA             3   // Wake source data
+
+// =============================================================================
+// SSR Compute Descriptor Set
+// =============================================================================
+#define BINDING_SSR_COLOR                  0   // Color texture input
+#define BINDING_SSR_DEPTH                  1   // Depth texture input
+#define BINDING_SSR_OUTPUT                 2   // SSR output image
+#define BINDING_SSR_PREV                   3   // Previous frame SSR
+
+// =============================================================================
+// Tree Shader Descriptor Set
+// =============================================================================
+#define BINDING_TREE_BARK_COLOR            1   // Bark color texture
+#define BINDING_TREE_BARK_NORMAL           2   // Bark normal map
+#define BINDING_TREE_BARK_AO               3   // Bark ambient occlusion
+#define BINDING_TREE_BARK_ROUGHNESS        4   // Bark roughness map
+#define BINDING_TREE_LEAF                  5   // Leaf texture
+
+// =============================================================================
 // C++ Type-Safe Wrappers
 // =============================================================================
 #ifdef __cplusplus
@@ -390,6 +444,48 @@ constexpr uint32_t CC_CBT_BUFFER          = BINDING_CC_CBT_BUFFER;
 constexpr uint32_t CC_VERTEX_BUFFER       = BINDING_CC_VERTEX_BUFFER;
 constexpr uint32_t CC_HALFEDGE_BUFFER     = BINDING_CC_HALFEDGE_BUFFER;
 constexpr uint32_t CC_FACE_BUFFER         = BINDING_CC_FACE_BUFFER;
+
+// Water System
+constexpr uint32_t WATER_UBO              = BINDING_WATER_UBO;
+constexpr uint32_t WATER_SHADOW_MAP       = BINDING_WATER_SHADOW_MAP;
+constexpr uint32_t WATER_TERRAIN_HEIGHT   = BINDING_WATER_TERRAIN_HEIGHT;
+constexpr uint32_t WATER_FLOW_MAP         = BINDING_WATER_FLOW_MAP;
+constexpr uint32_t WATER_DISPLACEMENT     = BINDING_WATER_DISPLACEMENT;
+constexpr uint32_t WATER_FOAM_NOISE       = BINDING_WATER_FOAM_NOISE;
+constexpr uint32_t WATER_TEMPORAL_FOAM    = BINDING_WATER_TEMPORAL_FOAM;
+constexpr uint32_t WATER_CAUSTICS         = BINDING_WATER_CAUSTICS;
+constexpr uint32_t WATER_SSR              = BINDING_WATER_SSR;
+constexpr uint32_t WATER_SCENE_DEPTH      = BINDING_WATER_SCENE_DEPTH;
+
+// Water Displacement
+constexpr uint32_t WATER_DISP_OUTPUT      = BINDING_WATER_DISP_OUTPUT;
+constexpr uint32_t WATER_DISP_PREV        = BINDING_WATER_DISP_PREV;
+constexpr uint32_t WATER_DISP_PARTICLES   = BINDING_WATER_DISP_PARTICLES;
+
+// Water Tile Cull
+constexpr uint32_t WATER_CULL_DEPTH       = BINDING_WATER_CULL_DEPTH;
+constexpr uint32_t WATER_CULL_TILES       = BINDING_WATER_CULL_TILES;
+constexpr uint32_t WATER_CULL_COUNTER     = BINDING_WATER_CULL_COUNTER;
+constexpr uint32_t WATER_CULL_INDIRECT    = BINDING_WATER_CULL_INDIRECT;
+
+// Foam Blur
+constexpr uint32_t FOAM_OUTPUT            = BINDING_FOAM_OUTPUT;
+constexpr uint32_t FOAM_INPUT             = BINDING_FOAM_INPUT;
+constexpr uint32_t FOAM_FLOW_MAP          = BINDING_FOAM_FLOW_MAP;
+constexpr uint32_t FOAM_WAKE_DATA         = BINDING_FOAM_WAKE_DATA;
+
+// SSR
+constexpr uint32_t SSR_COLOR              = BINDING_SSR_COLOR;
+constexpr uint32_t SSR_DEPTH              = BINDING_SSR_DEPTH;
+constexpr uint32_t SSR_OUTPUT             = BINDING_SSR_OUTPUT;
+constexpr uint32_t SSR_PREV               = BINDING_SSR_PREV;
+
+// Tree Shader
+constexpr uint32_t TREE_BARK_COLOR        = BINDING_TREE_BARK_COLOR;
+constexpr uint32_t TREE_BARK_NORMAL       = BINDING_TREE_BARK_NORMAL;
+constexpr uint32_t TREE_BARK_AO           = BINDING_TREE_BARK_AO;
+constexpr uint32_t TREE_BARK_ROUGHNESS    = BINDING_TREE_BARK_ROUGHNESS;
+constexpr uint32_t TREE_LEAF              = BINDING_TREE_LEAF;
 
 } // namespace Bindings
 

--- a/shaders/foam_blur.comp
+++ b/shaders/foam_blur.comp
@@ -16,16 +16,20 @@
  * Based on Sea of Thieves GDC 2018 talk.
  */
 
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
 // Output foam buffer (write)
-layout(binding = 0, r16f) uniform image2D foamBufferOut;
+layout(binding = BINDING_FOAM_OUTPUT, r16f) uniform image2D foamBufferOut;
 
 // Previous frame foam buffer (read)
-layout(binding = 1) uniform sampler2D foamBufferIn;
+layout(binding = BINDING_FOAM_INPUT) uniform sampler2D foamBufferIn;
 
 // Flow map for advection (rg = flow direction, b = speed)
-layout(binding = 2) uniform sampler2D flowMap;
+layout(binding = BINDING_FOAM_FLOW_MAP) uniform sampler2D flowMap;
 
 // Wake source structure (must match C++ WakeSource struct)
 struct WakeSource {
@@ -41,7 +45,7 @@ struct WakeSource {
 #define MAX_WAKE_SOURCES 16
 
 // Wake sources uniform buffer
-layout(std140, binding = 3) uniform WakeData {
+layout(std140, binding = BINDING_FOAM_WAKE_DATA) uniform WakeData {
     WakeSource wakeSources[MAX_WAKE_SOURCES];
 };
 

--- a/shaders/ssr.comp
+++ b/shaders/ssr.comp
@@ -13,17 +13,21 @@
  * - Edge fading to hide artifacts
  */
 
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 // Input textures
-layout(binding = 0) uniform sampler2D colorTexture;
-layout(binding = 1) uniform sampler2D depthTexture;
+layout(binding = BINDING_SSR_COLOR) uniform sampler2D colorTexture;
+layout(binding = BINDING_SSR_DEPTH) uniform sampler2D depthTexture;
 
 // Output SSR texture
-layout(binding = 2, rgba16f) uniform writeonly image2D ssrOutput;
+layout(binding = BINDING_SSR_OUTPUT, rgba16f) uniform writeonly image2D ssrOutput;
 
 // Previous frame SSR for temporal filtering
-layout(binding = 3) uniform sampler2D prevSSR;
+layout(binding = BINDING_SSR_PREV) uniform sampler2D prevSSR;
 
 // Push constants
 layout(push_constant) uniform SSRParams {

--- a/shaders/tree.frag
+++ b/shaders/tree.frag
@@ -5,6 +5,7 @@
 #include "ubo_common.glsl"
 #include "lighting_common.glsl"
 #include "atmosphere_common.glsl"
+#include "bindings.glsl"
 
 // Push constants
 layout(push_constant) uniform PushConstants {
@@ -16,11 +17,11 @@ layout(push_constant) uniform PushConstants {
 } pc;
 
 // Texture samplers
-layout(set = 0, binding = 1) uniform sampler2D barkColorTex;
-layout(set = 0, binding = 2) uniform sampler2D barkNormalTex;
-layout(set = 0, binding = 3) uniform sampler2D barkAOTex;
-layout(set = 0, binding = 4) uniform sampler2D barkRoughnessTex;
-layout(set = 0, binding = 5) uniform sampler2D leafTex;
+layout(set = 0, binding = BINDING_TREE_BARK_COLOR) uniform sampler2D barkColorTex;
+layout(set = 0, binding = BINDING_TREE_BARK_NORMAL) uniform sampler2D barkNormalTex;
+layout(set = 0, binding = BINDING_TREE_BARK_AO) uniform sampler2D barkAOTex;
+layout(set = 0, binding = BINDING_TREE_BARK_ROUGHNESS) uniform sampler2D barkRoughnessTex;
+layout(set = 0, binding = BINDING_TREE_LEAF) uniform sampler2D leafTex;
 
 // Fragment inputs
 layout(location = 0) in vec3 fragNormal;

--- a/shaders/tree_billboard.frag
+++ b/shaders/tree_billboard.frag
@@ -4,6 +4,7 @@
 
 #include "ubo_common.glsl"
 #include "lighting_common.glsl"
+#include "bindings.glsl"
 
 // Push constants
 layout(push_constant) uniform PushConstants {
@@ -15,11 +16,11 @@ layout(push_constant) uniform PushConstants {
 } pc;
 
 // Texture samplers
-layout(set = 0, binding = 1) uniform sampler2D barkColorTex;
-layout(set = 0, binding = 2) uniform sampler2D barkNormalTex;
-layout(set = 0, binding = 3) uniform sampler2D barkAOTex;
-layout(set = 0, binding = 4) uniform sampler2D barkRoughnessTex;
-layout(set = 0, binding = 5) uniform sampler2D leafTex;
+layout(set = 0, binding = BINDING_TREE_BARK_COLOR) uniform sampler2D barkColorTex;
+layout(set = 0, binding = BINDING_TREE_BARK_NORMAL) uniform sampler2D barkNormalTex;
+layout(set = 0, binding = BINDING_TREE_BARK_AO) uniform sampler2D barkAOTex;
+layout(set = 0, binding = BINDING_TREE_BARK_ROUGHNESS) uniform sampler2D barkRoughnessTex;
+layout(set = 0, binding = BINDING_TREE_LEAF) uniform sampler2D leafTex;
 
 // Fragment inputs
 layout(location = 0) in vec3 fragNormal;

--- a/shaders/water.frag
+++ b/shaders/water.frag
@@ -17,9 +17,10 @@
 #include "flow_common.glsl"
 #include "fbm_common.glsl"
 #include "foam.glsl"
+#include "bindings.glsl"
 
 // Water-specific uniforms
-layout(std140, binding = 1) uniform WaterUniforms {
+layout(std140, binding = BINDING_WATER_UBO) uniform WaterUniforms {
     // Primary material properties
     vec4 waterColor;           // rgb = base water color, a = transparency
     vec4 waveParams;           // x = amplitude, y = wavelength, z = steepness, w = speed
@@ -61,14 +62,14 @@ layout(std140, binding = 1) uniform WaterUniforms {
     float padding;             // Alignment padding
 };
 
-layout(binding = 2) uniform sampler2DArrayShadow shadowMapArray;
-layout(binding = 3) uniform sampler2D terrainHeightMap;
-layout(binding = 4) uniform sampler2D flowMap;
-layout(binding = 6) uniform sampler2D foamNoiseTexture;
-layout(binding = 7) uniform sampler2D temporalFoamMap;  // Phase 14: Persistent foam
-layout(binding = 8) uniform sampler2D causticsTexture;  // Phase 9: Underwater light patterns
-layout(binding = 9) uniform sampler2D ssrTexture;       // Phase 10: Screen-Space Reflections
-layout(binding = 10) uniform sampler2D sceneDepthTexture; // Phase 11: Scene depth for refraction
+layout(binding = BINDING_WATER_SHADOW_MAP) uniform sampler2DArrayShadow shadowMapArray;
+layout(binding = BINDING_WATER_TERRAIN_HEIGHT) uniform sampler2D terrainHeightMap;
+layout(binding = BINDING_WATER_FLOW_MAP) uniform sampler2D flowMap;
+layout(binding = BINDING_WATER_FOAM_NOISE) uniform sampler2D foamNoiseTexture;
+layout(binding = BINDING_WATER_TEMPORAL_FOAM) uniform sampler2D temporalFoamMap;  // Phase 14: Persistent foam
+layout(binding = BINDING_WATER_CAUSTICS) uniform sampler2D causticsTexture;  // Phase 9: Underwater light patterns
+layout(binding = BINDING_WATER_SSR) uniform sampler2D ssrTexture;       // Phase 10: Screen-Space Reflections
+layout(binding = BINDING_WATER_SCENE_DEPTH) uniform sampler2D sceneDepthTexture; // Phase 11: Scene depth for refraction
 
 layout(location = 0) in vec3 fragWorldPos;
 layout(location = 1) in vec3 fragNormal;

--- a/shaders/water.vert
+++ b/shaders/water.vert
@@ -9,9 +9,10 @@
  */
 
 #include "ubo_common.glsl"
+#include "bindings.glsl"
 
 // Water-specific uniforms
-layout(std140, binding = 1) uniform WaterUniforms {
+layout(std140, binding = BINDING_WATER_UBO) uniform WaterUniforms {
     vec4 waterColor;           // rgb = base water color, a = transparency
     vec4 waveParams;           // x = amplitude, y = wavelength, z = steepness, w = speed
     vec4 waveParams2;          // Second wave layer parameters
@@ -41,7 +42,7 @@ layout(std140, binding = 1) uniform WaterUniforms {
 };
 
 // Displacement map (Phase 4: Interactive splashes)
-layout(binding = 5) uniform sampler2D displacementMap;
+layout(binding = BINDING_WATER_DISPLACEMENT) uniform sampler2D displacementMap;
 
 layout(push_constant) uniform PushConstants {
     mat4 model;

--- a/shaders/water_displacement.comp
+++ b/shaders/water_displacement.comp
@@ -13,13 +13,17 @@
  * Based on Far Cry 5's water rendering approach (GDC 2018).
  */
 
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
 // Output displacement map (R16F - height displacement)
-layout(binding = 0, r16f) uniform image2D displacementMap;
+layout(binding = BINDING_WATER_DISP_OUTPUT, r16f) uniform image2D displacementMap;
 
 // Previous frame displacement (for temporal blending/decay)
-layout(binding = 1) uniform sampler2D prevDisplacementMap;
+layout(binding = BINDING_WATER_DISP_PREV) uniform sampler2D prevDisplacementMap;
 
 // Splash particle data
 struct SplashParticle {
@@ -35,7 +39,7 @@ struct SplashParticle {
     float padding3;
 };
 
-layout(std430, binding = 2) readonly buffer ParticleBuffer {
+layout(std430, binding = BINDING_WATER_DISP_PARTICLES) readonly buffer ParticleBuffer {
     SplashParticle particles[];
 };
 

--- a/shaders/water_position.frag
+++ b/shaders/water_position.frag
@@ -14,8 +14,9 @@
 #include "constants_common.glsl"
 #include "terrain_height_common.glsl"
 #include "flow_common.glsl"
+#include "bindings.glsl"
 
-layout(binding = 0) uniform UniformBufferObject {
+layout(binding = BINDING_UBO) uniform UniformBufferObject {
     mat4 model;
     mat4 view;
     mat4 proj;
@@ -36,7 +37,7 @@ layout(binding = 0) uniform UniformBufferObject {
     float julianDay;
 } ubo;
 
-layout(std140, binding = 1) uniform WaterUniforms {
+layout(std140, binding = BINDING_WATER_UBO) uniform WaterUniforms {
     vec4 waterColor;
     vec4 waveParams;
     vec4 waveParams2;
@@ -61,10 +62,10 @@ layout(std140, binding = 1) uniform WaterUniforms {
 } water;
 
 // Terrain heightmap for depth calculation
-layout(binding = 3) uniform sampler2D terrainHeightMap;
+layout(binding = BINDING_WATER_TERRAIN_HEIGHT) uniform sampler2D terrainHeightMap;
 
 // Flow map for foam and flow data
-layout(binding = 4) uniform sampler2D flowMap;
+layout(binding = BINDING_WATER_FLOW_MAP) uniform sampler2D flowMap;
 
 layout(location = 0) in vec3 fragWorldPos;
 layout(location = 1) in vec3 fragNormal;

--- a/shaders/water_position.vert
+++ b/shaders/water_position.vert
@@ -11,8 +11,9 @@
 
 #include "constants_common.glsl"
 #include "ubo_common.glsl"
+#include "bindings.glsl"
 
-layout(std140, binding = 1) uniform WaterUniforms {
+layout(std140, binding = BINDING_WATER_UBO) uniform WaterUniforms {
     vec4 waterColor;
     vec4 waveParams;
     vec4 waveParams2;

--- a/shaders/water_tile_cull.comp
+++ b/shaders/water_tile_cull.comp
@@ -16,10 +16,14 @@
  * 5. Update indirect draw command
  */
 
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 // Depth buffer for occlusion
-layout(binding = 0) uniform sampler2D depthTexture;
+layout(binding = BINDING_WATER_CULL_DEPTH) uniform sampler2D depthTexture;
 
 // Output: visible tile buffer
 struct TileData {
@@ -28,12 +32,12 @@ struct TileData {
     float maxDepth;
 };
 
-layout(binding = 1, std430) writeonly buffer TileBuffer {
+layout(binding = BINDING_WATER_CULL_TILES, std430) writeonly buffer TileBuffer {
     TileData tiles[];
 };
 
 // Atomic counter for visible tiles
-layout(binding = 2, std430) buffer CounterBuffer {
+layout(binding = BINDING_WATER_CULL_COUNTER, std430) buffer CounterBuffer {
     uint visibleCount;
 };
 
@@ -45,7 +49,7 @@ struct IndirectDrawCommand {
     uint firstInstance;
 };
 
-layout(binding = 3, std430) buffer IndirectBuffer {
+layout(binding = BINDING_WATER_CULL_INDIRECT, std430) buffer IndirectBuffer {
     IndirectDrawCommand drawCommand;
 };
 


### PR DESCRIPTION
Convert all remaining hardcoded shader bindings to use centralized defines from bindings.h. This ensures consistency between C++ code and GLSL shaders and makes binding management more maintainable.

Added binding defines for:
- Water system (UBO, textures, displacement, tile cull)
- SSR compute shader
- Foam blur compute shader
- Tree fragment shaders

Updated shaders:
- water.vert, water.frag
- water_position.vert, water_position.frag
- water_displacement.comp
- water_tile_cull.comp
- ssr.comp
- foam_blur.comp
- tree.frag, tree_billboard.frag