### PR TITLE
Fix memory unmapping assertion error on exit

### DIFF
--- a/src/WaterTileCull.cpp
+++ b/src/WaterTileCull.cpp
@@ -61,7 +61,8 @@ void WaterTileCull::destroy() {
         tileBuffer = VK_NULL_HANDLE;
     }
     if (counterBuffer != VK_NULL_HANDLE) {
-        vmaUnmapMemory(allocator, counterAllocation);
+        // Note: Do NOT call vmaUnmapMemory here - the buffer was created with
+        // VMA_ALLOCATION_CREATE_MAPPED_BIT, so VMA manages the mapping automatically
         vmaDestroyBuffer(allocator, counterBuffer, counterAllocation);
         counterBuffer = VK_NULL_HANDLE;
         counterMapped = nullptr;


### PR DESCRIPTION
The counterBuffer in WaterTileCull was created with VMA_ALLOCATION_CREATE_MAPPED_BIT, which means VMA manages the mapping automatically. Calling vmaUnmapMemory on such allocations triggers an assertion because there's no matching vmaMapMemory call.