### PR TITLE
Add camera planes to water shader UBO

### DIFF
--- a/shaders/ubo_common.glsl
+++ b/shaders/ubo_common.glsl
@@ -37,8 +37,8 @@ layout(binding = UBO_BINDING) uniform UniformBufferObject {
     float debugCascades;       // 1.0 = show cascade colors
     float julianDay;           // Julian day for sidereal rotation
     float cloudStyle;
-    float uboPad1;             // Padding - was vec3 but vec3 causes std140 alignment mismatch
-    float uboPad2;
+    float cameraNear;          // Camera near plane for linearizing depth
+    float cameraFar;           // Camera far plane for linearizing depth
     float uboPad3;
 
     // Atmosphere parameters (from UI controls) - used by atmosphere_common.glsl

--- a/shaders/water.frag
+++ b/shaders/water.frag
@@ -714,10 +714,10 @@ void main() {
     {
         // Calculate linear depth of water surface
         vec4 clipPos = ubo.proj * ubo.view * vec4(fragWorldPos, 1.0);
-        float waterLinearDepth = linearizeDepth(clipPos.z / clipPos.w * 0.5 + 0.5, 0.1, 1000.0);
+        float waterLinearDepth = linearizeDepth(clipPos.z / clipPos.w * 0.5 + 0.5, ubo.cameraNear, ubo.cameraFar);
 
         // Get scene depth and calculate soft edge
-        float sceneLinearDepth = getSceneDepth(screenUV, 0.1, 1000.0);
+        float sceneLinearDepth = getSceneDepth(screenUV, ubo.cameraNear, ubo.cameraFar);
         float depthDiff = sceneLinearDepth - waterLinearDepth;
 
         // Soft edge factor: 0 at intersection, 1 away from geometry

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -2014,6 +2014,8 @@ UniformBufferObject Renderer::buildUniformBufferData(const Camera& camera, const
     ubo.debugCascades = showCascadeDebug ? 1.0f : 0.0f;
     ubo.julianDay = static_cast<float>(lighting.julianDay);
     ubo.cloudStyle = useParaboloidClouds ? 1.0f : 0.0f;
+    ubo.cameraNear = camera.getNearPlane();
+    ubo.cameraFar = camera.getFarPlane();
 
     // Copy atmosphere parameters from AtmosphereLUTSystem for use in atmosphere_common.glsl
     const auto& atmosParams = atmosphereLUTSystem.getAtmosphereParams();


### PR DESCRIPTION
The water shader was using hardcoded near (0.1) and far (1000.0) plane values for linearizing depth in soft edge and intersection foam effects. This adds cameraNear/cameraFar to the UniformBufferObject and passes the actual camera plane values from the Camera class.