### PR TITLE
Review animations for issues and bugs

### DIFF
--- a/src/AnimatedCharacter.cpp
+++ b/src/AnimatedCharacter.cpp
@@ -220,6 +220,7 @@ void AnimatedCharacter::playAnimation(const std::string& name) {
 
 void AnimatedCharacter::playAnimation(size_t index) {
     if (index < animations.size()) {
+        currentAnimationIndex = index;
         animationPlayer.setAnimation(&animations[index]);
         SDL_Log("AnimatedCharacter: Now playing '%s'", animations[index].name.c_str());
     }
@@ -240,10 +241,8 @@ void AnimatedCharacter::startJump(const glm::vec3& startPos, const glm::vec3& ve
 }
 
 const AnimationClip* AnimatedCharacter::getCurrentAnimation() const {
-    for (const auto& clip : animations) {
-        if (animationPlayer.getDuration() == clip.duration) {
-            return &clip;
-        }
+    if (currentAnimationIndex < animations.size()) {
+        return &animations[currentAnimationIndex];
     }
     return nullptr;
 }

--- a/src/AnimatedCharacter.h
+++ b/src/AnimatedCharacter.h
@@ -90,6 +90,9 @@ public:
     IKSystem& getIKSystem() { return ikSystem; }
     const IKSystem& getIKSystem() const { return ikSystem; }
 
+    // Reset foot IK locks (call when teleporting or significantly repositioning the character)
+    void resetFootLocks() { ikSystem.resetFootLocks(); }
+
     // Setup common IK chains (arms, legs) by searching for standard bone names
     void setupDefaultIKChains();
 
@@ -114,6 +117,7 @@ private:
     AnimationPlayer animationPlayer;
     AnimationStateMachine stateMachine;
     bool useStateMachine = false;  // Set true after state machine is initialized
+    size_t currentAnimationIndex = 0;  // Track current animation by index, not duration
 
     // IK system for procedural adjustments
     IKSystem ikSystem;

--- a/src/IKSolver.h
+++ b/src/IKSolver.h
@@ -566,6 +566,9 @@ public:
     void setFootPlacementEnabled(const std::string& name, bool enabled);
     void setFootPlacementWeight(const std::string& name, float weight);
 
+    // Reset all foot locks (call when character is teleported or position changes significantly)
+    void resetFootLocks();
+
     // ========== Straddling IK (stepping on boxes) ==========
 
     // Setup straddling by bone names


### PR DESCRIPTION
- Replace euler-based joint limit clamping with swing-twist decomposition to avoid gimbal lock near ±90° rotations (IKSolver.cpp)
- Fix potential crash in climbing IK when hand bone is at root level by checking parent index before accessing global transforms (IKSolver.cpp)
- Store current animation index directly instead of matching by duration, which was fragile when multiple animations had the same length (AnimatedCharacter.cpp/h)
- Add resetFootLocks() method to clear foot IK locks when character is teleported, preventing feet snapping to old world positions (IKSolver.cpp/h)
- Improve FBX animation scale keyframe detection to use source unit scale factor instead of arbitrary threshold, preserving intentional scale animations like squash/stretch (FBXPostProcess.cpp)