### PR TITLE
Fix camera snapping in third person mode

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -465,9 +465,13 @@ void Application::processEvents() {
 
     // Handle camera mode switch initialization
     if (input.wasModeSwitchedThisFrame()) {
-        camera.resetSmoothing();
         if (input.isThirdPersonMode()) {
-            camera.orbitPitch(15.0f);
+            // Initialize third-person camera from current free camera position
+            // This ensures smooth transition instead of snapping to origin
+            camera.initializeThirdPersonFromCurrentPosition(player.getFocusPoint());
+        } else {
+            // Switching to free camera - just reset smoothing
+            camera.resetSmoothing();
         }
     }
 }

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -198,3 +198,44 @@ void Camera::resetSmoothing() {
 void Camera::setTargetFov(float newFov) {
     targetFov = newFov;
 }
+
+void Camera::initializeThirdPersonFromCurrentPosition(const glm::vec3& target) {
+    // Set the target position
+    thirdPersonTarget = target;
+    smoothedTarget = target;
+
+    // Calculate camera offset from target
+    glm::vec3 offset = position - target;
+    float distance = glm::length(offset);
+
+    // Clamp distance to valid range
+    distance = std::clamp(distance, thirdPersonMinDistance, thirdPersonMaxDistance);
+
+    // Calculate yaw from horizontal offset (atan2 of x,z gives angle)
+    // Camera is positioned at target - horizontalDist * (cos(yaw), 0, sin(yaw))
+    // So offset = -horizontalDist * (cos(yaw), 0, sin(yaw)) + (0, verticalOffset, 0)
+    // Therefore: yaw = atan2(-offset.z, -offset.x)
+    float calculatedYaw = glm::degrees(atan2(-offset.z, -offset.x));
+
+    // Calculate pitch from vertical offset
+    // verticalOffset = distance * sin(pitch)
+    // horizontalDist = distance * cos(pitch)
+    float horizontalDist = glm::length(glm::vec2(offset.x, offset.z));
+    float calculatedPitch = glm::degrees(atan2(offset.y, horizontalDist));
+
+    // Clamp pitch to valid range
+    calculatedPitch = std::clamp(calculatedPitch, -60.0f, 60.0f);
+
+    // Set both target and smoothed values to calculated values for smooth transition
+    targetYaw = calculatedYaw;
+    smoothedYaw = calculatedYaw;
+    targetPitch = calculatedPitch;
+    smoothedPitch = calculatedPitch;
+    targetDistance = distance;
+    smoothedDistance = distance;
+
+    // Also update the base yaw/pitch so getYaw() returns correct value
+    yaw = calculatedYaw;
+    pitch = calculatedPitch;
+    thirdPersonDistance = distance;
+}

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -33,6 +33,10 @@ public:
     // Snap smoothed values to targets (call on mode switch)
     void resetSmoothing();
 
+    // Initialize third-person camera from current free camera position
+    // Call this when switching from free camera to third-person mode
+    void initializeThirdPersonFromCurrentPosition(const glm::vec3& target);
+
     glm::mat4 getViewMatrix() const;
     glm::mat4 getProjectionMatrix() const;
     glm::vec3 getPosition() const { return position; }


### PR DESCRIPTION
When switching from free camera to third-person mode, the camera was snapping to the world origin because resetSmoothing() initialized smoothedTarget to the default value (0, 1.5, 0) instead of the current position.

Added initializeThirdPersonFromCurrentPosition() which properly calculates yaw, pitch, and distance from the current camera position relative to the player's focus point, ensuring a smooth transition instead of a jarring snap.