### PR TITLE
Review animations for issues and bugs

### DIFF
--- a/src/Animation.h
+++ b/src/Animation.h
@@ -93,7 +93,10 @@ T AnimationSampler<T>::sample(float time) const {
         return values.back();
     }
 
-    // Find the two keyframes to interpolate between
+    // Find the two keyframes to interpolate between.
+    // Note: This linear search is O(n) but binary search optimization is not necessary
+    // because animations typically have few keyframes per channel (< 100) and the
+    // constant factor of std::lower_bound would negate benefits at small sizes.
     size_t nextIndex = 0;
     for (size_t i = 0; i < times.size(); ++i) {
         if (times[i] > time) {
@@ -126,6 +129,7 @@ inline glm::quat AnimationSampler<glm::quat>::sample(float time) const {
         return values.back();
     }
 
+    // Linear search - see comment in primary template for rationale
     size_t nextIndex = 0;
     for (size_t i = 0; i < times.size(); ++i) {
         if (times[i] > time) {

--- a/src/IKSolver.cpp
+++ b/src/IKSolver.cpp
@@ -1597,10 +1597,13 @@ bool ClimbingIKSolver::canReach(
     bool isLeft,
     const std::vector<glm::mat4>& globalTransforms
 ) {
-    // Get shoulder/hip position
-    int32_t rootBoneIndex = isArm
-        ? (isLeft ? climbing.leftArmChainIndex : climbing.rightArmChainIndex)
-        : (isLeft ? climbing.leftLegChainIndex : climbing.rightLegChainIndex);
+    // Get shoulder/hip bone index (the root of the arm/leg chain)
+    int32_t rootBoneIndex;
+    if (isArm) {
+        rootBoneIndex = isLeft ? climbing.leftShoulderBoneIndex : climbing.rightShoulderBoneIndex;
+    } else {
+        rootBoneIndex = isLeft ? climbing.leftHipBoneIndex : climbing.rightHipBoneIndex;
+    }
 
     if (rootBoneIndex < 0 || static_cast<size_t>(rootBoneIndex) >= globalTransforms.size()) {
         return false;
@@ -1763,10 +1766,16 @@ void IKSystem::setClimbingArmChains(const std::string& leftArm, const std::strin
     leftArmChainName = leftArm;
     rightArmChainName = rightArm;
 
-    // Find chain indices
+    // Find chain indices and store root bone indices for reach calculations
     for (size_t i = 0; i < chains.size(); i++) {
-        if (chains[i].name == leftArm) climbing.leftArmChainIndex = static_cast<int32_t>(i);
-        if (chains[i].name == rightArm) climbing.rightArmChainIndex = static_cast<int32_t>(i);
+        if (chains[i].name == leftArm) {
+            climbing.leftArmChainIndex = static_cast<int32_t>(i);
+            climbing.leftShoulderBoneIndex = chains[i].chain.rootBoneIndex;
+        }
+        if (chains[i].name == rightArm) {
+            climbing.rightArmChainIndex = static_cast<int32_t>(i);
+            climbing.rightShoulderBoneIndex = chains[i].chain.rootBoneIndex;
+        }
     }
 }
 
@@ -1774,9 +1783,16 @@ void IKSystem::setClimbingLegChains(const std::string& leftLeg, const std::strin
     leftLegChainName = leftLeg;
     rightLegChainName = rightLeg;
 
+    // Find chain indices and store root bone indices for reach calculations
     for (size_t i = 0; i < chains.size(); i++) {
-        if (chains[i].name == leftLeg) climbing.leftLegChainIndex = static_cast<int32_t>(i);
-        if (chains[i].name == rightLeg) climbing.rightLegChainIndex = static_cast<int32_t>(i);
+        if (chains[i].name == leftLeg) {
+            climbing.leftLegChainIndex = static_cast<int32_t>(i);
+            climbing.leftHipBoneIndex = chains[i].chain.rootBoneIndex;
+        }
+        if (chains[i].name == rightLeg) {
+            climbing.rightLegChainIndex = static_cast<int32_t>(i);
+            climbing.rightHipBoneIndex = chains[i].chain.rootBoneIndex;
+        }
     }
 }
 

--- a/src/IKSolver.h
+++ b/src/IKSolver.h
@@ -225,6 +225,12 @@ struct ClimbingIK {
     int32_t leftHandBoneIndex = -1;
     int32_t rightHandBoneIndex = -1;
 
+    // Root bone indices for reach calculations (shoulder/hip)
+    int32_t leftShoulderBoneIndex = -1;
+    int32_t rightShoulderBoneIndex = -1;
+    int32_t leftHipBoneIndex = -1;
+    int32_t rightHipBoneIndex = -1;
+
     // Current holds
     HandHold leftHandHold;
     HandHold rightHandHold;


### PR DESCRIPTION
- Fix animation blending to properly handle FBX preRotation: Extract animated rotation by removing preRotation before blending, interpolate the animated rotations, then reapply preRotation. This prevents incorrect joint orientations during crossfades.

- Fix variable shadowing in AnimationStateMachine.cpp: Rename local 'blendTime' to 'landingBlendDuration' to avoid shadowing the class member variable.

- Fix incorrect bone index usage in ClimbingIK::canReach: Chain indices were incorrectly used as bone indices. Added new shoulder/hip bone index fields to ClimbingIK struct and populate them when setting up climbing chains.

- Add comment explaining why keyframe search optimization is unnecessary: Linear search is O(n) but animations typically have few keyframes per channel (< 100) where binary search overhead negates benefits.