### PR TITLE
Replace system 7z command with libarchive for sbsar extraction

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(SDL3 CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(lodepng CONFIG REQUIRED)
 find_package(miniz CONFIG REQUIRED)
+find_package(LibArchive REQUIRED)
 find_path(STB_INCLUDE_DIRS "stb_image.h")
 
 add_executable(shader_reflect shader_reflect.cpp)
@@ -113,6 +114,7 @@ target_link_libraries(sbsar_render PRIVATE
     glm::glm
     lodepng
     miniz::miniz
+    LibArchive::LibArchive
 )
 
 target_compile_features(sbsar_render PRIVATE cxx_std_17)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,7 @@
     "openfbx",
     "lodepng",
     "nlohmann-json",
-    "miniz"
+    "miniz",
+    "libarchive"
   ]
 }


### PR DESCRIPTION
Use libarchive library instead of shelling out to external 7z command for extracting sbsar files. This removes the dependency on having 7z installed on the system and provides more reliable cross-platform support.

Changes:
- Add libarchive dependency to vcpkg.json
- Link LibArchive to sbsar_render in CMakeLists.txt
- Replace check7zAvailable() and extract7zXmlContent() with extractLibarchive7zXmlContent() that uses libarchive API