### PR TITLE
Fix physics tile height offset

### DIFF
--- a/src/PhysicsSystem.cpp
+++ b/src/PhysicsSystem.cpp
@@ -805,12 +805,11 @@ PhysicsBodyID PhysicsWorld::createTerrainTile(const float* samples, uint32_t sam
     JPH::BodyInterface& bodyInterface = physicsSystem->GetBodyInterface();
 
     // Convert normalized heights to world heights
-    // Use same formula as global heightfield: worldY = h * heightScale
+    // Use same formula as global heightfield: worldY = h * heightScale + minAltitude
     // See TerrainHeight.h for authoritative formula
-    (void)minAltitude; // Unused - kept for API compatibility
     std::vector<float> joltSamples(sampleCount * sampleCount);
     for (uint32_t i = 0; i < sampleCount * sampleCount; i++) {
-        joltSamples[i] = samples[i] * heightScale;
+        joltSamples[i] = TerrainHeight::toWorld(samples[i], heightScale) + minAltitude;
     }
 
     // Debug: Log first sample height for tile containing origin


### PR DESCRIPTION
## Summary
- convert terrain tile physics samples to world heights using the configured base altitude

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936047a7cc883278b22c9ae1afad92c)