### PR TITLE
Thread player velocity into leaf uniforms

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -309,13 +309,14 @@ void Application::run() {
 
         // Update player position from physics character controller
         glm::vec3 physicsPos = playerPos;
+        glm::vec3 physicsVelocity = physics.getCharacterVelocity();
         player.setPosition(physicsPos);
 
         // Update scene object transforms from physics
         renderer.getSceneManager().update(physics);
 
         // Update player position for grass interaction (always, regardless of camera mode)
-        renderer.setPlayerPosition(player.getPosition(), Player::CAPSULE_RADIUS);
+        renderer.setPlayerState(player.getPosition(), physicsVelocity, Player::CAPSULE_RADIUS);
 
         // Wait for previous frame's GPU work to complete before updating dynamic meshes.
         // This prevents race conditions where we destroy mesh buffers while the GPU

--- a/src/FrameData.h
+++ b/src/FrameData.h
@@ -41,6 +41,7 @@ struct FrameData {
 
     // Player (for interaction systems like grass displacement)
     glm::vec3 playerPosition = glm::vec3(0.0f);
+    glm::vec3 playerVelocity = glm::vec3(0.0f);
     float playerCapsuleRadius = 0.5f;
 
     // Terrain parameters (for systems that need terrain info)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -733,7 +733,12 @@ void Renderer::setWeatherType(uint32_t type) {
 }
 
 void Renderer::setPlayerPosition(const glm::vec3& position, float radius) {
+    setPlayerState(position, glm::vec3(0.0f), radius);
+}
+
+void Renderer::setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius) {
     playerPosition = position;
+    playerVelocity = velocity;
     playerCapsuleRadius = radius;
 }
 
@@ -1535,10 +1540,8 @@ void Renderer::render(const Camera& camera) {
         volumetricSnowSystem.addInteraction(frame.playerPosition, frame.playerCapsuleRadius * 1.5f, 0.3f);
     }
 
-    // Update leaf system with player position (using camera as player proxy)
-    // TODO: Integrate actual player velocity from Player class for proper disruption
-    glm::vec3 playerVel = glm::vec3(0.0f);  // Will be updated when player movement tracking is added
-    leafSystem.updateUniforms(frame.frameIndex, frame.cameraPosition, frame.viewProj, frame.cameraPosition, playerVel, frame.deltaTime, frame.time,
+    // Update leaf system with player position and velocity for disruption
+    leafSystem.updateUniforms(frame.frameIndex, frame.cameraPosition, frame.viewProj, frame.cameraPosition, frame.playerVelocity, frame.deltaTime, frame.time,
                                frame.terrainSize, frame.heightScale);
 
     // Update water system uniforms
@@ -2125,6 +2128,7 @@ FrameData Renderer::buildFrameData(const Camera& camera, float deltaTime, float 
     frame.sunIntensity = ubo->sunDirection.w;
 
     frame.playerPosition = playerPosition;
+    frame.playerVelocity = playerVelocity;
     frame.playerCapsuleRadius = playerCapsuleRadius;
 
     const auto& terrainConfig = terrainSystem.getConfig();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -231,6 +231,7 @@ public:
 
     // Player position for grass interaction (xyz = position, w = capsule radius)
     void setPlayerPosition(const glm::vec3& position, float radius);
+    void setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius);
 
     // Access to systems for simulation
     WindSystem& getWindSystem() { return windSystem; }
@@ -497,6 +498,7 @@ private:
 
     // Player position for grass displacement
     glm::vec3 playerPosition = glm::vec3(0.0f);
+    glm::vec3 playerVelocity = glm::vec3(0.0f);
     float playerCapsuleRadius = 0.3f;      // Default capsule radius
 
     // Dynamic lights


### PR DESCRIPTION
## Summary
- propagate player velocity through renderer frame data and into leaf uniform updates
- add renderer API to accept per-frame player state including velocity
- source character velocity from physics when updating player state each frame

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69360683a5b88327b11eef79c7d2a795)