### PR TITLE
Bind froxel and bloom resources in post-process descriptors

### DIFF
--- a/src/PostProcessSystem.h
+++ b/src/PostProcessSystem.h
@@ -178,6 +178,8 @@ private:
     // Froxel volumetrics (Phase 4.3)
     VkImageView froxelVolumeView = VK_NULL_HANDLE;
     VkSampler froxelSampler = VK_NULL_HANDLE;
+    VkImageView bloomView = VK_NULL_HANDLE;
+    VkSampler bloomSampler = VK_NULL_HANDLE;
     bool froxelEnabled = false;
     bool hdrEnabled = true;  // HDR tonemapping enabled by default
     float froxelFarPlane = 200.0f;


### PR DESCRIPTION
## Summary
- bind froxel volume and bloom output resources into the post-process composite descriptor sets instead of HDR placeholders
- store bloom resources and only write descriptor bindings once the real views/samplers are available for each frame

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69360671a84883279e45ccc3631e25a5)