### PR TITLE
Implement dynamic shadow rendering pass

### DIFF
--- a/src/ShadowSystem.h
+++ b/src/ShadowSystem.h
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "Camera.h"
+#include "Light.h"
 #include "RenderableBuilder.h"
 #include "SkinnedMesh.h"
 
@@ -83,7 +84,13 @@ public:
     VkSampler getSpotShadowSampler() const { return spotShadowSampler; }
 
     // Dynamic shadow rendering (placeholder for future implementation)
-    void renderDynamicShadows(VkCommandBuffer cmd, uint32_t frameIndex);
+    void renderDynamicShadows(VkCommandBuffer cmd, uint32_t frameIndex,
+                              VkDescriptorSet descriptorSet,
+                              const std::vector<Renderable>& sceneObjects,
+                              const DrawCallback& terrainDrawCallback,
+                              const DrawCallback& grassDrawCallback,
+                              const DrawCallback& skinnedDrawCallback,
+                              const std::vector<Light>& visibleLights);
 
 private:
     // CSM creation methods


### PR DESCRIPTION
## Summary
- extend dynamic shadow rendering interface to accept scene draw callbacks and visible lights
- add command recording for point and spot light shadow maps using existing shadow pipelines

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936068dea908327b7f902d150a407db)