### PR TITLE
Ensure water tile counter synchronization for CPU readback

### DIFF
--- a/src/WaterTileCull.h
+++ b/src/WaterTileCull.h
@@ -122,6 +122,11 @@ private:
     VmaAllocation counterAllocation = VK_NULL_HANDLE;
     void* counterMapped = nullptr;
 
+    // Readback buffer for CPU-visible counter results
+    VkBuffer counterReadbackBuffer = VK_NULL_HANDLE;
+    VmaAllocation counterReadbackAllocation = VK_NULL_HANDLE;
+    void* counterReadbackMapped = nullptr;
+
     // Indirect draw buffer
     VkBuffer indirectDrawBuffer = VK_NULL_HANDLE;
     VmaAllocation indirectDrawAllocation = VK_NULL_HANDLE;


### PR DESCRIPTION
## Summary
- add a host-visible readback buffer for the water tile counter and enable buffer transfer usage
- insert compute-to-host buffer barriers and copy commands so CPU reads see the latest counter value
- use the synchronized counter results to decide water visibility instead of always drawing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936068f58648327950fa9d2e7cf3b7a)