### PR TITLE
Investigate HDR pass performance bottleneck

### DIFF
--- a/src/GuiSystem.cpp
+++ b/src/GuiSystem.cpp
@@ -1180,7 +1180,41 @@ void GuiSystem::renderPostProcessSection(Renderer& renderer) {
     ImGui::Text("GOD RAYS");
     ImGui::PopStyleColor();
 
-    ImGui::TextDisabled("God rays follow sun position");
+    bool godRaysEnabled = renderer.isGodRaysEnabled();
+    if (ImGui::Checkbox("Enable God Rays", &godRaysEnabled)) {
+        renderer.setGodRaysEnabled(godRaysEnabled);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Toggle god ray light shafts effect");
+    }
+
+    if (godRaysEnabled) {
+        // God ray quality dropdown
+        const char* qualityNames[] = {"Low (16 samples)", "Medium (32 samples)", "High (64 samples)"};
+        int currentQuality = static_cast<int>(renderer.getGodRayQuality());
+        if (ImGui::Combo("God Ray Quality", &currentQuality, qualityNames, 3)) {
+            renderer.setGodRayQuality(static_cast<PostProcessSystem::GodRayQuality>(currentQuality));
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Higher quality = more samples = better rays but slower");
+        }
+    }
+
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.9f, 1.0f, 1.0f));
+    ImGui::Text("VOLUMETRIC FOG");
+    ImGui::PopStyleColor();
+
+    bool froxelHighQuality = renderer.isFroxelFilterHighQuality();
+    if (ImGui::Checkbox("High Quality Fog Filter", &froxelHighQuality)) {
+        renderer.setFroxelFilterQuality(froxelHighQuality);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Tricubic filtering (8 samples) vs Trilinear (1 sample)");
+    }
 
     ImGui::Spacing();
     ImGui::Separator();

--- a/src/PostProcessSystem.h
+++ b/src/PostProcessSystem.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <functional>
+#include <array>
 #include "UBOs.h"
 #include "DescriptorManager.h"
 
@@ -85,6 +86,17 @@ public:
     float getGodRayIntensity() const { return godRayIntensity; }
     void setGodRayDecay(float d) { godRayDecay = d; }
     float getGodRayDecay() const { return godRayDecay; }
+    void setGodRaysEnabled(bool enabled) { godRaysEnabled = enabled; }
+    bool isGodRaysEnabled() const { return godRaysEnabled; }
+
+    // God ray quality (sample count): 0=Low(16), 1=Medium(32), 2=High(64)
+    enum class GodRayQuality { Low = 0, Medium = 1, High = 2 };
+    void setGodRayQuality(GodRayQuality quality);
+    GodRayQuality getGodRayQuality() const { return godRayQuality; }
+
+    // Froxel filter quality: false=trilinear (fast), true=tricubic (quality)
+    void setFroxelFilterQuality(bool highQuality) { froxelFilterHighQuality = highQuality; }
+    bool isFroxelFilterHighQuality() const { return froxelFilterHighQuality; }
 
     // Froxel volumetrics (Phase 4.3)
     void setFroxelVolume(VkImageView volumeView, VkSampler volumeSampler);
@@ -150,7 +162,9 @@ private:
     // Final composite pipeline
     VkDescriptorSetLayout compositeDescriptorSetLayout = VK_NULL_HANDLE;
     VkPipelineLayout compositePipelineLayout = VK_NULL_HANDLE;
-    VkPipeline compositePipeline = VK_NULL_HANDLE;
+    // Pipeline variants for different god ray sample counts
+    // Index 0=Low(16), 1=Medium(32), 2=High(64)
+    std::array<VkPipeline, 3> compositePipelines = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
     std::vector<VkDescriptorSet> compositeDescriptorSets;
 
     // Uniform buffers (per frame)
@@ -174,6 +188,9 @@ private:
     glm::vec2 sunScreenPos = glm::vec2(0.5f, 0.5f);  // Default to center
     float godRayIntensity = 0.25f;  // God ray strength (subtle)
     float godRayDecay = 0.92f;      // Falloff per sample (faster falloff = less extreme)
+    bool godRaysEnabled = true;     // Enable/disable god rays
+    GodRayQuality godRayQuality = GodRayQuality::High;  // Sample count quality level
+    bool froxelFilterHighQuality = true;  // Tricubic (true) vs trilinear (false)
 
     // Froxel volumetrics (Phase 4.3)
     VkImageView froxelVolumeView = VK_NULL_HANDLE;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -169,6 +169,16 @@ public:
     void setCloudShadowIntensity(float intensity) { cloudShadowSystem.setShadowIntensity(intensity); }
     float getCloudShadowIntensity() const { return cloudShadowSystem.getShadowIntensity(); }
 
+    // God ray quality control
+    void setGodRaysEnabled(bool enabled) { postProcessSystem.setGodRaysEnabled(enabled); }
+    bool isGodRaysEnabled() const { return postProcessSystem.isGodRaysEnabled(); }
+    void setGodRayQuality(PostProcessSystem::GodRayQuality quality) { postProcessSystem.setGodRayQuality(quality); }
+    PostProcessSystem::GodRayQuality getGodRayQuality() const { return postProcessSystem.getGodRayQuality(); }
+
+    // Froxel volumetric fog quality control
+    void setFroxelFilterQuality(bool highQuality) { postProcessSystem.setFroxelFilterQuality(highQuality); }
+    bool isFroxelFilterHighQuality() const { return postProcessSystem.isFroxelFilterHighQuality(); }
+
     // Terrain control
     void setTerrainEnabled(bool enabled) { terrainEnabled = enabled; }
     bool isTerrainEnabled() const { return terrainEnabled; }


### PR DESCRIPTION
Performance optimization settings for the HDR post-process pass:
- God rays enable/disable toggle
- God ray quality: Low (16), Medium (32), High (64) samples via specialization constants
- Froxel fog filter quality: trilinear (1 sample) vs tricubic (8 samples)
- Pipeline variants created at init for each god ray quality level
- GUI controls in Post Process tab for all settings