### PR TITLE
Optimize RenderPipeline to reduce size

### DIFF
--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -372,6 +372,9 @@ private:
     void recordHDRPass(VkCommandBuffer cmd, uint32_t frameIndex, float grassTime);
     void recordSceneObjects(VkCommandBuffer cmd, uint32_t frameIndex);
 
+    // Setup render pipeline stages with lambdas (called once during init)
+    void setupRenderPipeline();
+
     // Pure calculation helpers (no state mutation)
     struct LightingParams {
         glm::vec3 sunDir;


### PR DESCRIPTION
…ost-processing stages

- Add setupRenderPipeline() method that populates pipeline stages with lambdas during init
- Move compute passes (terrain, subdivision, grass, weather, snow, leaf, foam, cloud shadow) to ComputeStage
- Move atmosphere/froxel rendering to pipeline's froxelStageFn
- Move HiZ and bloom passes to PostStage callbacks
- Setup HDRStage draw calls and ShadowStage callbacks for future use
- Simplify render() by calling pipeline stages instead of inline command recording

This makes the rendering architecture more modular and easier to understand, while preparing for future improvements where individual stages can be enabled/disabled independently.