### PR TITLE
Refactor AtmosphereLUTSystem buffer patterns

### DIFF
--- a/src/atmosphere/AtmosphereLUTCompute.cpp
+++ b/src/atmosphere/AtmosphereLUTCompute.cpp
@@ -7,7 +7,7 @@ void AtmosphereLUTSystem::computeTransmittanceLUT(VkCommandBuffer cmd) {
     // Update uniform buffer with atmosphere params
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    memcpy(uniformMappedPtr, &uniforms, sizeof(AtmosphereUniforms));
+    memcpy(staticUniformBuffers.mappedPointers[0], &uniforms, sizeof(AtmosphereUniforms));
 
     // Transition to GENERAL layout for compute write
     Barriers::prepareImageForCompute(cmd, transmittanceLUT);
@@ -31,7 +31,7 @@ void AtmosphereLUTSystem::computeMultiScatterLUT(VkCommandBuffer cmd) {
     // Update uniform buffer with atmosphere params
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    memcpy(uniformMappedPtr, &uniforms, sizeof(AtmosphereUniforms));
+    memcpy(staticUniformBuffers.mappedPointers[0], &uniforms, sizeof(AtmosphereUniforms));
 
     // Transition to GENERAL layout for compute write
     Barriers::prepareImageForCompute(cmd, multiScatterLUT);
@@ -55,7 +55,7 @@ void AtmosphereLUTSystem::computeIrradianceLUT(VkCommandBuffer cmd) {
     // Update uniform buffer with atmosphere params
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    memcpy(uniformMappedPtr, &uniforms, sizeof(AtmosphereUniforms));
+    memcpy(staticUniformBuffers.mappedPointers[0], &uniforms, sizeof(AtmosphereUniforms));
 
     barrierIrradianceLUTsForCompute(cmd);
 
@@ -193,7 +193,7 @@ void AtmosphereLUTSystem::recomputeStaticLUTs(VkCommandBuffer cmd) {
     // Update uniform buffer with new atmosphere parameters
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    memcpy(uniformMappedPtr, &uniforms, sizeof(AtmosphereUniforms));
+    memcpy(staticUniformBuffers.mappedPointers[0], &uniforms, sizeof(AtmosphereUniforms));
 
     // Recompute the static LUTs that depend on atmosphere parameters
     computeTransmittanceLUT(cmd);

--- a/src/atmosphere/AtmosphereLUTDescriptors.cpp
+++ b/src/atmosphere/AtmosphereLUTDescriptors.cpp
@@ -247,7 +247,7 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         writes[0].pImageInfo = &imageInfo;
 
         VkDescriptorBufferInfo bufferInfo{};
-        bufferInfo.buffer = uniformBuffer;
+        bufferInfo.buffer = staticUniformBuffers.buffers[0];
         bufferInfo.offset = 0;
         bufferInfo.range = sizeof(AtmosphereUniforms);
 
@@ -298,7 +298,7 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         writes[1].pImageInfo = &transmittanceImageInfo;
 
         VkDescriptorBufferInfo bufferInfo{};
-        bufferInfo.buffer = uniformBuffer;
+        bufferInfo.buffer = staticUniformBuffers.buffers[0];
         bufferInfo.offset = 0;
         bufferInfo.range = sizeof(AtmosphereUniforms);
 
@@ -428,7 +428,7 @@ bool AtmosphereLUTSystem::createDescriptorSets() {
         writes[2].pImageInfo = &transmittanceImageInfo;
 
         VkDescriptorBufferInfo bufferInfo{};
-        bufferInfo.buffer = uniformBuffer;
+        bufferInfo.buffer = staticUniformBuffers.buffers[0];
         bufferInfo.offset = 0;
         bufferInfo.range = sizeof(AtmosphereUniforms);
 

--- a/src/atmosphere/AtmosphereLUTResources.cpp
+++ b/src/atmosphere/AtmosphereLUTResources.cpp
@@ -251,27 +251,15 @@ bool AtmosphereLUTSystem::createLUTSampler() {
 }
 
 bool AtmosphereLUTSystem::createUniformBuffer() {
-    // Create atmosphere LUT uniform buffer (single buffer for one-time LUT computations)
-    VkDeviceSize bufferSize = sizeof(AtmosphereUniforms);
-
-    VkBufferCreateInfo bufferInfo{};
-    bufferInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufferInfo.size = bufferSize;
-    bufferInfo.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VmaAllocationCreateInfo allocInfo{};
-    allocInfo.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
-    allocInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
-
-    VmaAllocationInfo allocResult{};
-    if (vmaCreateBuffer(allocator, &bufferInfo, &allocInfo,
-                        &uniformBuffer, &uniformAllocation, &allocResult) != VK_SUCCESS) {
-        SDL_Log("Failed to create atmosphere uniform buffer");
+    // Create static uniform buffer for one-time LUT computations (frame count of 1 for consistency)
+    BufferUtils::PerFrameBufferBuilder staticBuilder;
+    if (!staticBuilder.setAllocator(allocator)
+             .setFrameCount(1)
+             .setSize(sizeof(AtmosphereUniforms))
+             .build(staticUniformBuffers)) {
+        SDL_Log("Failed to create static atmosphere uniform buffer");
         return false;
     }
-
-    uniformMappedPtr = allocResult.pMappedData;
 
     // Create per-frame uniform buffers for sky view LUT updates (double-buffered)
     BufferUtils::PerFrameBufferBuilder skyViewBuilder;

--- a/src/atmosphere/AtmosphereLUTSystem.cpp
+++ b/src/atmosphere/AtmosphereLUTSystem.cpp
@@ -48,12 +48,8 @@ bool AtmosphereLUTSystem::init(const InitContext& ctx) {
 void AtmosphereLUTSystem::destroy(VkDevice device, VmaAllocator allocator) {
     destroyLUTResources();
 
-    if (uniformBuffer != VK_NULL_HANDLE) {
-        vmaDestroyBuffer(allocator, uniformBuffer, uniformAllocation);
-        uniformBuffer = VK_NULL_HANDLE;
-    }
-
-    // Destroy per-frame uniform buffers
+    // Destroy all uniform buffers using consistent BufferUtils pattern
+    BufferUtils::destroyBuffers(allocator, staticUniformBuffers);
     BufferUtils::destroyBuffers(allocator, skyViewUniformBuffers);
     BufferUtils::destroyBuffers(allocator, cloudMapUniformBuffers);
 

--- a/src/atmosphere/AtmosphereLUTSystem.h
+++ b/src/atmosphere/AtmosphereLUTSystem.h
@@ -229,10 +229,9 @@ private:
     std::vector<VkDescriptorSet> skyViewDescriptorSets;
     std::vector<VkDescriptorSet> cloudMapDescriptorSets;
 
-    // Single uniform buffer for one-time LUT computation (at startup)
-    VkBuffer uniformBuffer = VK_NULL_HANDLE;
-    VmaAllocation uniformAllocation = VK_NULL_HANDLE;
-    void* uniformMappedPtr = nullptr;
+    // Uniform buffers for one-time LUT computation (at startup)
+    // Uses PerFrameBufferSet with frame count of 1 for consistency
+    BufferUtils::PerFrameBufferSet staticUniformBuffers;
 
     // Per-frame uniform buffers for per-frame updates (double-buffered)
     BufferUtils::PerFrameBufferSet skyViewUniformBuffers;


### PR DESCRIPTION
Replace manual VkBuffer/VmaAllocation/void* members with BufferUtils::PerFrameBufferSet for the static uniform buffer used in one-time LUT computation. This aligns the static buffer management with the existing pattern used by skyViewUniformBuffers and cloudMapUniformBuffers.