### PR TITLE
Create window resize coordinator class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
     # Core
     src/core/Renderer.cpp
     src/core/RendererInit.cpp
+    src/core/ResizeCoordinator.cpp
     src/core/UBOBuilder.cpp
     src/core/VulkanContext.cpp
     src/core/Mesh.cpp

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -53,6 +53,7 @@
 #include "WaterGBuffer.h"
 #include "DebugLineSystem.h"
 #include "UBOBuilder.h"
+#include "ResizeCoordinator.h"
 
 #ifdef JPH_DEBUG_RENDERER
 #include "PhysicsDebugRenderer.h"
@@ -353,6 +354,7 @@ private:
     void destroyRenderResources();
     void destroyDepthImageAndView();  // Helper for resize (keeps sampler)
     void destroyFramebuffers();       // Helper for resize
+    bool recreateDepthResources(VkExtent2D newExtent);  // Helper for resize
     bool createFramebuffers();
     bool createCommandPool();
     bool createCommandBuffers();
@@ -426,6 +428,7 @@ private:
     UBOBuilder uboBuilder;
     Profiler profiler;
     DebugLineSystem debugLineSystem;
+    ResizeCoordinator resizeCoordinator;
 #ifdef JPH_DEBUG_RENDERER
     std::unique_ptr<PhysicsDebugRenderer> physicsDebugRenderer;
 #endif

--- a/src/core/ResizeCoordinator.cpp
+++ b/src/core/ResizeCoordinator.cpp
@@ -1,0 +1,56 @@
+#include "ResizeCoordinator.h"
+#include <SDL3/SDL_log.h>
+#include <algorithm>
+#include <memory>
+
+void ResizeCoordinator::registerResizable(IResizable* resizable, ResizePriority priority) {
+    registrations_.push_back({resizable, priority});
+    sorted_ = false;
+}
+
+void ResizeCoordinator::registerCallback(const char* name, ResizeCallback resizeCb, ExtentCallback extentCb, ResizePriority priority) {
+    auto callback = std::make_unique<CallbackResizable>(name, std::move(resizeCb), std::move(extentCb));
+    registerResizable(callback.get(), priority);
+    adapters_.push_back(std::move(callback));
+}
+
+void ResizeCoordinator::ensureSorted() {
+    if (sorted_) return;
+
+    std::stable_sort(registrations_.begin(), registrations_.end(),
+        [](const Registration& a, const Registration& b) {
+            return static_cast<int>(a.priority) < static_cast<int>(b.priority);
+        });
+    sorted_ = true;
+}
+
+bool ResizeCoordinator::performResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent) {
+    ensureSorted();
+
+    SDL_Log("ResizeCoordinator: Resizing %zu systems to %ux%u",
+            registrations_.size(), newExtent.width, newExtent.height);
+
+    for (const auto& reg : registrations_) {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "  Resizing: %s", reg.resizable->getResizableName());
+        reg.resizable->onResize(device, allocator, newExtent);
+    }
+
+    // Also update extents
+    updateExtent(newExtent);
+
+    return true;
+}
+
+void ResizeCoordinator::updateExtent(VkExtent2D newExtent) {
+    ensureSorted();
+
+    for (const auto& reg : registrations_) {
+        reg.resizable->onExtentChanged(newExtent);
+    }
+}
+
+void ResizeCoordinator::clear() {
+    registrations_.clear();
+    adapters_.clear();
+    sorted_ = false;
+}

--- a/src/core/ResizeCoordinator.h
+++ b/src/core/ResizeCoordinator.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <vector>
+#include <functional>
+#include <string>
+#include <memory>
+
+// Interface for components that need to respond to window resize
+// There are two levels of resize handling:
+// 1. Full resize - reallocates GPU resources (render targets, buffers)
+// 2. Extent update - just updates viewport/scissor dimensions
+class IResizable {
+public:
+    virtual ~IResizable() = default;
+
+    // Called when window is resized - reallocate resources if needed
+    // Default implementation does nothing (for extent-only systems)
+    virtual void onResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent) {
+        (void)device;
+        (void)allocator;
+        (void)newExtent;
+    }
+
+    // Called after resize to update viewport/scissor dimensions
+    virtual void onExtentChanged(VkExtent2D newExtent) = 0;
+
+    // Name for debugging/logging purposes
+    virtual const char* getResizableName() const = 0;
+};
+
+// Adapter to wrap existing systems with resize() method
+template<typename T>
+class ResizeAdapter : public IResizable {
+public:
+    ResizeAdapter(T& system, const char* name) : system_(system), name_(name) {}
+
+    void onResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent) override {
+        system_.resize(device, allocator, newExtent);
+    }
+
+    void onExtentChanged(VkExtent2D newExtent) override {
+        // Systems with resize() typically don't need separate extent update
+        (void)newExtent;
+    }
+
+    const char* getResizableName() const override { return name_; }
+
+private:
+    T& system_;
+    const char* name_;
+};
+
+// Adapter for systems with resize(extent) method (no device/allocator needed)
+template<typename T>
+class SimpleResizeAdapter : public IResizable {
+public:
+    SimpleResizeAdapter(T& system, const char* name) : system_(system), name_(name) {}
+
+    void onResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent) override {
+        (void)device;
+        (void)allocator;
+        system_.resize(newExtent);
+    }
+
+    void onExtentChanged(VkExtent2D newExtent) override {
+        (void)newExtent;  // resize() already handles everything
+    }
+
+    const char* getResizableName() const override { return name_; }
+
+private:
+    T& system_;
+    const char* name_;
+};
+
+// Adapter for systems that only need extent updates via setExtent()
+template<typename T>
+class ExtentAdapter : public IResizable {
+public:
+    ExtentAdapter(T& system, const char* name) : system_(system), name_(name) {}
+
+    void onExtentChanged(VkExtent2D newExtent) override {
+        system_.setExtent(newExtent);
+    }
+
+    const char* getResizableName() const override { return name_; }
+
+private:
+    T& system_;
+    const char* name_;
+};
+
+// Adapter for systems with updateExtent() method
+template<typename T>
+class UpdateExtentAdapter : public IResizable {
+public:
+    UpdateExtentAdapter(T& system, const char* name) : system_(system), name_(name) {}
+
+    void onExtentChanged(VkExtent2D newExtent) override {
+        system_.updateExtent(newExtent);
+    }
+
+    const char* getResizableName() const override { return name_; }
+
+private:
+    T& system_;
+    const char* name_;
+};
+
+// Resize priority levels - determines order of resize operations
+enum class ResizePriority {
+    Core = 0,       // Swapchain, depth buffer, framebuffers
+    RenderTarget,   // Post-process, bloom, HDR targets
+    Culling,        // Hi-Z, water tile cull
+    GBuffer,        // G-buffer systems
+    Viewport        // Systems that just need extent updates
+};
+
+// Coordinates window resize across all rendering subsystems
+// Ensures proper ordering and simplifies Renderer code
+class ResizeCoordinator {
+public:
+    ResizeCoordinator() = default;
+    ~ResizeCoordinator() = default;
+
+    // Non-copyable, non-movable (owns adapters)
+    ResizeCoordinator(const ResizeCoordinator&) = delete;
+    ResizeCoordinator& operator=(const ResizeCoordinator&) = delete;
+
+    // Register a resizable component with given priority
+    void registerResizable(IResizable* resizable, ResizePriority priority);
+
+    // Register using adapter (takes ownership of adapter)
+    template<typename T>
+    void registerWithResize(T& system, const char* name, ResizePriority priority) {
+        auto adapter = std::make_unique<ResizeAdapter<T>>(system, name);
+        registerResizable(adapter.get(), priority);
+        adapters_.push_back(std::move(adapter));
+    }
+
+    template<typename T>
+    void registerWithExtent(T& system, const char* name, ResizePriority priority = ResizePriority::Viewport) {
+        auto adapter = std::make_unique<ExtentAdapter<T>>(system, name);
+        registerResizable(adapter.get(), priority);
+        adapters_.push_back(std::move(adapter));
+    }
+
+    // Register systems with resize(extent) signature (no device/allocator)
+    template<typename T>
+    void registerWithSimpleResize(T& system, const char* name, ResizePriority priority) {
+        auto adapter = std::make_unique<SimpleResizeAdapter<T>>(system, name);
+        registerResizable(adapter.get(), priority);
+        adapters_.push_back(std::move(adapter));
+    }
+
+    // Register systems with updateExtent(extent) method
+    template<typename T>
+    void registerWithUpdateExtent(T& system, const char* name, ResizePriority priority = ResizePriority::Viewport) {
+        auto adapter = std::make_unique<UpdateExtentAdapter<T>>(system, name);
+        registerResizable(adapter.get(), priority);
+        adapters_.push_back(std::move(adapter));
+    }
+
+    // Register a custom resize callback for systems with non-standard interfaces
+    using ResizeCallback = std::function<void(VkDevice, VmaAllocator, VkExtent2D)>;
+    using ExtentCallback = std::function<void(VkExtent2D)>;
+    void registerCallback(const char* name, ResizeCallback resizeCb, ExtentCallback extentCb, ResizePriority priority);
+
+    // Perform resize on all registered components
+    // Returns false if any component fails to resize
+    bool performResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent);
+
+    // Update extent only (no resource reallocation)
+    void updateExtent(VkExtent2D newExtent);
+
+    // Clear all registrations
+    void clear();
+
+private:
+    struct Registration {
+        IResizable* resizable;
+        ResizePriority priority;
+    };
+
+    // Callback-based resizable for custom handlers
+    class CallbackResizable : public IResizable {
+    public:
+        CallbackResizable(const char* name, ResizeCallback resizeCb, ExtentCallback extentCb)
+            : name_(name), resizeCb_(std::move(resizeCb)), extentCb_(std::move(extentCb)) {}
+
+        void onResize(VkDevice device, VmaAllocator allocator, VkExtent2D newExtent) override {
+            if (resizeCb_) resizeCb_(device, allocator, newExtent);
+        }
+
+        void onExtentChanged(VkExtent2D newExtent) override {
+            if (extentCb_) extentCb_(newExtent);
+        }
+
+        const char* getResizableName() const override { return name_; }
+
+    private:
+        const char* name_;
+        ResizeCallback resizeCb_;
+        ExtentCallback extentCb_;
+    };
+
+    std::vector<Registration> registrations_;
+    std::vector<std::unique_ptr<IResizable>> adapters_;  // Owns adapter instances
+    bool sorted_ = false;
+
+    void ensureSorted();
+};


### PR DESCRIPTION
- Create IResizable interface with onResize() and onExtentChanged() methods
- Add adapter templates for different resize patterns (resize with device/allocator, simple resize with extent only, setExtent, updateExtent)
- Implement ResizeCoordinator with priority-based ordering of resize operations
- Register all rendering subsystems with the coordinator in Renderer::init()
- Refactor handleResize() to use ResizeCoordinator for subsystem resize
- Extract recreateDepthResources() helper for cleaner code organization