### PR TITLE
Fix terrain altitude scaling throughout codebase

### DIFF
--- a/shaders/terrain/terrain.vert
+++ b/shaders/terrain/terrain.vert
@@ -88,16 +88,18 @@ int findTileForWorldPos(vec2 worldXZ) {
 }
 
 // Sample height with LOD tile support
+// Uses terrainHeightToWorld() for tile arrays, sampleTerrainHeight() for global fallback
 float sampleHeightLOD(vec2 uv, vec2 worldXZ) {
     int tileIdx = findTileForWorldPos(worldXZ);
     if (tileIdx >= 0) {
         // High-res tile available - calculate local UV within tile
         vec4 bounds = tiles[tileIdx].worldBounds;
         vec2 tileUV = (worldXZ - bounds.xy) / (bounds.zw - bounds.xy);
-        return texture(heightMapTiles, vec3(tileUV, float(tileIdx))).r * HEIGHT_SCALE;
+        float h = texture(heightMapTiles, vec3(tileUV, float(tileIdx))).r;
+        return terrainHeightToWorld(h, HEIGHT_SCALE);
     }
-    // Fall back to global coarse texture
-    return texture(heightMapGlobal, uv).r * HEIGHT_SCALE;
+    // Fall back to global coarse texture (uses sampleTerrainHeight from terrain_height_common.glsl)
+    return sampleTerrainHeight(heightMapGlobal, uv, HEIGHT_SCALE);
 }
 
 // Calculate normal from height map gradient with LOD support

--- a/shaders/terrain/terrain_shadow.vert
+++ b/shaders/terrain/terrain_shadow.vert
@@ -59,16 +59,18 @@ int findTileForWorldPos(vec2 worldXZ) {
 }
 
 // Sample height with LOD tile support
+// Uses terrainHeightToWorld() for tile arrays, sampleTerrainHeight() for global fallback
 float sampleHeightLOD(vec2 uv, vec2 worldXZ) {
     int tileIdx = findTileForWorldPos(worldXZ);
     if (tileIdx >= 0) {
         // High-res tile available - calculate local UV within tile
         vec4 bounds = tiles[tileIdx].worldBounds;
         vec2 tileUV = (worldXZ - bounds.xy) / (bounds.zw - bounds.xy);
-        return texture(heightMapTiles, vec3(tileUV, float(tileIdx))).r * heightScale;
+        float h = texture(heightMapTiles, vec3(tileUV, float(tileIdx))).r;
+        return terrainHeightToWorld(h, heightScale);
     }
-    // Fall back to global coarse texture
-    return texture(heightMapGlobal, uv).r * heightScale;
+    // Fall back to global coarse texture (uses sampleTerrainHeight from terrain_height_common.glsl)
+    return sampleTerrainHeight(heightMapGlobal, uv, heightScale);
 }
 
 void main() {

--- a/src/terrain/TerrainTileCache.cpp
+++ b/src/terrain/TerrainTileCache.cpp
@@ -1,4 +1,5 @@
 #include "TerrainTileCache.h"
+#include "TerrainHeight.h"
 #include "VulkanBarriers.h"
 #include <SDL3/SDL.h>
 #include <stb_image.h>
@@ -651,9 +652,8 @@ bool TerrainTileCache::getHeightAt(float worldX, float worldZ, float& outHeight)
         float h1 = h01 * (1.0f - tx) + h11 * tx;
         float h = h0 * (1.0f - ty) + h1 * ty;
 
-        // Convert to world height using standard formula: h * heightScale
-        // See TerrainHeight.h for authoritative formula
-        outHeight = h * heightScale;
+        // Convert to world height using authoritative formula from TerrainHeight.h
+        outHeight = TerrainHeight::toWorld(h, heightScale);
         return true;
     };
 


### PR DESCRIPTION
- TerrainTileCache::getHeightAt() now uses TerrainHeight::toWorld() instead of duplicating the height formula
- terrain.vert sampleHeightLOD() uses terrainHeightToWorld() for tile arrays and sampleTerrainHeight() for global fallback
- terrain_shadow.vert sampleHeightLOD() updated similarly

This improves consistency with the authoritative height formula defined in TerrainHeight.h (C++) and terrain_height_common.glsl (GLSL).