### PR TITLE
Deprecate redundant BindingBuilder class

### DIFF
--- a/src/atmosphere/AtmosphereLUTDescriptors.cpp
+++ b/src/atmosphere/AtmosphereLUTDescriptors.cpp
@@ -1,24 +1,23 @@
 #include "AtmosphereLUTSystem.h"
-#include "BindingBuilder.h"
 #include <SDL3/SDL_log.h>
 #include <array>
 
 bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
+    auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        return b;
+    };
+
     // Transmittance LUT descriptor set layout (just output image and uniform buffer)
     {
-        auto outputImage = BindingBuilder()
-            .setBinding(0)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto uniformBuffer = BindingBuilder()
-            .setBinding(1)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {outputImage, uniformBuffer};
+        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {
+            makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        };
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -43,25 +42,11 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Multi-scatter LUT descriptor set layout (transmittance input, output image, uniform buffer)
     {
-        auto outputImage = BindingBuilder()
-            .setBinding(0)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto transmittanceInput = BindingBuilder()
-            .setBinding(1)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto uniformBuffer = BindingBuilder()
-            .setBinding(2)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        std::array<VkDescriptorSetLayoutBinding, 3> bindings = {outputImage, transmittanceInput, uniformBuffer};
+        std::array<VkDescriptorSetLayoutBinding, 3> bindings = {
+            makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+            makeComputeBinding(2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        };
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -86,31 +71,12 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Sky-view LUT descriptor set layout (transmittance + multiscatter inputs, output image, uniform buffer)
     {
-        auto outputImage = BindingBuilder()
-            .setBinding(0)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto transmittanceInput = BindingBuilder()
-            .setBinding(1)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto multiScatterInput = BindingBuilder()
-            .setBinding(2)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto uniformBuffer = BindingBuilder()
-            .setBinding(3)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {outputImage, transmittanceInput, multiScatterInput, uniformBuffer};
+        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {
+            makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+            makeComputeBinding(2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+            makeComputeBinding(3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        };
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -136,31 +102,12 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
     // Irradiance LUT descriptor set layout (Phase 4.1.9)
     // Two output images (Rayleigh and Mie), transmittance input, uniform buffer
     {
-        auto rayleighOutput = BindingBuilder()
-            .setBinding(0)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto mieOutput = BindingBuilder()
-            .setBinding(1)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto transmittanceInput = BindingBuilder()
-            .setBinding(2)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto uniformBuffer = BindingBuilder()
-            .setBinding(3)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {rayleighOutput, mieOutput, transmittanceInput, uniformBuffer};
+        std::array<VkDescriptorSetLayoutBinding, 4> bindings = {
+            makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+            makeComputeBinding(3, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        };
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -185,19 +132,10 @@ bool AtmosphereLUTSystem::createDescriptorSetLayouts() {
 
     // Cloud Map LUT descriptor set layout (output image, uniform buffer)
     {
-        auto outputImage = BindingBuilder()
-            .setBinding(0)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        auto uniformBuffer = BindingBuilder()
-            .setBinding(1)
-            .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
-
-        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {outputImage, uniformBuffer};
+        std::array<VkDescriptorSetLayoutBinding, 2> bindings = {
+            makeComputeBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE),
+            makeComputeBinding(1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
+        };
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/atmosphere/CloudShadowSystem.cpp
+++ b/src/atmosphere/CloudShadowSystem.cpp
@@ -1,6 +1,5 @@
 #include "CloudShadowSystem.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include "VulkanBarriers.h"
 #include <SDL3/SDL_log.h>
 #include <glm/gtc/matrix_transform.hpp>

--- a/src/atmosphere/SkySystem.cpp
+++ b/src/atmosphere/SkySystem.cpp
@@ -1,7 +1,6 @@
 #include "SkySystem.h"
 #include "AtmosphereLUTSystem.h"
 #include "GraphicsPipelineFactory.h"
-#include "BindingBuilder.h"
 #include "UBOs.h"
 #include <SDL3/SDL.h>
 #include <array>
@@ -61,51 +60,26 @@ bool SkySystem::createDescriptorSetLayout() {
     // 5: Mie Irradiance LUT sampler (Phase 4.1.9)
     // 6: Cloud Map LUT sampler (Paraboloid projection, updated per-frame)
 
-    auto uboBinding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-        .setStageFlags(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
+    auto makeBinding = [](uint32_t binding, VkDescriptorType type, VkShaderStageFlags stages) {
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = stages;
+        return b;
+    };
 
-    auto transmittanceLUTBinding = BindingBuilder()
-        .setBinding(1)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto multiScatterLUTBinding = BindingBuilder()
-        .setBinding(2)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto skyViewLUTBinding = BindingBuilder()
-        .setBinding(3)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto rayleighIrradianceLUTBinding = BindingBuilder()
-        .setBinding(4)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto mieIrradianceLUTBinding = BindingBuilder()
-        .setBinding(5)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
-
-    auto cloudMapLUTBinding = BindingBuilder()
-        .setBinding(6)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
+    constexpr auto VF = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    constexpr auto F = VK_SHADER_STAGE_FRAGMENT_BIT;
 
     std::array<VkDescriptorSetLayoutBinding, 7> bindings = {
-        uboBinding, transmittanceLUTBinding, multiScatterLUTBinding, skyViewLUTBinding,
-        rayleighIrradianceLUTBinding, mieIrradianceLUTBinding, cloudMapLUTBinding
+        makeBinding(0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VF),
+        makeBinding(1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F),
+        makeBinding(2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F),
+        makeBinding(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F),
+        makeBinding(4, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F),
+        makeBinding(5, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F),
+        makeBinding(6, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, F)
     };
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};

--- a/src/core/BindingBuilder.h
+++ b/src/core/BindingBuilder.h
@@ -2,7 +2,16 @@
 
 #include <vulkan/vulkan.h>
 
-class BindingBuilder {
+// DEPRECATED: Use direct VkDescriptorSetLayoutBinding initialization instead.
+// Example:
+//   VkDescriptorSetLayoutBinding binding{};
+//   binding.binding = 0;
+//   binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+//   binding.descriptorCount = 1;
+//   binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+//
+// This class will be removed in a future version.
+class [[deprecated("Use direct VkDescriptorSetLayoutBinding initialization")]] BindingBuilder {
 public:
     BindingBuilder();
 

--- a/src/core/PipelineBuilder.cpp
+++ b/src/core/PipelineBuilder.cpp
@@ -1,6 +1,5 @@
 #include "PipelineBuilder.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include <SDL3/SDL.h>
 #include <glm/glm.hpp>
 #include <array>
@@ -19,13 +18,12 @@ PipelineBuilder& PipelineBuilder::reset() {
 
 PipelineBuilder& PipelineBuilder::addDescriptorBinding(uint32_t binding, VkDescriptorType type, uint32_t count,
                                                        VkShaderStageFlags stageFlags, const VkSampler* immutableSamplers) {
-    VkDescriptorSetLayoutBinding layoutBinding = BindingBuilder()
-                                                     .setBinding(binding)
-                                                     .setDescriptorType(type)
-                                                     .setDescriptorCount(count)
-                                                     .setStageFlags(stageFlags)
-                                                     .setImmutableSamplers(immutableSamplers)
-                                                     .build();
+    VkDescriptorSetLayoutBinding layoutBinding{};
+    layoutBinding.binding = binding;
+    layoutBinding.descriptorType = type;
+    layoutBinding.descriptorCount = count;
+    layoutBinding.stageFlags = stageFlags;
+    layoutBinding.pImmutableSamplers = immutableSamplers;
     descriptorBindings.push_back(layoutBinding);
     return *this;
 }

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -2,7 +2,6 @@
 #include "Renderer.h"
 #include "RendererInit.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include "GraphicsPipelineFactory.h"
 #include "MaterialDescriptorFactory.h"
 #include "VulkanResourceFactory.h"

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -1,6 +1,5 @@
 #include "FroxelSystem.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include "VulkanBarriers.h"
 #include <SDL3/SDL_log.h>
 #include <glm/gtc/matrix_transform.hpp>
@@ -229,11 +228,12 @@ bool FroxelSystem::createSampler() {
 
 bool FroxelSystem::createDescriptorSetLayout() {
     auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
-        return BindingBuilder()
-            .setBinding(binding)
-            .setDescriptorType(type)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        return b;
     };
 
     std::array<VkDescriptorSetLayoutBinding, 6> bindings = {

--- a/src/postprocess/BloomSystem.cpp
+++ b/src/postprocess/BloomSystem.cpp
@@ -1,6 +1,5 @@
 #include "BloomSystem.h"
 #include "GraphicsPipelineFactory.h"
-#include "BindingBuilder.h"
 #include "VulkanBarriers.h"
 #include <array>
 #include <algorithm>
@@ -246,11 +245,11 @@ bool BloomSystem::createSampler() {
 bool BloomSystem::createDescriptorSetLayouts() {
     // Both downsample and upsample use the same descriptor set layout
     // Binding 0: input texture (sampler2D)
-    auto binding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
-        .build();
+    VkDescriptorSetLayoutBinding binding{};
+    binding.binding = 0;
+    binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    binding.descriptorCount = 1;
+    binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
     VkDescriptorSetLayoutCreateInfo layoutInfo = {};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/postprocess/SSRSystem.cpp
+++ b/src/postprocess/SSRSystem.cpp
@@ -1,6 +1,5 @@
 #include "SSRSystem.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include "VulkanBarriers.h"
 #include "VulkanRAII.h"
 #include <SDL3/SDL.h>
@@ -266,33 +265,26 @@ bool SSRSystem::createComputePipeline() {
     // 2: SSR output (storage image, write)
     // 3: Previous SSR (sampler2D, for temporal)
 
-    auto colorBinding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    std::array<VkDescriptorSetLayoutBinding, 4> bindings{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    auto depthBinding = BindingBuilder()
-        .setBinding(1)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    auto outputBinding = BindingBuilder()
-        .setBinding(2)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    bindings[2].binding = 2;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    bindings[2].descriptorCount = 1;
+    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    auto prevBinding = BindingBuilder()
-        .setBinding(3)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
-
-    std::array<VkDescriptorSetLayoutBinding, 4> bindings = {
-        colorBinding, depthBinding, outputBinding, prevBinding
-    };
+    bindings[3].binding = 3;
+    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[3].descriptorCount = 1;
+    bindings[3].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -360,27 +352,21 @@ bool SSRSystem::createBlurPipeline() {
     // 1: Depth buffer (sampler2D) for bilateral weights
     // 2: Blurred output (storage image, write)
 
-    auto ssrInputBinding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    std::array<VkDescriptorSetLayoutBinding, 3> bindings{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    auto depthBinding = BindingBuilder()
-        .setBinding(1)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
-    auto outputBinding = BindingBuilder()
-        .setBinding(2)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
-
-    std::array<VkDescriptorSetLayoutBinding, 3> bindings = {
-        ssrInputBinding, depthBinding, outputBinding
-    };
+    bindings[2].binding = 2;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    bindings[2].descriptorCount = 1;
+    bindings[2].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -1,7 +1,6 @@
 #include "TerrainSystem.h"
 #include "TerrainBuffers.h"
 #include "TerrainCameraOptimizer.h"
-#include "BindingBuilder.h"
 #include "DescriptorManager.h"
 #include "GpuProfiler.h"
 #include "UBOs.h"
@@ -211,11 +210,12 @@ uint32_t TerrainSystem::getTriangleCount() const {
 
 bool TerrainSystem::createComputeDescriptorSetLayout() {
     auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
-        return BindingBuilder()
-            .setBinding(binding)
-            .setDescriptorType(type)
-            .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-            .build();
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        return b;
     };
 
     std::array<VkDescriptorSetLayoutBinding, 9> bindings = {
@@ -243,11 +243,12 @@ bool TerrainSystem::createComputeDescriptorSetLayout() {
 
 bool TerrainSystem::createRenderDescriptorSetLayout() {
     auto makeGraphicsBinding = [](uint32_t binding, VkDescriptorType type, VkShaderStageFlags stageFlags) {
-        return BindingBuilder()
-            .setBinding(binding)
-            .setDescriptorType(type)
-            .setStageFlags(stageFlags)
-            .build();
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = stageFlags;
+        return b;
     };
 
     std::array<VkDescriptorSetLayoutBinding, 18> bindings = {

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -1,6 +1,5 @@
 #include "WaterTileCull.h"
 #include "ShaderLoader.h"
-#include "BindingBuilder.h"
 #include "VulkanBarriers.h"
 #include <SDL3/SDL.h>
 #include <array>
@@ -214,32 +213,20 @@ bool WaterTileCull::createComputePipeline() {
     // 2: Counter buffer (storage)
     // 3: Indirect draw buffer (storage)
 
-    auto depthBinding = BindingBuilder()
-        .setBinding(0)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
-
-    auto tileBinding = BindingBuilder()
-        .setBinding(1)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
-
-    auto counterBinding = BindingBuilder()
-        .setBinding(2)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
-
-    auto indirectBinding = BindingBuilder()
-        .setBinding(3)
-        .setDescriptorType(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
-        .setStageFlags(VK_SHADER_STAGE_COMPUTE_BIT)
-        .build();
+    auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
+        VkDescriptorSetLayoutBinding b{};
+        b.binding = binding;
+        b.descriptorType = type;
+        b.descriptorCount = 1;
+        b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        return b;
+    };
 
     std::array<VkDescriptorSetLayoutBinding, 4> bindings = {
-        depthBinding, tileBinding, counterBinding, indirectBinding
+        makeComputeBinding(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
+        makeComputeBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+        makeComputeBinding(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
+        makeComputeBinding(3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
     };
 
     VkDescriptorSetLayoutCreateInfo layoutInfo{};


### PR DESCRIPTION
Mark BindingBuilder class as [[deprecated]] and update all usages across the codebase to use direct VkDescriptorSetLayoutBinding initialization or local helper lambdas. This removes the unnecessary abstraction layer while making the code more explicit.

- Add deprecation notice and attribute to BindingBuilder class
- Update 12 files to use direct struct initialization
- Remove unused BindingBuilder.h includes from 2 files
- Net reduction of ~229 lines of code