### PR TITLE
Migrate OceanFFT to VulkanRAII

### DIFF
--- a/src/core/VulkanRAII.h
+++ b/src/core/VulkanRAII.h
@@ -642,6 +642,14 @@ public:
         return true;
     }
 
+    // Adopt an existing raw descriptor set layout (e.g., created by DescriptorManager)
+    static ManagedDescriptorSetLayout fromRaw(VkDevice device, VkDescriptorSetLayout layout) {
+        ManagedDescriptorSetLayout result;
+        result.device_ = device;
+        result.layout_ = layout;
+        return result;
+    }
+
     void destroy() {
         if (layout_ != VK_NULL_HANDLE && device_ != VK_NULL_HANDLE) {
             vkDestroyDescriptorSetLayout(device_, layout_, nullptr);


### PR DESCRIPTION
Migrate OceanFFT to use VulkanRAII.h wrappers for automatic resource management:

- Use ManagedImage/ManagedImageView for all cascade images
- Use ManagedPipeline/ManagedPipelineLayout/ManagedDescriptorSetLayout for compute pipelines
- Use ManagedBuffer for spectrum UBOs
- Use ManagedSampler for the output texture sampler

Add fromRaw() factory method to ManagedDescriptorSetLayout for adopting existing layouts created by DescriptorManager.

Simplify destroy() method - RAII handles cleanup when vectors are cleared. Remove destroyCascade() helper that is no longer needed.