### PR TITLE
Migrate cloud and sky systems to RAII helpers

### DIFF
--- a/src/atmosphere/CloudShadowSystem.h
+++ b/src/atmosphere/CloudShadowSystem.h
@@ -7,6 +7,7 @@
 #include <string>
 #include "DescriptorManager.h"
 #include "InitContext.h"
+#include "core/VulkanRAII.h"
 
 // Cloud Shadow System
 // Generates a world-space cloud shadow map by ray-marching through the cloud layer
@@ -112,10 +113,10 @@ private:
     VkImageView shadowMapView = VK_NULL_HANDLE;
     VkSampler shadowMapSampler = VK_NULL_HANDLE;
 
-    // Compute pipeline
-    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
-    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-    VkPipeline computePipeline = VK_NULL_HANDLE;
+    // Compute pipeline (RAII-managed)
+    ManagedDescriptorSetLayout descriptorSetLayout;
+    ManagedPipelineLayout pipelineLayout;
+    ManagedPipeline computePipeline;
     std::vector<VkDescriptorSet> descriptorSets;
 
     // Uniform buffers (per frame)

--- a/src/atmosphere/SkySystem.h
+++ b/src/atmosphere/SkySystem.h
@@ -6,6 +6,7 @@
 #include <string>
 #include "DescriptorManager.h"
 #include "InitContext.h"
+#include "core/VulkanRAII.h"
 
 class AtmosphereLUTSystem;
 
@@ -51,7 +52,7 @@ private:
     VkRenderPass hdrRenderPass = VK_NULL_HANDLE;
 
     VkPipeline pipeline = VK_NULL_HANDLE;
-    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    ManagedPipelineLayout pipelineLayout;
+    ManagedDescriptorSetLayout descriptorSetLayout;
     std::vector<VkDescriptorSet> descriptorSets;
 };


### PR DESCRIPTION
Migrate the following resources to use VulkanRAII wrappers:
- CloudShadowSystem: descriptor set layout, pipeline layout, compute pipeline
- SkySystem: descriptor set layout, pipeline layout

This improves resource management by using automatic cleanup on destruction.