### PR TITLE
Migrate SSR and HiZ systems to RAII helpers

### DIFF
--- a/src/postprocess/HiZSystem.h
+++ b/src/postprocess/HiZSystem.h
@@ -11,6 +11,7 @@
 #include "DescriptorManager.h"
 #include "InitContext.h"
 #include "Mesh.h"
+#include "core/VulkanRAII.h"
 
 // GPU-side object data for culling (matches shader struct)
 struct alignas(16) CullObjectData {
@@ -160,7 +161,7 @@ private:
     VmaAllocation hiZPyramidAllocation = VK_NULL_HANDLE;
     VkImageView hiZPyramidView = VK_NULL_HANDLE;         // View of all mip levels
     std::vector<VkImageView> hiZMipViews;                // Individual mip level views
-    VkSampler hiZSampler = VK_NULL_HANDLE;               // Sampler for Hi-Z reads
+    ManagedSampler hiZSampler;                           // Sampler for Hi-Z reads
     uint32_t mipLevelCount = 0;
 
     // Source depth buffer reference
@@ -168,15 +169,15 @@ private:
     VkSampler sourceDepthSampler = VK_NULL_HANDLE;
 
     // Pyramid generation pipeline
-    VkDescriptorSetLayout pyramidDescSetLayout = VK_NULL_HANDLE;
-    VkPipelineLayout pyramidPipelineLayout = VK_NULL_HANDLE;
-    VkPipeline pyramidPipeline = VK_NULL_HANDLE;
+    ManagedDescriptorSetLayout pyramidDescSetLayout;
+    ManagedPipelineLayout pyramidPipelineLayout;
+    ManagedPipeline pyramidPipeline;
     std::vector<VkDescriptorSet> pyramidDescSets;  // One per mip level
 
     // Culling pipeline
-    VkDescriptorSetLayout cullingDescSetLayout = VK_NULL_HANDLE;
-    VkPipelineLayout cullingPipelineLayout = VK_NULL_HANDLE;
-    VkPipeline cullingPipeline = VK_NULL_HANDLE;
+    ManagedDescriptorSetLayout cullingDescSetLayout;
+    ManagedPipelineLayout cullingPipelineLayout;
+    ManagedPipeline cullingPipeline;
     std::vector<VkDescriptorSet> cullingDescSets;  // Per frame
 
     // Object data buffer (input to culling)

--- a/src/postprocess/SSRSystem.h
+++ b/src/postprocess/SSRSystem.h
@@ -7,6 +7,7 @@
 #include <string>
 #include "InitContext.h"
 #include "DescriptorManager.h"
+#include "core/VulkanRAII.h"
 
 /**
  * SSRSystem - Phase 10: Screen-Space Reflections
@@ -86,7 +87,7 @@ public:
 
     // Get SSR result texture for sampling in water shader
     VkImageView getSSRResultView() const { return ssrResultView[currentBuffer]; }
-    VkSampler getSampler() const { return sampler; }
+    VkSampler getSampler() const { return sampler.get(); }
 
     // Configuration
     void setMaxDistance(float dist) { maxDistance = dist; }
@@ -144,19 +145,19 @@ private:
     int currentBuffer = 0;
 
     // Sampler
-    VkSampler sampler = VK_NULL_HANDLE;
+    ManagedSampler sampler;
 
     // Main SSR compute pipeline
-    VkPipeline computePipeline = VK_NULL_HANDLE;
-    VkPipelineLayout computePipelineLayout = VK_NULL_HANDLE;
-    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+    ManagedPipeline computePipeline;
+    ManagedPipelineLayout computePipelineLayout;
+    ManagedDescriptorSetLayout descriptorSetLayout;
     DescriptorManager::Pool* descriptorPool = nullptr;  // Shared auto-growing pool
     std::vector<VkDescriptorSet> descriptorSets;
 
     // Blur compute pipeline
-    VkPipeline blurPipeline = VK_NULL_HANDLE;
-    VkPipelineLayout blurPipelineLayout = VK_NULL_HANDLE;
-    VkDescriptorSetLayout blurDescriptorSetLayout = VK_NULL_HANDLE;
+    ManagedPipeline blurPipeline;
+    ManagedPipelineLayout blurPipelineLayout;
+    ManagedDescriptorSetLayout blurDescriptorSetLayout;
     std::vector<VkDescriptorSet> blurDescriptorSets;
 
     // Intermediate buffer for blur (SSR writes here, blur reads and writes to final)


### PR DESCRIPTION
Migrate pipelines, layouts, and samplers to use RAII wrappers from VulkanRAII.h for automatic resource management:

SSRSystem:
- sampler -> ManagedSampler
- computePipeline, blurPipeline -> ManagedPipeline
- computePipelineLayout, blurPipelineLayout -> ManagedPipelineLayout
- descriptorSetLayout, blurDescriptorSetLayout -> ManagedDescriptorSetLayout

HiZSystem:
- hiZSampler -> ManagedSampler
- pyramidPipeline, cullingPipeline -> ManagedPipeline
- pyramidPipelineLayout, cullingPipelineLayout -> ManagedPipelineLayout
- pyramidDescSetLayout, cullingDescSetLayout -> ManagedDescriptorSetLayout