### PR TITLE
Implement smart pointers for jolt integration

### DIFF
--- a/src/scene/Application.h
+++ b/src/scene/Application.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
+#include <optional>
 #include "Renderer.h"
 #include "Camera.h"
 #include "Player.h"
@@ -36,7 +37,10 @@ private:
     Renderer renderer;
     Camera camera;
     Player player;
-    PhysicsWorld physics;
+    std::optional<PhysicsWorld> physics_;
+
+    // Helper to access physics (assumes physics is initialized)
+    PhysicsWorld& physics() { return *physics_; }
 
     // Input system
     InputSystem input;


### PR DESCRIPTION
Implement RAII pattern for PhysicsWorld following the plan in docs/PLAN-eliminate-two-phase-init.md:

- Create JoltRuntime RAII wrapper that manages global Jolt state (RegisterDefaultAllocator, Factory singleton, RegisterTypes) with thread-safe reference counting via weak_ptr/shared_ptr

- Convert PhysicsWorld to factory pattern with std::optional<PhysicsWorld> create() static method instead of two-phase init()/shutdown()

- Add move constructor/assignment for PhysicsWorld (RAII handles)

- Remove all `if (!initialized)` guards from methods since the factory pattern guarantees valid state after successful creation

- Update Application to use std::optional<PhysicsWorld> member with physics() accessor method for dereferencing

This eliminates raw new/delete for JPH::Factory and ensures proper cleanup order via RAII destructors. Multiple PhysicsWorld instances can share the JoltRuntime through reference counting.