### PR TITLE
Make HDR rendering features toggleable

### DIFF
--- a/shaders/postprocess.frag
+++ b/shaders/postprocess.frag
@@ -31,8 +31,8 @@ layout(binding = BINDING_PP_UNIFORMS) uniform PostProcessUniforms {
     // Quality settings
     float godRaysEnabled;       // 1.0 = enabled, 0.0 = disabled
     float froxelFilterQuality;  // 0.0 = trilinear (fast), 1.0 = tricubic (quality)
-    float padding2;
-    float padding3;
+    float bloomEnabled;         // 1.0 = enabled, 0.0 = disabled
+    float autoExposureEnabled;  // 1.0 = auto, 0.0 = manual (UI display only)
 } ubo;
 
 // Specialization constant for god ray sample count
@@ -309,8 +309,11 @@ void main() {
     // Exposure is computed by histogram compute shaders and passed via uniform
     float finalExposure = ubo.exposure;
 
-    // Sample bloom from multi-pass bloom texture
-    vec3 bloom = texture(bloomTexture, fragTexCoord).rgb;
+    // Sample bloom from multi-pass bloom texture (only if enabled)
+    vec3 bloom = vec3(0.0);
+    if (ubo.bloomEnabled > 0.5) {
+        bloom = texture(bloomTexture, fragTexCoord).rgb;
+    }
 
     // Compute god rays (Phase 4.4)
     // Only compute if enabled and intensity > 0

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -974,7 +974,8 @@ bool Renderer::render(const Camera& camera) {
     if (renderPipeline.postStage.hiZRecordFn) {
         renderPipeline.postStage.hiZRecordFn(ctx);
     }
-    if (renderPipeline.postStage.bloomRecordFn) {
+    // Only run bloom passes if bloom is enabled (skip for performance)
+    if (systems_->postProcess().isBloomEnabled() && renderPipeline.postStage.bloomRecordFn) {
         renderPipeline.postStage.bloomRecordFn(ctx);
     }
 
@@ -1587,6 +1588,17 @@ int Renderer::getGodRayQuality() const {
 // Froxel volumetric fog quality control
 void Renderer::setFroxelFilterQuality(bool highQuality) { systems_->postProcess().setFroxelFilterQuality(highQuality); }
 bool Renderer::isFroxelFilterHighQuality() const { return systems_->postProcess().isFroxelFilterHighQuality(); }
+
+// Bloom control
+void Renderer::setBloomEnabled(bool enabled) { systems_->postProcess().setBloomEnabled(enabled); }
+bool Renderer::isBloomEnabled() const { return systems_->postProcess().isBloomEnabled(); }
+
+// Auto-exposure control
+void Renderer::setAutoExposureEnabled(bool enabled) { systems_->postProcess().setAutoExposure(enabled); }
+bool Renderer::isAutoExposureEnabled() const { return systems_->postProcess().isAutoExposureEnabled(); }
+void Renderer::setManualExposure(float ev) { systems_->postProcess().setExposure(ev); }
+float Renderer::getManualExposure() const { return systems_->postProcess().getExposure(); }
+float Renderer::getCurrentExposure() const { return systems_->postProcess().getCurrentExposure(); }
 
 // Terrain control
 void Renderer::toggleTerrainWireframe() { systems_->terrain().setWireframeMode(!systems_->terrain().isWireframeMode()); }

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -143,6 +143,18 @@ public:
     // HDR/Post-processing control
     void setHDREnabled(bool enabled) { hdrEnabled = enabled; }
     bool isHDREnabled() const { return hdrEnabled; }
+
+    // Bloom control
+    void setBloomEnabled(bool enabled);
+    bool isBloomEnabled() const;
+
+    // Auto-exposure control
+    void setAutoExposureEnabled(bool enabled);
+    bool isAutoExposureEnabled() const;
+    void setManualExposure(float ev);
+    float getManualExposure() const;
+    float getCurrentExposure() const;
+
     void setCloudShadowIntensity(float intensity);
     float getCloudShadowIntensity() const;
 

--- a/src/gui/GuiPostFXTab.cpp
+++ b/src/gui/GuiPostFXTab.cpp
@@ -53,7 +53,13 @@ void GuiPostFXTab::render(Renderer& renderer) {
     ImGui::Text("BLOOM");
     ImGui::PopStyleColor();
 
-    ImGui::TextDisabled("Bloom is enabled by default");
+    bool bloomEnabled = renderer.isBloomEnabled();
+    if (ImGui::Checkbox("Enable Bloom", &bloomEnabled)) {
+        renderer.setBloomEnabled(bloomEnabled);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Enable/disable bloom glow effect");
+    }
 
     ImGui::Spacing();
     ImGui::Separator();
@@ -107,6 +113,23 @@ void GuiPostFXTab::render(Renderer& renderer) {
     ImGui::Text("EXPOSURE");
     ImGui::PopStyleColor();
 
-    ImGui::TextDisabled("Auto-exposure is active");
-    ImGui::TextDisabled("Histogram-based adaptation");
+    bool autoExposure = renderer.isAutoExposureEnabled();
+    if (ImGui::Checkbox("Auto Exposure", &autoExposure)) {
+        renderer.setAutoExposureEnabled(autoExposure);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Enable/disable histogram-based auto-exposure");
+    }
+
+    if (autoExposure) {
+        ImGui::TextDisabled("Current: %.2f EV", renderer.getCurrentExposure());
+    } else {
+        float manualExposure = renderer.getManualExposure();
+        if (ImGui::SliderFloat("Manual Exposure", &manualExposure, -4.0f, 4.0f, "%.2f EV")) {
+            renderer.setManualExposure(manualExposure);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Manual exposure value in EV (-4 to +4)");
+        }
+    }
 }

--- a/src/postprocess/PostProcessSystem.cpp
+++ b/src/postprocess/PostProcessSystem.cpp
@@ -569,6 +569,8 @@ void PostProcessSystem::recordPostProcess(VkCommandBuffer cmd, uint32_t frameInd
     // Quality settings
     ubo->godRaysEnabled = godRaysEnabled ? 1.0f : 0.0f;
     ubo->froxelFilterQuality = froxelFilterHighQuality ? 1.0f : 0.0f;
+    ubo->bloomEnabled = bloomEnabled ? 1.0f : 0.0f;
+    ubo->autoExposureEnabled = autoExposureEnabled ? 1.0f : 0.0f;
 
     // Store computed exposure for next frame
     lastAutoExposure = autoExposureEnabled ? computedExposure : manualExposure;

--- a/src/postprocess/PostProcessSystem.h
+++ b/src/postprocess/PostProcessSystem.h
@@ -108,6 +108,8 @@ public:
 
     // Bloom (multi-pass)
     void setBloomTexture(VkImageView bloomView, VkSampler bloomSampler);
+    void setBloomEnabled(bool enabled) { bloomEnabled = enabled; }
+    bool isBloomEnabled() const { return bloomEnabled; }
     bool isFroxelEnabled() const { return froxelEnabled; }
 
     // HDR tonemapping bypass (for comparison/debugging)
@@ -207,6 +209,7 @@ private:
     VkSampler bloomSampler = VK_NULL_HANDLE;
     bool froxelEnabled = false;
     bool hdrEnabled = true;  // HDR tonemapping enabled by default
+    bool bloomEnabled = true;  // Bloom enabled by default
     float froxelFarPlane = 200.0f;
     float froxelDepthDist = 1.2f;
     float nearPlane = 0.1f;


### PR DESCRIPTION
- Add bloomEnabled toggle to PostProcessSystem with shader support
- Add auto-exposure toggle with manual exposure slider when disabled
- Skip bloom render passes entirely when disabled for performance
- Shader now skips bloom texture sampling when feature is off
- Add new uniforms (bloomEnabled, autoExposureEnabled) to PostProcessUniforms

These toggles allow users to disable expensive HDR features to improve performance, addressing bottlenecks in the HDR rendering pipeline.