### PR TITLE
Refactor factories to use optional results

### DIFF
--- a/src/atmosphere/AtmosphereLUTPipelines.cpp
+++ b/src/atmosphere/AtmosphereLUTPipelines.cpp
@@ -7,12 +7,16 @@ bool AtmosphereLUTSystem::createComputePipelines() {
     // Create transmittance pipeline
     {
         std::string shaderFile = shaderPath + "/transmittance_lut.comp.spv";
-        std::vector<char> shaderCode = ShaderLoader::readFile(shaderFile);
+        auto shaderCode = ShaderLoader::readFile(shaderFile);
+        if (!shaderCode) {
+            SDL_Log("Failed to read transmittance shader file");
+            return false;
+        }
 
         VkShaderModuleCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        createInfo.codeSize = shaderCode.size();
-        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode.data());
+        createInfo.codeSize = shaderCode->size();
+        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode->data());
 
         VkShaderModule shaderModule;
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
@@ -43,12 +47,16 @@ bool AtmosphereLUTSystem::createComputePipelines() {
     // Create multi-scatter pipeline
     {
         std::string shaderFile = shaderPath + "/multiscatter_lut.comp.spv";
-        std::vector<char> shaderCode = ShaderLoader::readFile(shaderFile);
+        auto shaderCode = ShaderLoader::readFile(shaderFile);
+        if (!shaderCode) {
+            SDL_Log("Failed to read multi-scatter shader file");
+            return false;
+        }
 
         VkShaderModuleCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        createInfo.codeSize = shaderCode.size();
-        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode.data());
+        createInfo.codeSize = shaderCode->size();
+        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode->data());
 
         VkShaderModule shaderModule;
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
@@ -79,12 +87,16 @@ bool AtmosphereLUTSystem::createComputePipelines() {
     // Create sky-view pipeline
     {
         std::string shaderFile = shaderPath + "/skyview_lut.comp.spv";
-        std::vector<char> shaderCode = ShaderLoader::readFile(shaderFile);
+        auto shaderCode = ShaderLoader::readFile(shaderFile);
+        if (!shaderCode) {
+            SDL_Log("Failed to read sky-view shader file");
+            return false;
+        }
 
         VkShaderModuleCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        createInfo.codeSize = shaderCode.size();
-        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode.data());
+        createInfo.codeSize = shaderCode->size();
+        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode->data());
 
         VkShaderModule shaderModule;
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
@@ -115,12 +127,16 @@ bool AtmosphereLUTSystem::createComputePipelines() {
     // Create irradiance pipeline
     {
         std::string shaderFile = shaderPath + "/irradiance_lut.comp.spv";
-        std::vector<char> shaderCode = ShaderLoader::readFile(shaderFile);
+        auto shaderCode = ShaderLoader::readFile(shaderFile);
+        if (!shaderCode) {
+            SDL_Log("Failed to read irradiance shader file");
+            return false;
+        }
 
         VkShaderModuleCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        createInfo.codeSize = shaderCode.size();
-        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode.data());
+        createInfo.codeSize = shaderCode->size();
+        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode->data());
 
         VkShaderModule shaderModule;
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
@@ -151,12 +167,16 @@ bool AtmosphereLUTSystem::createComputePipelines() {
     // Create cloud map pipeline
     {
         std::string shaderFile = shaderPath + "/cloudmap_lut.comp.spv";
-        std::vector<char> shaderCode = ShaderLoader::readFile(shaderFile);
+        auto shaderCode = ShaderLoader::readFile(shaderFile);
+        if (!shaderCode) {
+            SDL_Log("Failed to read cloud map shader file");
+            return false;
+        }
 
         VkShaderModuleCreateInfo createInfo{};
         createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-        createInfo.codeSize = shaderCode.size();
-        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode.data());
+        createInfo.codeSize = shaderCode->size();
+        createInfo.pCode = reinterpret_cast<const uint32_t*>(shaderCode->data());
 
         VkShaderModule shaderModule;
         if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {

--- a/src/atmosphere/CloudShadowSystem.cpp
+++ b/src/atmosphere/CloudShadowSystem.cpp
@@ -197,13 +197,13 @@ bool CloudShadowSystem::createDescriptorSets() {
 bool CloudShadowSystem::createComputePipeline() {
     // Load compute shader
     auto shaderCode = ShaderLoader::readFile(shaderPath + "/cloud_shadow.comp.spv");
-    if (shaderCode.empty()) {
+    if (!shaderCode) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load cloud shadow compute shader");
         return false;
     }
 
-    VkShaderModule shaderModule = ShaderLoader::createShaderModule(device, shaderCode);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::createShaderModule(device, *shaderCode);
+    if (!shaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create cloud shadow shader module");
         return false;
     }
@@ -211,11 +211,11 @@ bool CloudShadowSystem::createComputePipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     if (!DescriptorManager::createManagedPipelineLayout(device, descriptorSetLayout.get(), pipelineLayout)) {
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create cloud shadow pipeline layout");
         return false;
     }
@@ -226,12 +226,12 @@ bool CloudShadowSystem::createComputePipeline() {
     pipelineInfo.layout = pipelineLayout.get();
 
     if (!ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, computePipeline)) {
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create cloud shadow compute pipeline");
         return false;
     }
 
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
     return true;
 }
 

--- a/src/core/GraphicsPipelineFactory.cpp
+++ b/src/core/GraphicsPipelineFactory.cpp
@@ -289,34 +289,34 @@ bool GraphicsPipelineFactory::loadShaderModules(std::vector<VkPipelineShaderStag
     auto vertCode = ShaderLoader::readFile(vertShaderPath);
     auto fragCode = ShaderLoader::readFile(fragShaderPath);
 
-    if (vertCode.empty() || fragCode.empty()) {
+    if (!vertCode || !fragCode) {
         SDL_Log("GraphicsPipelineFactory: Failed to read shader files");
         return false;
     }
 
-    VkShaderModule vertModule = ShaderLoader::createShaderModule(device, vertCode);
-    VkShaderModule fragModule = ShaderLoader::createShaderModule(device, fragCode);
+    auto vertModule = ShaderLoader::createShaderModule(device, *vertCode);
+    auto fragModule = ShaderLoader::createShaderModule(device, *fragCode);
 
-    if (vertModule == VK_NULL_HANDLE || fragModule == VK_NULL_HANDLE) {
+    if (!vertModule || !fragModule) {
         SDL_Log("GraphicsPipelineFactory: Failed to create shader modules");
-        if (vertModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, vertModule, nullptr);
-        if (fragModule != VK_NULL_HANDLE) vkDestroyShaderModule(device, fragModule, nullptr);
+        if (vertModule) vkDestroyShaderModule(device, *vertModule, nullptr);
+        if (fragModule) vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
-    shaderModules.push_back(vertModule);
-    shaderModules.push_back(fragModule);
+    shaderModules.push_back(*vertModule);
+    shaderModules.push_back(*fragModule);
 
     VkPipelineShaderStageCreateInfo vertStage{};
     vertStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     vertStage.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    vertStage.module = vertModule;
+    vertStage.module = *vertModule;
     vertStage.pName = "main";
 
     VkPipelineShaderStageCreateInfo fragStage{};
     fragStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     fragStage.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    fragStage.module = fragModule;
+    fragStage.module = *fragModule;
     fragStage.pName = "main";
 
     stages.push_back(vertStage);

--- a/src/core/PipelineBuilder.cpp
+++ b/src/core/PipelineBuilder.cpp
@@ -52,8 +52,8 @@ PipelineBuilder& PipelineBuilder::addPushConstantRange(VkShaderStageFlags stageF
 }
 
 PipelineBuilder& PipelineBuilder::addShaderStage(const std::string& path, VkShaderStageFlagBits stage, const char* entry) {
-    VkShaderModule module = ShaderLoader::loadShaderModule(device, path);
-    if (module == VK_NULL_HANDLE) {
+    auto module = ShaderLoader::loadShaderModule(device, path);
+    if (!module) {
         SDL_Log("Failed to load shader module at %s", path.c_str());
         return *this;
     }
@@ -61,11 +61,11 @@ PipelineBuilder& PipelineBuilder::addShaderStage(const std::string& path, VkShad
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = stage;
-    stageInfo.module = module;
+    stageInfo.module = *module;
     stageInfo.pName = entry;
 
     shaderStages.push_back(stageInfo);
-    shaderModules.push_back(module);
+    shaderModules.push_back(*module);
     return *this;
 }
 

--- a/src/core/ShaderLoader.cpp
+++ b/src/core/ShaderLoader.cpp
@@ -4,12 +4,12 @@
 
 namespace ShaderLoader {
 
-std::vector<char> readFile(const std::string& filename) {
+std::optional<std::vector<char>> readFile(const std::string& filename) {
     std::ifstream file(filename, std::ios::ate | std::ios::binary);
 
     if (!file.is_open()) {
         SDL_Log("Failed to open file: %s", filename.c_str());
-        return {};
+        return std::nullopt;
     }
 
     size_t fileSize = static_cast<size_t>(file.tellg());
@@ -22,7 +22,7 @@ std::vector<char> readFile(const std::string& filename) {
     return buffer;
 }
 
-VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code) {
+std::optional<VkShaderModule> createShaderModule(VkDevice device, const std::vector<char>& code) {
     VkShaderModuleCreateInfo createInfo{};
     createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     createInfo.codeSize = code.size();
@@ -30,18 +30,18 @@ VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code
 
     VkShaderModule shaderModule;
     if (vkCreateShaderModule(device, &createInfo, nullptr, &shaderModule) != VK_SUCCESS) {
-        return VK_NULL_HANDLE;
+        return std::nullopt;
     }
 
     return shaderModule;
 }
 
-VkShaderModule loadShaderModule(VkDevice device, const std::string& path) {
+std::optional<VkShaderModule> loadShaderModule(VkDevice device, const std::string& path) {
     auto code = readFile(path);
-    if (code.empty()) {
-        return VK_NULL_HANDLE;
+    if (!code) {
+        return std::nullopt;
     }
-    return createShaderModule(device, code);
+    return createShaderModule(device, *code);
 }
 
 }

--- a/src/core/ShaderLoader.h
+++ b/src/core/ShaderLoader.h
@@ -3,11 +3,12 @@
 #include <vulkan/vulkan.h>
 #include <vector>
 #include <string>
+#include <optional>
 
 namespace ShaderLoader {
 
-std::vector<char> readFile(const std::string& filename);
-VkShaderModule createShaderModule(VkDevice device, const std::vector<char>& code);
-VkShaderModule loadShaderModule(VkDevice device, const std::string& path);
+std::optional<std::vector<char>> readFile(const std::string& filename);
+std::optional<VkShaderModule> createShaderModule(VkDevice device, const std::vector<char>& code);
+std::optional<VkShaderModule> loadShaderModule(VkDevice device, const std::string& path);
 
 }

--- a/src/debug/DebugLineSystem.cpp
+++ b/src/debug/DebugLineSystem.cpp
@@ -62,13 +62,13 @@ void DebugLineSystem::shutdown() {
 
 bool DebugLineSystem::createPipeline(VkRenderPass renderPass, const std::string& shaderPath) {
     // Load shaders
-    VkShaderModule vertShader = ShaderLoader::loadShaderModule(device, shaderPath + "/debug_line.vert.spv");
-    VkShaderModule fragShader = ShaderLoader::loadShaderModule(device, shaderPath + "/debug_line.frag.spv");
+    auto vertShader = ShaderLoader::loadShaderModule(device, shaderPath + "/debug_line.vert.spv");
+    auto fragShader = ShaderLoader::loadShaderModule(device, shaderPath + "/debug_line.frag.spv");
 
-    if (vertShader == VK_NULL_HANDLE || fragShader == VK_NULL_HANDLE) {
+    if (!vertShader || !fragShader) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DebugLineSystem: Failed to load shaders");
-        if (vertShader != VK_NULL_HANDLE) vkDestroyShaderModule(device, vertShader, nullptr);
-        if (fragShader != VK_NULL_HANDLE) vkDestroyShaderModule(device, fragShader, nullptr);
+        if (vertShader) vkDestroyShaderModule(device, *vertShader, nullptr);
+        if (fragShader) vkDestroyShaderModule(device, *fragShader, nullptr);
         return false;
     }
 
@@ -85,8 +85,8 @@ bool DebugLineSystem::createPipeline(VkRenderPass renderPass, const std::string&
 
     if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DebugLineSystem: Failed to create pipeline layout");
-        vkDestroyShaderModule(device, vertShader, nullptr);
-        vkDestroyShaderModule(device, fragShader, nullptr);
+        vkDestroyShaderModule(device, *vertShader, nullptr);
+        vkDestroyShaderModule(device, *fragShader, nullptr);
         return false;
     }
 
@@ -94,11 +94,11 @@ bool DebugLineSystem::createPipeline(VkRenderPass renderPass, const std::string&
     VkPipelineShaderStageCreateInfo shaderStages[2]{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = vertShader;
+    shaderStages[0].module = *vertShader;
     shaderStages[0].pName = "main";
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = fragShader;
+    shaderStages[1].module = *fragShader;
     shaderStages[1].pName = "main";
 
     // Vertex input
@@ -211,8 +211,8 @@ bool DebugLineSystem::createPipeline(VkRenderPass renderPass, const std::string&
 
     if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &linePipeline) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DebugLineSystem: Failed to create line pipeline");
-        vkDestroyShaderModule(device, vertShader, nullptr);
-        vkDestroyShaderModule(device, fragShader, nullptr);
+        vkDestroyShaderModule(device, *vertShader, nullptr);
+        vkDestroyShaderModule(device, *fragShader, nullptr);
         return false;
     }
 
@@ -222,13 +222,13 @@ bool DebugLineSystem::createPipeline(VkRenderPass renderPass, const std::string&
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DebugLineSystem: Failed to create triangle pipeline");
         vkDestroyPipeline(device, linePipeline, nullptr);
         linePipeline = VK_NULL_HANDLE;
-        vkDestroyShaderModule(device, vertShader, nullptr);
-        vkDestroyShaderModule(device, fragShader, nullptr);
+        vkDestroyShaderModule(device, *vertShader, nullptr);
+        vkDestroyShaderModule(device, *fragShader, nullptr);
         return false;
     }
 
-    vkDestroyShaderModule(device, vertShader, nullptr);
-    vkDestroyShaderModule(device, fragShader, nullptr);
+    vkDestroyShaderModule(device, *vertShader, nullptr);
+    vkDestroyShaderModule(device, *fragShader, nullptr);
 
     return true;
 }

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -276,13 +276,13 @@ bool FroxelSystem::createDescriptorSets() {
 bool FroxelSystem::createFroxelUpdatePipeline() {
     std::string shaderFile = shaderPath + "/froxel_update.comp.spv";
     auto shaderCode = ShaderLoader::readFile(shaderFile);
-    if (shaderCode.empty()) {
+    if (!shaderCode) {
         SDL_Log("Failed to load froxel update shader: %s", shaderFile.c_str());
         return false;
     }
 
-    VkShaderModule shaderModule = ShaderLoader::createShaderModule(device, shaderCode);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::createShaderModule(device, *shaderCode);
+    if (!shaderModule) {
         SDL_Log("Failed to create froxel update shader module");
         return false;
     }
@@ -290,7 +290,7 @@ bool FroxelSystem::createFroxelUpdatePipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -299,7 +299,7 @@ bool FroxelSystem::createFroxelUpdatePipeline() {
     pipelineInfo.layout = froxelPipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, froxelUpdatePipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_Log("Failed to create froxel update pipeline");
@@ -312,13 +312,13 @@ bool FroxelSystem::createFroxelUpdatePipeline() {
 bool FroxelSystem::createIntegrationPipeline() {
     std::string shaderFile = shaderPath + "/froxel_integrate.comp.spv";
     auto shaderCode = ShaderLoader::readFile(shaderFile);
-    if (shaderCode.empty()) {
+    if (!shaderCode) {
         SDL_Log("Failed to load froxel integration shader: %s", shaderFile.c_str());
         return false;
     }
 
-    VkShaderModule shaderModule = ShaderLoader::createShaderModule(device, shaderCode);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::createShaderModule(device, *shaderCode);
+    if (!shaderModule) {
         SDL_Log("Failed to create froxel integration shader module");
         return false;
     }
@@ -326,7 +326,7 @@ bool FroxelSystem::createIntegrationPipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -335,7 +335,7 @@ bool FroxelSystem::createIntegrationPipeline() {
     pipelineInfo.layout = froxelPipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, integrationPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_Log("Failed to create froxel integration pipeline");

--- a/src/postprocess/HiZSystem.cpp
+++ b/src/postprocess/HiZSystem.cpp
@@ -236,9 +236,9 @@ bool HiZSystem::createPyramidPipeline() {
     }
 
     // Load compute shader
-    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(
+    auto shaderModule = ShaderLoader::loadShaderModule(
         device, shaderPath + "/hiz_downsample.comp.spv");
-    if (shaderModule == VK_NULL_HANDLE) {
+    if (!shaderModule) {
         SDL_Log("HiZSystem: Failed to load hiz_downsample.comp.spv");
         return false;
     }
@@ -246,7 +246,7 @@ bool HiZSystem::createPyramidPipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -255,7 +255,7 @@ bool HiZSystem::createPyramidPipeline() {
     pipelineInfo.layout = pyramidPipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, pyramidPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_Log("HiZSystem: Failed to create pyramid compute pipeline");
@@ -292,9 +292,9 @@ bool HiZSystem::createCullingPipeline() {
     }
 
     // Load compute shader
-    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(
+    auto shaderModule = ShaderLoader::loadShaderModule(
         device, shaderPath + "/hiz_culling.comp.spv");
-    if (shaderModule == VK_NULL_HANDLE) {
+    if (!shaderModule) {
         SDL_Log("HiZSystem: Failed to load hiz_culling.comp.spv");
         return false;
     }
@@ -302,7 +302,7 @@ bool HiZSystem::createCullingPipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -311,7 +311,7 @@ bool HiZSystem::createCullingPipeline() {
     pipelineInfo.layout = cullingPipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, cullingPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_Log("HiZSystem: Failed to create culling compute pipeline");

--- a/src/postprocess/SSRSystem.cpp
+++ b/src/postprocess/SSRSystem.cpp
@@ -268,8 +268,8 @@ bool SSRSystem::createComputePipeline() {
 
     // Load compute shader
     std::string shaderFile = shaderPath + "/ssr.comp.spv";
-    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
+    if (!shaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load SSR compute shader: %s", shaderFile.c_str());
         return false;
     }
@@ -277,7 +277,7 @@ bool SSRSystem::createComputePipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -286,7 +286,7 @@ bool SSRSystem::createComputePipeline() {
     pipelineInfo.layout = computePipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, computePipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SSR compute pipeline");
@@ -327,8 +327,8 @@ bool SSRSystem::createBlurPipeline() {
 
     // Load blur compute shader
     std::string shaderFile = shaderPath + "/ssr_blur.comp.spv";
-    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
+    if (!shaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load SSR blur compute shader: %s", shaderFile.c_str());
         return false;
     }
@@ -336,7 +336,7 @@ bool SSRSystem::createBlurPipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -345,7 +345,7 @@ bool SSRSystem::createBlurPipeline() {
     pipelineInfo.layout = blurPipelineLayout.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, blurPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (!success) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SSR blur compute pipeline");

--- a/src/subdivision/CatmullClarkSystem.cpp
+++ b/src/subdivision/CatmullClarkSystem.cpp
@@ -271,7 +271,7 @@ void CatmullClarkSystem::updateDescriptorSets(VkDevice device, const std::vector
 }
 
 bool CatmullClarkSystem::createSubdivisionPipeline() {
-    VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/catmullclark_subdivision.comp.spv");
+    auto shaderModule = loadShaderModule(device, shaderPath + "/catmullclark_subdivision.comp.spv");
     if (!shaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load Catmull-Clark subdivision compute shader");
         return false;
@@ -292,14 +292,14 @@ bool CatmullClarkSystem::createSubdivisionPipeline() {
 
     if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &subdivisionPipelineLayout) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create subdivision pipeline layout");
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         return false;
     }
 
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -308,7 +308,7 @@ bool CatmullClarkSystem::createSubdivisionPipeline() {
     pipelineInfo.layout = subdivisionPipelineLayout;
 
     VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &subdivisionPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create subdivision compute pipeline");
@@ -319,24 +319,24 @@ bool CatmullClarkSystem::createSubdivisionPipeline() {
 }
 
 bool CatmullClarkSystem::createRenderPipeline() {
-    VkShaderModule vertModule = loadShaderModule(device, shaderPath + "/catmullclark_render.vert.spv");
-    VkShaderModule fragModule = loadShaderModule(device, shaderPath + "/catmullclark_render.frag.spv");
+    auto vertModule = loadShaderModule(device, shaderPath + "/catmullclark_render.vert.spv");
+    auto fragModule = loadShaderModule(device, shaderPath + "/catmullclark_render.frag.spv");
     if (!vertModule || !fragModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load Catmull-Clark render shaders");
-        if (vertModule) vkDestroyShaderModule(device, vertModule, nullptr);
-        if (fragModule) vkDestroyShaderModule(device, fragModule, nullptr);
+        if (vertModule) vkDestroyShaderModule(device, *vertModule, nullptr);
+        if (fragModule) vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
     std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = vertModule;
+    shaderStages[0].module = *vertModule;
     shaderStages[0].pName = "main";
 
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = fragModule;
+    shaderStages[1].module = *fragModule;
     shaderStages[1].pName = "main";
 
     // No vertex input - all vertex data comes from buffers bound as storage buffers
@@ -399,8 +399,8 @@ bool CatmullClarkSystem::createRenderPipeline() {
 
     if (vkCreatePipelineLayout(device, &layoutInfo, nullptr, &renderPipelineLayout) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create render pipeline layout");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -422,8 +422,8 @@ bool CatmullClarkSystem::createRenderPipeline() {
 
     VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &renderPipeline);
 
-    vkDestroyShaderModule(device, vertModule, nullptr);
-    vkDestroyShaderModule(device, fragModule, nullptr);
+    vkDestroyShaderModule(device, *vertModule, nullptr);
+    vkDestroyShaderModule(device, *fragModule, nullptr);
 
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create render graphics pipeline");
@@ -434,24 +434,24 @@ bool CatmullClarkSystem::createRenderPipeline() {
 }
 
 bool CatmullClarkSystem::createWireframePipeline() {
-    VkShaderModule vertModule = loadShaderModule(device, shaderPath + "/catmullclark_render.vert.spv");
-    VkShaderModule fragModule = loadShaderModule(device, shaderPath + "/catmullclark_render.frag.spv");
+    auto vertModule = loadShaderModule(device, shaderPath + "/catmullclark_render.vert.spv");
+    auto fragModule = loadShaderModule(device, shaderPath + "/catmullclark_render.frag.spv");
     if (!vertModule || !fragModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load Catmull-Clark wireframe shaders");
-        if (vertModule) vkDestroyShaderModule(device, vertModule, nullptr);
-        if (fragModule) vkDestroyShaderModule(device, fragModule, nullptr);
+        if (vertModule) vkDestroyShaderModule(device, *vertModule, nullptr);
+        if (fragModule) vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
     std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = vertModule;
+    shaderStages[0].module = *vertModule;
     shaderStages[0].pName = "main";
 
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = fragModule;
+    shaderStages[1].module = *fragModule;
     shaderStages[1].pName = "main";
 
     // No vertex input - all vertex data comes from buffers bound as storage buffers
@@ -518,8 +518,8 @@ bool CatmullClarkSystem::createWireframePipeline() {
 
     VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &wireframePipeline);
 
-    vkDestroyShaderModule(device, vertModule, nullptr);
-    vkDestroyShaderModule(device, fragModule, nullptr);
+    vkDestroyShaderModule(device, *vertModule, nullptr);
+    vkDestroyShaderModule(device, *fragModule, nullptr);
 
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create wireframe graphics pipeline");

--- a/src/terrain/TerrainPipelines.cpp
+++ b/src/terrain/TerrainPipelines.cpp
@@ -44,7 +44,7 @@ void TerrainPipelines::destroy(VkDevice /*device*/) {
 }
 
 bool TerrainPipelines::createDispatcherPipeline() {
-    VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_dispatcher.comp.spv");
+    auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_dispatcher.comp.spv");
     if (!shaderModule) return false;
 
     VkPushConstantRange pushConstantRange{};
@@ -60,14 +60,14 @@ bool TerrainPipelines::createDispatcherPipeline() {
     layoutInfo.pPushConstantRanges = &pushConstantRange;
 
     if (!ManagedPipelineLayout::create(device, layoutInfo, dispatcherPipelineLayout_)) {
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         return false;
     }
 
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -76,13 +76,13 @@ bool TerrainPipelines::createDispatcherPipeline() {
     pipelineInfo.layout = dispatcherPipelineLayout_.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, dispatcherPipeline_);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     return success;
 }
 
 bool TerrainPipelines::createSubdivisionPipeline() {
-    VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_subdivision.comp.spv");
+    auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_subdivision.comp.spv");
     if (!shaderModule) return false;
 
     VkPushConstantRange pushConstantRange{};
@@ -98,14 +98,14 @@ bool TerrainPipelines::createSubdivisionPipeline() {
     layoutInfo.pPushConstantRanges = &pushConstantRange;
 
     if (!ManagedPipelineLayout::create(device, layoutInfo, subdivisionPipelineLayout_)) {
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         return false;
     }
 
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -114,7 +114,7 @@ bool TerrainPipelines::createSubdivisionPipeline() {
     pipelineInfo.layout = subdivisionPipelineLayout_.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, subdivisionPipeline_);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     return success;
 }
@@ -138,13 +138,13 @@ bool TerrainPipelines::createSumReductionPipelines() {
 
     // Prepass pipeline
     {
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_prepass.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_prepass.comp.spv");
         if (!shaderModule) return false;
 
         VkPipelineShaderStageCreateInfo stageInfo{};
         stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stageInfo.module = shaderModule;
+        stageInfo.module = *shaderModule;
         stageInfo.pName = "main";
 
         VkComputePipelineCreateInfo pipelineInfo{};
@@ -153,18 +153,18 @@ bool TerrainPipelines::createSumReductionPipelines() {
         pipelineInfo.layout = sumReductionPipelineLayout_.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, sumReductionPrepassPipeline_);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         if (!success) return false;
     }
 
     // Subgroup-optimized prepass pipeline (processes 13 levels instead of 5)
     if (subgroupCaps && subgroupCaps->hasSubgroupArithmetic) {
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_prepass_subgroup.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_prepass_subgroup.comp.spv");
         if (shaderModule) {
             VkPipelineShaderStageCreateInfo stageInfo{};
             stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
             stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-            stageInfo.module = shaderModule;
+            stageInfo.module = *shaderModule;
             stageInfo.pName = "main";
 
             VkComputePipelineCreateInfo pipelineInfo{};
@@ -173,7 +173,7 @@ bool TerrainPipelines::createSumReductionPipelines() {
             pipelineInfo.layout = sumReductionPipelineLayout_.get();
 
             bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, sumReductionPrepassSubgroupPipeline_);
-            vkDestroyShaderModule(device, shaderModule, nullptr);
+            vkDestroyShaderModule(device, *shaderModule, nullptr);
             if (!success) {
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Failed to create subgroup prepass pipeline, using fallback");
             } else {
@@ -184,13 +184,13 @@ bool TerrainPipelines::createSumReductionPipelines() {
 
     // Regular sum reduction pipeline (legacy single-level per dispatch)
     {
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction.comp.spv");
         if (!shaderModule) return false;
 
         VkPipelineShaderStageCreateInfo stageInfo{};
         stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stageInfo.module = shaderModule;
+        stageInfo.module = *shaderModule;
         stageInfo.pName = "main";
 
         VkComputePipelineCreateInfo pipelineInfo{};
@@ -199,7 +199,7 @@ bool TerrainPipelines::createSumReductionPipelines() {
         pipelineInfo.layout = sumReductionPipelineLayout_.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, sumReductionPipeline_);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         if (!success) return false;
     }
 
@@ -222,13 +222,13 @@ bool TerrainPipelines::createSumReductionPipelines() {
             return false;
         }
 
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_batched.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_sum_reduction_batched.comp.spv");
         if (!shaderModule) return false;
 
         VkPipelineShaderStageCreateInfo stageInfo{};
         stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stageInfo.module = shaderModule;
+        stageInfo.module = *shaderModule;
         stageInfo.pName = "main";
 
         VkComputePipelineCreateInfo pipelineInfo{};
@@ -237,7 +237,7 @@ bool TerrainPipelines::createSumReductionPipelines() {
         pipelineInfo.layout = sumReductionBatchedPipelineLayout_.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, sumReductionBatchedPipeline_);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         if (!success) return false;
     }
 
@@ -247,7 +247,7 @@ bool TerrainPipelines::createSumReductionPipelines() {
 bool TerrainPipelines::createFrustumCullPipelines() {
     // Frustum cull pipeline (with push constants for dispatch calculation)
     {
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_frustum_cull.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_frustum_cull.comp.spv");
         if (!shaderModule) return false;
 
         VkPushConstantRange pushConstantRange{};
@@ -263,14 +263,14 @@ bool TerrainPipelines::createFrustumCullPipelines() {
         layoutInfo.pPushConstantRanges = &pushConstantRange;
 
         if (!ManagedPipelineLayout::create(device, layoutInfo, frustumCullPipelineLayout_)) {
-            vkDestroyShaderModule(device, shaderModule, nullptr);
+            vkDestroyShaderModule(device, *shaderModule, nullptr);
             return false;
         }
 
         VkPipelineShaderStageCreateInfo stageInfo{};
         stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stageInfo.module = shaderModule;
+        stageInfo.module = *shaderModule;
         stageInfo.pName = "main";
 
         VkComputePipelineCreateInfo pipelineInfo{};
@@ -279,13 +279,13 @@ bool TerrainPipelines::createFrustumCullPipelines() {
         pipelineInfo.layout = frustumCullPipelineLayout_.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, frustumCullPipeline_);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         if (!success) return false;
     }
 
     // Prepare cull dispatch pipeline
     {
-        VkShaderModule shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_prepare_cull_dispatch.comp.spv");
+        auto shaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_prepare_cull_dispatch.comp.spv");
         if (!shaderModule) return false;
 
         VkPushConstantRange pushConstantRange{};
@@ -301,14 +301,14 @@ bool TerrainPipelines::createFrustumCullPipelines() {
         layoutInfo.pPushConstantRanges = &pushConstantRange;
 
         if (!ManagedPipelineLayout::create(device, layoutInfo, prepareDispatchPipelineLayout_)) {
-            vkDestroyShaderModule(device, shaderModule, nullptr);
+            vkDestroyShaderModule(device, *shaderModule, nullptr);
             return false;
         }
 
         VkPipelineShaderStageCreateInfo stageInfo{};
         stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        stageInfo.module = shaderModule;
+        stageInfo.module = *shaderModule;
         stageInfo.pName = "main";
 
         VkComputePipelineCreateInfo pipelineInfo{};
@@ -317,7 +317,7 @@ bool TerrainPipelines::createFrustumCullPipelines() {
         pipelineInfo.layout = prepareDispatchPipelineLayout_.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, prepareDispatchPipeline_);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
         if (!success) return false;
     }
 
@@ -436,7 +436,7 @@ bool TerrainPipelines::createMeshletShadowPipeline() {
 
 bool TerrainPipelines::createShadowCullPipelines() {
     // Create shadow cull compute pipeline
-    VkShaderModule cullShaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow_cull.comp.spv");
+    auto cullShaderModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow_cull.comp.spv");
     if (!cullShaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load shadow cull compute shader");
         return false;
@@ -456,7 +456,7 @@ bool TerrainPipelines::createShadowCullPipelines() {
     layoutInfo.pPushConstantRanges = &pushConstantRange;
 
     if (!ManagedPipelineLayout::create(device, layoutInfo, shadowCullPipelineLayout_)) {
-        vkDestroyShaderModule(device, cullShaderModule, nullptr);
+        vkDestroyShaderModule(device, *cullShaderModule, nullptr);
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create shadow cull pipeline layout");
         return false;
     }
@@ -465,7 +465,7 @@ bool TerrainPipelines::createShadowCullPipelines() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = cullShaderModule;
+    stageInfo.module = *cullShaderModule;
     stageInfo.pName = "main";
 
     // Specialization constant for meshlet index count
@@ -487,7 +487,7 @@ bool TerrainPipelines::createShadowCullPipelines() {
     pipelineInfo.layout = shadowCullPipelineLayout_.get();
 
     bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, shadowCullPipeline_);
-    vkDestroyShaderModule(device, cullShaderModule, nullptr);
+    vkDestroyShaderModule(device, *cullShaderModule, nullptr);
 
     if (!success) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create shadow cull compute pipeline");
@@ -495,11 +495,11 @@ bool TerrainPipelines::createShadowCullPipelines() {
     }
 
     // Create shadow culled graphics pipeline (non-meshlet)
-    VkShaderModule shadowCulledVertModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow_culled.vert.spv");
-    VkShaderModule shadowFragModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow.frag.spv");
+    auto shadowCulledVertModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow_culled.vert.spv");
+    auto shadowFragModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow.frag.spv");
     if (!shadowCulledVertModule || !shadowFragModule) {
-        if (shadowCulledVertModule) vkDestroyShaderModule(device, shadowCulledVertModule, nullptr);
-        if (shadowFragModule) vkDestroyShaderModule(device, shadowFragModule, nullptr);
+        if (shadowCulledVertModule) vkDestroyShaderModule(device, *shadowCulledVertModule, nullptr);
+        if (shadowFragModule) vkDestroyShaderModule(device, *shadowFragModule, nullptr);
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load shadow culled shaders");
         return false;
     }
@@ -507,12 +507,12 @@ bool TerrainPipelines::createShadowCullPipelines() {
     std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = shadowCulledVertModule;
+    shaderStages[0].module = *shadowCulledVertModule;
     shaderStages[0].pName = "main";
 
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = shadowFragModule;
+    shaderStages[1].module = *shadowFragModule;
     shaderStages[1].pName = "main";
 
     // No vertex input for non-meshlet (generated in shader)
@@ -578,8 +578,8 @@ bool TerrainPipelines::createShadowCullPipelines() {
 
     VkPipeline rawPipeline = VK_NULL_HANDLE;
     VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &gfxPipelineInfo, nullptr, &rawPipeline);
-    vkDestroyShaderModule(device, shadowCulledVertModule, nullptr);
-    vkDestroyShaderModule(device, shadowFragModule, nullptr);
+    vkDestroyShaderModule(device, *shadowCulledVertModule, nullptr);
+    vkDestroyShaderModule(device, *shadowFragModule, nullptr);
 
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create shadow culled graphics pipeline");
@@ -589,17 +589,17 @@ bool TerrainPipelines::createShadowCullPipelines() {
 
     // Create meshlet shadow culled pipeline (if meshlets enabled)
     if (useMeshlets) {
-        VkShaderModule meshletShadowCulledVertModule = loadShaderModule(device, shaderPath + "/terrain/terrain_meshlet_shadow_culled.vert.spv");
-        shadowFragModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow.frag.spv");
-        if (!meshletShadowCulledVertModule || !shadowFragModule) {
-            if (meshletShadowCulledVertModule) vkDestroyShaderModule(device, meshletShadowCulledVertModule, nullptr);
-            if (shadowFragModule) vkDestroyShaderModule(device, shadowFragModule, nullptr);
+        auto meshletShadowCulledVertModule = loadShaderModule(device, shaderPath + "/terrain/terrain_meshlet_shadow_culled.vert.spv");
+        auto meshletShadowFragModule = loadShaderModule(device, shaderPath + "/terrain/terrain_shadow.frag.spv");
+        if (!meshletShadowCulledVertModule || !meshletShadowFragModule) {
+            if (meshletShadowCulledVertModule) vkDestroyShaderModule(device, *meshletShadowCulledVertModule, nullptr);
+            if (meshletShadowFragModule) vkDestroyShaderModule(device, *meshletShadowFragModule, nullptr);
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load meshlet shadow culled shaders");
             return false;
         }
 
-        shaderStages[0].module = meshletShadowCulledVertModule;
-        shaderStages[1].module = shadowFragModule;
+        shaderStages[0].module = *meshletShadowCulledVertModule;
+        shaderStages[1].module = *meshletShadowFragModule;
 
         // Meshlet vertex input: vec2 for local UV
         VkVertexInputBindingDescription bindingDesc{};
@@ -622,8 +622,8 @@ bool TerrainPipelines::createShadowCullPipelines() {
 
         rawPipeline = VK_NULL_HANDLE;
         result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &gfxPipelineInfo, nullptr, &rawPipeline);
-        vkDestroyShaderModule(device, meshletShadowCulledVertModule, nullptr);
-        vkDestroyShaderModule(device, shadowFragModule, nullptr);
+        vkDestroyShaderModule(device, *meshletShadowCulledVertModule, nullptr);
+        vkDestroyShaderModule(device, *meshletShadowFragModule, nullptr);
 
         if (result != VK_SUCCESS) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create meshlet shadow culled graphics pipeline");

--- a/src/vegetation/BillboardCapture.cpp
+++ b/src/vegetation/BillboardCapture.cpp
@@ -300,13 +300,13 @@ bool BillboardCapture::createUniformBuffer() {
 
 bool BillboardCapture::createPipeline() {
     // Load shaders - use tree.vert but tree_billboard.frag (no fog)
-    VkShaderModule vertModule = loadShaderModule(device, shaderPath + "/tree.vert.spv");
-    VkShaderModule fragModule = loadShaderModule(device, shaderPath + "/tree_billboard.frag.spv");
+    auto vertModule = loadShaderModule(device, shaderPath + "/tree.vert.spv");
+    auto fragModule = loadShaderModule(device, shaderPath + "/tree_billboard.frag.spv");
 
     if (!vertModule || !fragModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load billboard shaders");
-        if (vertModule) vkDestroyShaderModule(device, vertModule, nullptr);
-        if (fragModule) vkDestroyShaderModule(device, fragModule, nullptr);
+        if (vertModule) vkDestroyShaderModule(device, *vertModule, nullptr);
+        if (fragModule) vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -314,12 +314,12 @@ bool BillboardCapture::createPipeline() {
     std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = vertModule;
+    shaderStages[0].module = *vertModule;
     shaderStages[0].pName = "main";
 
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = fragModule;
+    shaderStages[1].module = *fragModule;
     shaderStages[1].pName = "main";
 
     // Vertex input
@@ -390,8 +390,8 @@ bool BillboardCapture::createPipeline() {
 
     if (!ManagedPipelineLayout::create(device, pipelineLayoutInfo, pipelineLayout_)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create billboard pipeline layout");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -414,8 +414,8 @@ bool BillboardCapture::createPipeline() {
 
     if (!ManagedPipeline::createGraphics(device, VK_NULL_HANDLE, pipelineInfo, solidPipeline_)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create billboard solid pipeline");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -431,13 +431,13 @@ bool BillboardCapture::createPipeline() {
 
     if (!ManagedPipeline::createGraphics(device, VK_NULL_HANDLE, pipelineInfo, leafPipeline_)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create billboard leaf pipeline");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
-    vkDestroyShaderModule(device, vertModule, nullptr);
-    vkDestroyShaderModule(device, fragModule, nullptr);
+    vkDestroyShaderModule(device, *vertModule, nullptr);
+    vkDestroyShaderModule(device, *fragModule, nullptr);
 
     return true;
 }

--- a/src/vegetation/GrassSystem.cpp
+++ b/src/vegetation/GrassSystem.cpp
@@ -227,17 +227,21 @@ bool GrassSystem::createDisplacementPipeline() {
 
     // Load compute shader
     auto compShaderCode = ShaderLoader::readFile(getShaderPath() + "/grass_displacement.comp.spv");
-    if (compShaderCode.empty()) {
+    if (!compShaderCode) {
         SDL_Log("Failed to load displacement compute shader");
         return false;
     }
 
-    VkShaderModule compShaderModule = ShaderLoader::createShaderModule(getDevice(), compShaderCode);
+    auto compShaderModule = ShaderLoader::createShaderModule(getDevice(), *compShaderCode);
+    if (!compShaderModule) {
+        SDL_Log("Failed to create displacement compute shader module");
+        return false;
+    }
 
     VkPipelineShaderStageCreateInfo shaderStageInfo{};
     shaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    shaderStageInfo.module = compShaderModule;
+    shaderStageInfo.module = *compShaderModule;
     shaderStageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -247,7 +251,7 @@ bool GrassSystem::createDisplacementPipeline() {
 
     bool success = ManagedPipeline::createCompute(getDevice(), VK_NULL_HANDLE, pipelineInfo, displacementPipeline_);
 
-    vkDestroyShaderModule(getDevice(), compShaderModule, nullptr);
+    vkDestroyShaderModule(getDevice(), *compShaderModule, nullptr);
 
     if (!success) {
         SDL_Log("Failed to create displacement compute pipeline");

--- a/src/vegetation/TreeEditSystem.cpp
+++ b/src/vegetation/TreeEditSystem.cpp
@@ -221,13 +221,13 @@ void TreeEditSystem::updateTextureBindings() {
 
 bool TreeEditSystem::createPipelines() {
     // Load shaders
-    VkShaderModule vertModule = loadShaderModule(device, shaderPath + "/tree.vert.spv");
-    VkShaderModule fragModule = loadShaderModule(device, shaderPath + "/tree.frag.spv");
+    auto vertModule = loadShaderModule(device, shaderPath + "/tree.vert.spv");
+    auto fragModule = loadShaderModule(device, shaderPath + "/tree.frag.spv");
 
     if (!vertModule || !fragModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load tree shaders");
-        if (vertModule) vkDestroyShaderModule(device, vertModule, nullptr);
-        if (fragModule) vkDestroyShaderModule(device, fragModule, nullptr);
+        if (vertModule) vkDestroyShaderModule(device, *vertModule, nullptr);
+        if (fragModule) vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -235,12 +235,12 @@ bool TreeEditSystem::createPipelines() {
     std::array<VkPipelineShaderStageCreateInfo, 2> shaderStages{};
     shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].module = vertModule;
+    shaderStages[0].module = *vertModule;
     shaderStages[0].pName = "main";
 
     shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStages[1].module = fragModule;
+    shaderStages[1].module = *fragModule;
     shaderStages[1].pName = "main";
 
     // Vertex input - use Vertex format from Mesh
@@ -318,8 +318,8 @@ bool TreeEditSystem::createPipelines() {
 
     if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &pipelineLayout) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tree pipeline layout");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -342,8 +342,8 @@ bool TreeEditSystem::createPipelines() {
 
     if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &solidPipeline) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tree solid pipeline");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -353,8 +353,8 @@ bool TreeEditSystem::createPipelines() {
 
     if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &wireframePipeline) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tree wireframe pipeline");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
@@ -373,13 +373,13 @@ bool TreeEditSystem::createPipelines() {
 
     if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &leafPipeline) != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tree leaf pipeline");
-        vkDestroyShaderModule(device, vertModule, nullptr);
-        vkDestroyShaderModule(device, fragModule, nullptr);
+        vkDestroyShaderModule(device, *vertModule, nullptr);
+        vkDestroyShaderModule(device, *fragModule, nullptr);
         return false;
     }
 
-    vkDestroyShaderModule(device, vertModule, nullptr);
-    vkDestroyShaderModule(device, fragModule, nullptr);
+    vkDestroyShaderModule(device, *vertModule, nullptr);
+    vkDestroyShaderModule(device, *fragModule, nullptr);
 
     return true;
 }

--- a/src/water/FoamBuffer.cpp
+++ b/src/water/FoamBuffer.cpp
@@ -221,7 +221,7 @@ bool FoamBuffer::createComputePipeline() {
     // Load compute shader
     std::string shaderFile = shaderPath + "/foam_blur.comp.spv";
     auto shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
-    if (shaderModule == VK_NULL_HANDLE) {
+    if (!shaderModule) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "FoamBuffer: Compute shader not found at %s", shaderFile.c_str());
         return true;  // Allow system to work without temporal foam
     }
@@ -229,7 +229,7 @@ bool FoamBuffer::createComputePipeline() {
     VkPipelineShaderStageCreateInfo shaderStage{};
     shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    shaderStage.module = shaderModule;
+    shaderStage.module = *shaderModule;
     shaderStage.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -240,7 +240,7 @@ bool FoamBuffer::createComputePipeline() {
     VkPipeline rawPipeline = VK_NULL_HANDLE;
     VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &rawPipeline);
 
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (result == VK_SUCCESS) {
         computePipeline = ManagedPipeline::fromRaw(device, rawPipeline);

--- a/src/water/OceanFFT.cpp
+++ b/src/water/OceanFFT.cpp
@@ -362,8 +362,8 @@ bool OceanFFT::createComputePipelines() {
         }
         spectrumPipelineLayout = ManagedPipelineLayout::fromRaw(device, rawPipelineLayout);
 
-        VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_spectrum.comp.spv");
-        if (shaderModule == VK_NULL_HANDLE) {
+        auto shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_spectrum.comp.spv");
+        if (!shaderModule) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to load ocean_spectrum.comp.spv");
             return false;
         }
@@ -372,12 +372,12 @@ bool OceanFFT::createComputePipelines() {
         pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
         pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        pipelineInfo.stage.module = shaderModule;
+        pipelineInfo.stage.module = *shaderModule;
         pipelineInfo.stage.pName = "main";
         pipelineInfo.layout = spectrumPipelineLayout.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, spectrumPipeline);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
 
         if (!success) {
             return false;
@@ -412,8 +412,8 @@ bool OceanFFT::createComputePipelines() {
         }
         timeEvolutionPipelineLayout = ManagedPipelineLayout::fromRaw(device, rawPipelineLayout);
 
-        VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_time_evolution.comp.spv");
-        if (shaderModule == VK_NULL_HANDLE) {
+        auto shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_time_evolution.comp.spv");
+        if (!shaderModule) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to load ocean_time_evolution.comp.spv");
             return false;
         }
@@ -422,12 +422,12 @@ bool OceanFFT::createComputePipelines() {
         pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
         pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        pipelineInfo.stage.module = shaderModule;
+        pipelineInfo.stage.module = *shaderModule;
         pipelineInfo.stage.pName = "main";
         pipelineInfo.layout = timeEvolutionPipelineLayout.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, timeEvolutionPipeline);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
 
         if (!success) {
             return false;
@@ -459,8 +459,8 @@ bool OceanFFT::createComputePipelines() {
         }
         fftPipelineLayout = ManagedPipelineLayout::fromRaw(device, rawPipelineLayout);
 
-        VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_fft.comp.spv");
-        if (shaderModule == VK_NULL_HANDLE) {
+        auto shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_fft.comp.spv");
+        if (!shaderModule) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to load ocean_fft.comp.spv");
             return false;
         }
@@ -469,12 +469,12 @@ bool OceanFFT::createComputePipelines() {
         pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
         pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        pipelineInfo.stage.module = shaderModule;
+        pipelineInfo.stage.module = *shaderModule;
         pipelineInfo.stage.pName = "main";
         pipelineInfo.layout = fftPipelineLayout.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, fftPipeline);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
 
         if (!success) {
             return false;
@@ -510,8 +510,8 @@ bool OceanFFT::createComputePipelines() {
         }
         displacementPipelineLayout = ManagedPipelineLayout::fromRaw(device, rawPipelineLayout);
 
-        VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_displacement.comp.spv");
-        if (shaderModule == VK_NULL_HANDLE) {
+        auto shaderModule = ShaderLoader::loadShaderModule(device, shaderPath + "/ocean_displacement.comp.spv");
+        if (!shaderModule) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to load ocean_displacement.comp.spv");
             return false;
         }
@@ -520,12 +520,12 @@ bool OceanFFT::createComputePipelines() {
         pipelineInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
         pipelineInfo.stage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         pipelineInfo.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-        pipelineInfo.stage.module = shaderModule;
+        pipelineInfo.stage.module = *shaderModule;
         pipelineInfo.stage.pName = "main";
         pipelineInfo.layout = displacementPipelineLayout.get();
 
         bool success = ManagedPipeline::createCompute(device, VK_NULL_HANDLE, pipelineInfo, displacementPipeline);
-        vkDestroyShaderModule(device, shaderModule, nullptr);
+        vkDestroyShaderModule(device, *shaderModule, nullptr);
 
         if (!success) {
             return false;

--- a/src/water/WaterDisplacement.cpp
+++ b/src/water/WaterDisplacement.cpp
@@ -260,7 +260,7 @@ bool WaterDisplacement::createComputePipeline() {
 
     // Load compute shader
     auto shaderModule = ShaderLoader::loadShaderModule(device, "shaders/water_displacement.comp.spv");
-    if (shaderModule == VK_NULL_HANDLE) {
+    if (!shaderModule) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "WaterDisplacement: Compute shader not found, using fallback");
         // Create a simple pass-through pipeline or return true to allow system to work without splashes
         return true;
@@ -269,7 +269,7 @@ bool WaterDisplacement::createComputePipeline() {
     VkPipelineShaderStageCreateInfo shaderStage{};
     shaderStage.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    shaderStage.module = shaderModule;
+    shaderStage.module = *shaderModule;
     shaderStage.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -280,7 +280,7 @@ bool WaterDisplacement::createComputePipeline() {
     VkPipeline rawPipeline = VK_NULL_HANDLE;
     VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &rawPipeline);
 
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (result == VK_SUCCESS) {
         computePipeline = ManagedPipeline::fromRaw(device, rawPipeline);

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -190,8 +190,8 @@ bool WaterTileCull::createComputePipeline() {
 
     // Load compute shader
     std::string shaderFile = shaderPath + "/water_tile_cull.comp.spv";
-    VkShaderModule shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
-    if (shaderModule == VK_NULL_HANDLE) {
+    auto shaderModule = ShaderLoader::loadShaderModule(device, shaderFile);
+    if (!shaderModule) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load tile cull compute shader: %s", shaderFile.c_str());
         return false;
     }
@@ -199,7 +199,7 @@ bool WaterTileCull::createComputePipeline() {
     VkPipelineShaderStageCreateInfo stageInfo{};
     stageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    stageInfo.module = shaderModule;
+    stageInfo.module = *shaderModule;
     stageInfo.pName = "main";
 
     VkComputePipelineCreateInfo pipelineInfo{};
@@ -210,7 +210,7 @@ bool WaterTileCull::createComputePipeline() {
     VkPipeline rawPipeline = VK_NULL_HANDLE;
     VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1,
                                                 &pipelineInfo, nullptr, &rawPipeline);
-    vkDestroyShaderModule(device, shaderModule, nullptr);
+    vkDestroyShaderModule(device, *shaderModule, nullptr);
 
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull compute pipeline");


### PR DESCRIPTION
Convert ShaderLoader functions to return std::optional instead of raw handles/empty vectors on failure:
- readFile() returns std::optional<std::vector<char>>
- createShaderModule() returns std::optional<VkShaderModule>
- loadShaderModule() returns std::optional<VkShaderModule>

Update all callsites across the codebase to use the new API:
- Use auto for return types
- Check with !module instead of module == VK_NULL_HANDLE
- Dereference with * when accessing values
- Dereference with -> when accessing vector methods

This provides better type safety and makes failure handling explicit.