### PR TITLE
Fix race condition in scene building wiring

### DIFF
--- a/src/animation/SkinnedMeshRenderer.cpp
+++ b/src/animation/SkinnedMeshRenderer.cpp
@@ -179,11 +179,13 @@ bool SkinnedMeshRenderer::createDescriptorSets(const DescriptorResources& resour
         common.placeholderTextureView = resources.whiteTextureView;
         common.placeholderTextureSampler = resources.whiteTextureSampler;
 
+        // Use player's actual material textures from MaterialRegistry
+        // (avoids race condition where player could have different material based on FBX load success)
         MaterialDescriptorFactory::MaterialTextures mat{};
-        mat.diffuseView = resources.whiteTextureView;
-        mat.diffuseSampler = resources.whiteTextureSampler;
-        mat.normalView = resources.whiteTextureView;
-        mat.normalSampler = resources.whiteTextureSampler;
+        mat.diffuseView = resources.playerDiffuseView;
+        mat.diffuseSampler = resources.playerDiffuseSampler;
+        mat.normalView = resources.playerNormalView;
+        mat.normalSampler = resources.playerNormalSampler;
         factory.writeSkinnedDescriptorSet(descriptorSets[i], common, mat);
     }
 

--- a/src/animation/SkinnedMeshRenderer.h
+++ b/src/animation/SkinnedMeshRenderer.h
@@ -52,6 +52,12 @@ public:
         // Placeholder textures
         VkImageView whiteTextureView;
         VkSampler whiteTextureSampler;
+
+        // Player material textures (from MaterialRegistry based on player's materialId)
+        VkImageView playerDiffuseView;
+        VkSampler playerDiffuseSampler;
+        VkImageView playerNormalView;
+        VkSampler playerNormalSampler;
     };
 
     SkinnedMeshRenderer() = default;

--- a/src/core/RenderableBuilder.h
+++ b/src/core/RenderableBuilder.h
@@ -17,8 +17,8 @@ constexpr MaterialId INVALID_MATERIAL_ID = ~0u;
 struct Renderable {
     glm::mat4 transform;
     Mesh* mesh;
-    Texture* texture;  // Used for texture selection, materialId for descriptor sets
-    MaterialId materialId = INVALID_MATERIAL_ID;
+    Texture* texture;  // Deprecated: kept for debug/inspection only. Use materialId for rendering.
+    MaterialId materialId = INVALID_MATERIAL_ID;  // Used for descriptor set lookup during rendering
     float roughness = 0.5f;
     float metallic = 0.0f;
     float emissiveIntensity = 0.0f;

--- a/src/scene/SceneBuilder.h
+++ b/src/scene/SceneBuilder.h
@@ -44,6 +44,11 @@ public:
     const std::vector<Renderable>& getRenderables() const { return sceneObjects; }
     std::vector<Renderable>& getRenderables() { return sceneObjects; }
     size_t getPlayerObjectIndex() const { return playerObjectIndex; }
+    size_t getEmissiveOrbIndex() const { return emissiveOrbIndex; }
+
+    // Get indices of objects that need physics bodies
+    // SceneManager uses this instead of hardcoded indices
+    const std::vector<size_t>& getPhysicsEnabledIndices() const { return physicsEnabledIndices; }
 
     // Material registry - call registerMaterials() after init(), before Renderer creates descriptor sets
     MaterialRegistry& getMaterialRegistry() { return materialRegistry; }
@@ -153,6 +158,11 @@ private:
     size_t flagClothIndex = 0;
     size_t wellEntranceIndex = 0;
     size_t capeIndex = 0;
+    size_t emissiveOrbIndex = 0;  // Glowing orb that has a corresponding light
+
+    // Indices of objects that should have physics bodies (dynamic objects)
+    // Objects NOT in this list are either static (lights, flags) or handled separately (player)
+    std::vector<size_t> physicsEnabledIndices;
 
     // Well entrance position (for terrain hole creation)
     float wellEntranceX = 0.0f;

--- a/src/scene/SceneManager.h
+++ b/src/scene/SceneManager.h
@@ -68,9 +68,6 @@ private:
     // Physics body tracking (mapped to scene object indices)
     std::vector<PhysicsBodyID> scenePhysicsBodies;
 
-    // Orb light position (follows physics object 6)
+    // Orb light position (follows emissive orb physics object)
     glm::vec3 orbLightPosition = glm::vec3(2.0f, 1.3f, 0.0f);
-
-    // Scene object indices (for clarity)
-    static constexpr size_t ORB_LIGHT_OBJECT_INDEX = 6;
 };


### PR DESCRIPTION
Root causes fixed:
- SkinnedMeshRenderer was hardcoding white texture in descriptor sets, ignoring the player's actual materialId from the Renderable
- SceneManager used hardcoded object indices creating fragile coupling

Changes:
- SkinnedMeshRenderer now uses player's actual material textures from MaterialRegistry, passed through DescriptorResources struct
- Renderer looks up player's materialId and passes correct textures
- SceneBuilder exposes physicsEnabledIndices and emissiveOrbIndex dynamically instead of requiring hardcoded constants
- SceneManager uses dynamic indices from SceneBuilder
- Marked Renderable.texture as deprecated (use materialId for rendering)