### PR TITLE
Add toggle to disable HDR pass for debugging

### DIFF
--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -144,6 +144,10 @@ public:
     void setHDREnabled(bool enabled) { hdrEnabled = enabled; }
     bool isHDREnabled() const { return hdrEnabled; }
 
+    // HDR pass control (skips entire scene rendering to HDR target)
+    void setHDRPassEnabled(bool enabled) { hdrPassEnabled = enabled; }
+    bool isHDRPassEnabled() const { return hdrPassEnabled; }
+
     // Bloom control
     void setBloomEnabled(bool enabled);
     bool isBloomEnabled() const;
@@ -434,6 +438,7 @@ private:
     bool showSnowDepthDebug = false;       // true = show snow depth heat map overlay
     bool useParaboloidClouds = true;       // true = paraboloid LUT hybrid, false = procedural
     bool hdrEnabled = true;                // true = HDR tonemapping/bloom, false = bypass
+    bool hdrPassEnabled = true;            // true = render HDR pass, false = skip entire HDR scene rendering
     bool terrainEnabled = true;            // true = render terrain, false = skip terrain rendering
 
     // Cloud parameters (synced to UBO, cloud shadows, and cloud map LUT)

--- a/src/gui/GuiPostFXTab.cpp
+++ b/src/gui/GuiPostFXTab.cpp
@@ -13,6 +13,14 @@ void GuiPostFXTab::render(Renderer& renderer) {
     ImGui::Text("HDR PIPELINE");
     ImGui::PopStyleColor();
 
+    bool hdrPassEnabled = renderer.isHDRPassEnabled();
+    if (ImGui::Checkbox("HDR Pass (Scene Rendering)", &hdrPassEnabled)) {
+        renderer.setHDRPassEnabled(hdrPassEnabled);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Enable/disable entire HDR scene rendering pass (for performance debugging)");
+    }
+
     bool hdrEnabled = renderer.isHDREnabled();
     if (ImGui::Checkbox("HDR Tonemapping", &hdrEnabled)) {
         renderer.setHDREnabled(hdrEnabled);


### PR DESCRIPTION
The existing HDR toggle only disabled tone mapping but still rendered the scene. This adds a separate toggle that skips the entire HDR render pass (including SSR and water tile culling) to help isolate performance issues that may not actually be in the HDR pass itself.

- Added hdrPassEnabled flag to Renderer
- GUI checkbox in Post-FX tab under "HDR PIPELINE" section
- Skips HDRPass, SSR, and WaterTileCull when disabled