### PR TITLE
Refactor terrain meshlet upload system

### DIFF
--- a/src/core/VulkanBarriers.h
+++ b/src/core/VulkanBarriers.h
@@ -159,6 +159,21 @@ inline void transferToHostRead(VkCommandBuffer cmd) {
         0, 1, &barrier, 0, nullptr, 0, nullptr);
 }
 
+/**
+ * Synchronize transfer operations before vertex input stage.
+ * Use after vkCmdCopyBuffer to vertex/index buffers when they
+ * will be bound for drawing.
+ */
+inline void transferToVertexInput(VkCommandBuffer cmd) {
+    VkMemoryBarrier barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_VERTEX_INPUT_BIT,
+        0, 1, &barrier, 0, nullptr, 0, nullptr);
+}
+
 // ============================================================================
 // Image layout transition helper
 // ============================================================================

--- a/src/terrain/TerrainMeshlet.h
+++ b/src/terrain/TerrainMeshlet.h
@@ -11,11 +11,17 @@
 // Pre-subdivided meshlet for terrain rendering
 // Each CBT leaf node is rendered as an instance of this meshlet,
 // providing higher resolution without increasing CBT memory
+//
+// Uses fence-free upload pattern like VirtualTextureCache:
+// - Per-frame staging buffers avoid race conditions
+// - recordUpload() records GPU commands without waiting
+// - Frame fences handle synchronization naturally
 class TerrainMeshlet {
 public:
     struct InitInfo {
         VmaAllocator allocator;
         uint32_t subdivisionLevel;  // Number of LEB subdivisions (e.g., 4 = 16 triangles, 6 = 64 triangles)
+        uint32_t framesInFlight = 3;  // For per-frame staging buffers
     };
 
     /**
@@ -35,10 +41,39 @@ public:
     // Buffer accessors
     VkBuffer getVertexBuffer() const { return vertexBuffer_.get(); }
     VkBuffer getIndexBuffer() const { return indexBuffer_.get(); }
-    uint32_t getVertexCount() const { return vertexCount; }
-    uint32_t getIndexCount() const { return indexCount; }
-    uint32_t getTriangleCount() const { return triangleCount; }
-    uint32_t getSubdivisionLevel() const { return subdivisionLevel; }
+    uint32_t getVertexCount() const { return vertexCount_; }
+    uint32_t getIndexCount() const { return indexCount_; }
+    uint32_t getTriangleCount() const { return triangleCount_; }
+    uint32_t getSubdivisionLevel() const { return subdivisionLevel_; }
+
+    /**
+     * Request a subdivision level change.
+     * Does NOT wait on GPU - generates new geometry to CPU memory.
+     * Call recordUpload() for each frame to upload the new geometry.
+     * @return true if level changed, false if already at requested level
+     */
+    bool requestSubdivisionChange(uint32_t newLevel);
+
+    /**
+     * Check if there's pending geometry that needs uploading.
+     */
+    bool hasPendingUpload() const { return pendingUpload_; }
+
+    /**
+     * Record GPU commands to upload pending geometry.
+     * Uses per-frame staging buffer to avoid race conditions.
+     * Must be called once per frame until hasPendingUpload() returns false.
+     *
+     * @param cmd Command buffer to record into (must be in recording state)
+     * @param frameIndex Current frame index for staging buffer selection
+     */
+    void recordUpload(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    /**
+     * Get number of frames still needing upload after subdivision change.
+     * Returns 0 when all frames have been uploaded.
+     */
+    uint32_t getPendingUploadFrames() const { return pendingUploadFrames_; }
 
 private:
     TerrainMeshlet() = default;  // Private: use factory
@@ -60,11 +95,31 @@ private:
     // Helper to create unique vertex key for deduplication
     static uint64_t makeVertexKey(const glm::vec2& v);
 
+    // Create GPU buffers sized for current geometry
+    bool createBuffers();
+
+    // Device-local GPU buffers
     ManagedBuffer vertexBuffer_;
     ManagedBuffer indexBuffer_;
 
-    uint32_t vertexCount = 0;
-    uint32_t indexCount = 0;
-    uint32_t triangleCount = 0;
-    uint32_t subdivisionLevel = 0;
+    // Per-frame staging buffers (like VirtualTextureCache pattern)
+    std::vector<ManagedBuffer> vertexStagingBuffers_;
+    std::vector<ManagedBuffer> indexStagingBuffers_;
+    std::vector<void*> vertexStagingMapped_;
+    std::vector<void*> indexStagingMapped_;
+
+    // Pending geometry in CPU memory (populated by requestSubdivisionChange)
+    std::vector<glm::vec2> pendingVertices_;
+    std::vector<uint16_t> pendingIndices_;
+
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    uint32_t framesInFlight_ = 3;
+    uint32_t vertexCount_ = 0;
+    uint32_t indexCount_ = 0;
+    uint32_t triangleCount_ = 0;
+    uint32_t subdivisionLevel_ = 0;
+
+    // Upload state tracking
+    bool pendingUpload_ = false;
+    uint32_t pendingUploadFrames_ = 0;  // Count down as each frame uploads
 };


### PR DESCRIPTION
Replace vkDeviceWaitIdle blocking in meshlet subdivision changes with per-frame staging buffers that record GPU upload commands. This follows the same pattern as VirtualTextureCache for fence-free streaming.

Key changes:
- Add per-frame vertex/index staging buffers to TerrainMeshlet
- Generate geometry to CPU memory on subdivision change (no GPU wait)
- Record staging->device copy commands via recordUpload() each frame
- Remove vkDeviceWaitIdle from setMeshletSubdivisionLevel
- Add transferToVertexInput barrier helper for buffer copies