### PR TITLE
Remove duplicate physical device selection code

### DIFF
--- a/src/core/VulkanContext.cpp
+++ b/src/core/VulkanContext.cpp
@@ -85,25 +85,13 @@ bool VulkanContext::selectPhysicalDevice() {
         return false;
     }
 
-    physicalDevice = physRet.value().physical_device;
+    vkbPhysicalDevice = physRet.value();
+    physicalDevice = vkbPhysicalDevice.physical_device;
     return true;
 }
 
 bool VulkanContext::createLogicalDevice() {
-    VkPhysicalDeviceFeatures features{};
-    features.samplerAnisotropy = VK_FALSE;
-
-    vkb::PhysicalDeviceSelector selector{vkbInstance};
-    auto physRet = selector.set_minimum_version(1, 2)
-        .set_surface(surface)
-        .set_required_features(features)
-        .select();
-
-    if (!physRet) {
-        return false;
-    }
-
-    vkb::DeviceBuilder deviceBuilder{physRet.value()};
+    vkb::DeviceBuilder deviceBuilder{vkbPhysicalDevice};
     auto devRet = deviceBuilder.build();
 
     if (!devRet) {

--- a/src/core/VulkanContext.h
+++ b/src/core/VulkanContext.h
@@ -64,6 +64,7 @@ private:
     SDL_Window* window = nullptr;
 
     vkb::Instance vkbInstance;
+    vkb::PhysicalDevice vkbPhysicalDevice;
     vkb::Device vkbDevice;
 
     VkInstance instance = VK_NULL_HANDLE;


### PR DESCRIPTION
Store vkb::PhysicalDevice result from selectPhysicalDevice() and reuse it in createLogicalDevice() instead of running the selection process twice. This removes redundant GPU enumeration and selection logic.