### PR TITLE
Add pipeline cache to graphics pipeline creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES
     src/core/Texture.cpp
     src/core/ShaderLoader.cpp
     src/core/PipelineBuilder.cpp
+    src/core/PipelineCache.cpp
     src/core/GraphicsPipelineFactory.cpp
     src/core/BindingBuilder.cpp
     src/core/DescriptorManager.cpp

--- a/src/core/GraphicsPipelineFactory.cpp
+++ b/src/core/GraphicsPipelineFactory.cpp
@@ -11,6 +11,11 @@ GraphicsPipelineFactory::~GraphicsPipelineFactory() {
     cleanup();
 }
 
+GraphicsPipelineFactory& GraphicsPipelineFactory::setPipelineCache(VkPipelineCache cache) {
+    pipelineCacheHandle = cache;
+    return *this;
+}
+
 GraphicsPipelineFactory& GraphicsPipelineFactory::reset() {
     cleanup();
 
@@ -19,6 +24,7 @@ GraphicsPipelineFactory& GraphicsPipelineFactory::reset() {
     renderPass = VK_NULL_HANDLE;
     subpass = 0;
     pipelineLayout = VK_NULL_HANDLE;
+    pipelineCacheHandle = VK_NULL_HANDLE;
     extent = {0, 0};
     dynamicViewport = false;
     vertexBindings.clear();
@@ -464,7 +470,7 @@ bool GraphicsPipelineFactory::build(VkPipeline& pipeline) {
     pipelineInfo.renderPass = renderPass;
     pipelineInfo.subpass = subpass;
 
-    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    VkResult result = vkCreateGraphicsPipelines(device, pipelineCacheHandle, 1, &pipelineInfo, nullptr, &pipeline);
     cleanup();
 
     if (result != VK_SUCCESS) {

--- a/src/core/GraphicsPipelineFactory.h
+++ b/src/core/GraphicsPipelineFactory.h
@@ -49,6 +49,9 @@ public:
     // Reset all state to defaults
     GraphicsPipelineFactory& reset();
 
+    // Set pipeline cache for faster pipeline creation
+    GraphicsPipelineFactory& setPipelineCache(VkPipelineCache cache);
+
     // Apply a preset configuration
     GraphicsPipelineFactory& applyPreset(Preset preset);
 
@@ -110,6 +113,7 @@ public:
 
 private:
     VkDevice device;
+    VkPipelineCache pipelineCacheHandle = VK_NULL_HANDLE;
 
     // Shader state
     std::string vertShaderPath;

--- a/src/core/PipelineBuilder.cpp
+++ b/src/core/PipelineBuilder.cpp
@@ -13,7 +13,13 @@ PipelineBuilder& PipelineBuilder::reset() {
     descriptorBindings.clear();
     pushConstantRanges.clear();
     shaderStages.clear();
+    pipelineCacheHandle = VK_NULL_HANDLE;
     cleanupShaderModules();
+    return *this;
+}
+
+PipelineBuilder& PipelineBuilder::setPipelineCache(VkPipelineCache cache) {
+    pipelineCacheHandle = cache;
     return *this;
 }
 
@@ -96,7 +102,7 @@ bool PipelineBuilder::buildComputePipeline(VkPipelineLayout layout, VkPipeline& 
     pipelineInfo.stage = shaderStages[0];
     pipelineInfo.layout = layout;
 
-    VkResult result = vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    VkResult result = vkCreateComputePipelines(device, pipelineCacheHandle, 1, &pipelineInfo, nullptr, &pipeline);
     cleanupShaderModules();
 
     if (result != VK_SUCCESS) {
@@ -119,7 +125,7 @@ bool PipelineBuilder::buildGraphicsPipeline(const VkGraphicsPipelineCreateInfo& 
     pipelineInfo.pStages = shaderStages.data();
     pipelineInfo.layout = layout;
 
-    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    VkResult result = vkCreateGraphicsPipelines(device, pipelineCacheHandle, 1, &pipelineInfo, nullptr, &pipeline);
     cleanupShaderModules();
 
     if (result != VK_SUCCESS) {
@@ -241,7 +247,7 @@ bool PipelineBuilder::buildGraphicsPipeline(const GraphicsPipelineConfig& config
     pipelineInfo.renderPass = config.renderPass;
     pipelineInfo.subpass = config.subpass;
 
-    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &pipeline);
+    VkResult result = vkCreateGraphicsPipelines(device, pipelineCacheHandle, 1, &pipelineInfo, nullptr, &pipeline);
     cleanupShaderModules();
 
     if (result != VK_SUCCESS) {

--- a/src/core/PipelineBuilder.h
+++ b/src/core/PipelineBuilder.h
@@ -44,6 +44,9 @@ public:
 
     PipelineBuilder& reset();
 
+    // Set pipeline cache for faster pipeline creation
+    PipelineBuilder& setPipelineCache(VkPipelineCache cache);
+
     PipelineBuilder& addDescriptorBinding(uint32_t binding, VkDescriptorType type, uint32_t count,
                                           VkShaderStageFlags stageFlags, const VkSampler* immutableSamplers = nullptr);
 
@@ -75,6 +78,7 @@ public:
 
 private:
     VkDevice device;
+    VkPipelineCache pipelineCacheHandle = VK_NULL_HANDLE;
     std::vector<VkDescriptorSetLayoutBinding> descriptorBindings;
     std::vector<VkPushConstantRange> pushConstantRanges;
     std::vector<VkPipelineShaderStageCreateInfo> shaderStages;

--- a/src/core/PipelineCache.cpp
+++ b/src/core/PipelineCache.cpp
@@ -1,0 +1,105 @@
+#include "PipelineCache.h"
+#include <SDL3/SDL.h>
+#include <fstream>
+#include <vector>
+
+bool PipelineCache::init(VkDevice dev, const std::string& filePath) {
+    device = dev;
+    cacheFilePath = filePath;
+
+    // Try to load existing cache data from file
+    std::vector<char> cacheData;
+    if (loadFromFile()) {
+        std::ifstream file(cacheFilePath, std::ios::binary | std::ios::ate);
+        if (file.is_open()) {
+            size_t fileSize = static_cast<size_t>(file.tellg());
+            cacheData.resize(fileSize);
+            file.seekg(0);
+            file.read(cacheData.data(), fileSize);
+            file.close();
+            SDL_Log("PipelineCache: Loaded %zu bytes from %s", fileSize, cacheFilePath.c_str());
+        }
+    }
+
+    VkPipelineCacheCreateInfo createInfo{};
+    createInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+    createInfo.initialDataSize = cacheData.size();
+    createInfo.pInitialData = cacheData.empty() ? nullptr : cacheData.data();
+
+    VkResult result = vkCreatePipelineCache(device, &createInfo, nullptr, &pipelineCache);
+    if (result != VK_SUCCESS) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "PipelineCache: Failed to create pipeline cache (VkResult=%d)", static_cast<int>(result));
+
+        // Try again without initial data in case cache is corrupted
+        if (!cacheData.empty()) {
+            SDL_Log("PipelineCache: Retrying without initial data");
+            createInfo.initialDataSize = 0;
+            createInfo.pInitialData = nullptr;
+            result = vkCreatePipelineCache(device, &createInfo, nullptr, &pipelineCache);
+            if (result != VK_SUCCESS) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                    "PipelineCache: Failed to create empty pipeline cache (VkResult=%d)", static_cast<int>(result));
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    SDL_Log("PipelineCache: Initialized successfully");
+    return true;
+}
+
+void PipelineCache::shutdown() {
+    if (pipelineCache != VK_NULL_HANDLE && device != VK_NULL_HANDLE) {
+        saveToFile();
+        vkDestroyPipelineCache(device, pipelineCache, nullptr);
+        pipelineCache = VK_NULL_HANDLE;
+    }
+    device = VK_NULL_HANDLE;
+}
+
+bool PipelineCache::loadFromFile() {
+    std::ifstream file(cacheFilePath, std::ios::binary);
+    return file.good();
+}
+
+bool PipelineCache::saveToFile() {
+    if (pipelineCache == VK_NULL_HANDLE || device == VK_NULL_HANDLE) {
+        return false;
+    }
+
+    // Get cache data size
+    size_t cacheSize = 0;
+    VkResult result = vkGetPipelineCacheData(device, pipelineCache, &cacheSize, nullptr);
+    if (result != VK_SUCCESS || cacheSize == 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+            "PipelineCache: No cache data to save (VkResult=%d, size=%zu)",
+            static_cast<int>(result), cacheSize);
+        return false;
+    }
+
+    // Get cache data
+    std::vector<char> cacheData(cacheSize);
+    result = vkGetPipelineCacheData(device, pipelineCache, &cacheSize, cacheData.data());
+    if (result != VK_SUCCESS) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "PipelineCache: Failed to get cache data (VkResult=%d)", static_cast<int>(result));
+        return false;
+    }
+
+    // Write to file
+    std::ofstream file(cacheFilePath, std::ios::binary);
+    if (!file.is_open()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "PipelineCache: Failed to open %s for writing", cacheFilePath.c_str());
+        return false;
+    }
+
+    file.write(cacheData.data(), cacheSize);
+    file.close();
+
+    SDL_Log("PipelineCache: Saved %zu bytes to %s", cacheSize, cacheFilePath.c_str());
+    return true;
+}

--- a/src/core/PipelineCache.h
+++ b/src/core/PipelineCache.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <string>
+
+/**
+ * PipelineCache - Manages Vulkan pipeline cache with disk persistence
+ *
+ * Pipeline caches significantly reduce shader compilation time on subsequent
+ * runs by storing driver-specific compiled pipeline data.
+ *
+ * Usage:
+ *   PipelineCache cache;
+ *   cache.init(device, "pipeline_cache.bin");
+ *   // Use cache.getCache() when creating pipelines
+ *   cache.shutdown(); // Saves cache to disk
+ */
+class PipelineCache {
+public:
+    PipelineCache() = default;
+    ~PipelineCache() = default;
+
+    // Non-copyable
+    PipelineCache(const PipelineCache&) = delete;
+    PipelineCache& operator=(const PipelineCache&) = delete;
+
+    /**
+     * Initialize the pipeline cache
+     * @param device The Vulkan device
+     * @param cacheFilePath Path to the cache file (loaded if exists)
+     * @return true on success
+     */
+    bool init(VkDevice device, const std::string& cacheFilePath = "pipeline_cache.bin");
+
+    /**
+     * Shutdown and save cache to disk
+     */
+    void shutdown();
+
+    /**
+     * Get the pipeline cache handle for use in pipeline creation
+     */
+    VkPipelineCache getCache() const { return pipelineCache; }
+
+    /**
+     * Save the current cache state to disk
+     * Can be called periodically to avoid losing cache on crash
+     * @return true on success
+     */
+    bool saveToFile();
+
+private:
+    bool loadFromFile();
+
+    VkDevice device = VK_NULL_HANDLE;
+    VkPipelineCache pipelineCache = VK_NULL_HANDLE;
+    std::string cacheFilePath;
+};

--- a/src/core/VulkanContext.cpp
+++ b/src/core/VulkanContext.cpp
@@ -10,6 +10,7 @@ bool VulkanContext::init(SDL_Window* win) {
     if (!selectPhysicalDevice()) return false;
     if (!createLogicalDevice()) return false;
     if (!createAllocator()) return false;
+    if (!createPipelineCache()) return false;
     if (!createSwapchain()) return false;
 
     return true;
@@ -21,6 +22,8 @@ void VulkanContext::shutdown() {
     }
 
     destroySwapchain();
+
+    pipelineCache.shutdown();
 
     if (allocator != VK_NULL_HANDLE) {
         vmaDestroyAllocator(allocator);
@@ -200,4 +203,8 @@ uint32_t VulkanContext::getGraphicsQueueFamily() const {
 
 uint32_t VulkanContext::getPresentQueueFamily() const {
     return vkbDevice.get_queue_index(vkb::QueueType::present).value();
+}
+
+bool VulkanContext::createPipelineCache() {
+    return pipelineCache.init(device, "pipeline_cache.bin");
 }

--- a/src/core/VulkanContext.h
+++ b/src/core/VulkanContext.h
@@ -5,6 +5,7 @@
 #include <VkBootstrap.h>
 #include <SDL3/SDL.h>
 #include <vector>
+#include "PipelineCache.h"
 
 /**
  * VulkanContext encapsulates core Vulkan setup:
@@ -43,6 +44,7 @@ public:
     uint32_t getGraphicsQueueFamily() const;
     uint32_t getPresentQueueFamily() const;
     VmaAllocator getAllocator() const { return allocator; }
+    VkPipelineCache getPipelineCache() const { return pipelineCache.getCache(); }
 
     VkSwapchainKHR getSwapchain() const { return swapchain; }
     const std::vector<VkImageView>& getSwapchainImageViews() const { return swapchainImageViews; }
@@ -60,6 +62,7 @@ private:
     bool selectPhysicalDevice();
     bool createLogicalDevice();
     bool createAllocator();
+    bool createPipelineCache();
 
     SDL_Window* window = nullptr;
 
@@ -74,6 +77,8 @@ private:
     VkQueue presentQueue = VK_NULL_HANDLE;
 
     VmaAllocator allocator = VK_NULL_HANDLE;
+
+    PipelineCache pipelineCache;
 
     VkSwapchainKHR swapchain = VK_NULL_HANDLE;
     std::vector<VkImage> swapchainImages;


### PR DESCRIPTION
- Create PipelineCache class with disk persistence (saves/loads from pipeline_cache.bin)
- Integrate pipeline cache into VulkanContext (created during init, saved on shutdown)
- Update GraphicsPipelineFactory to accept and use pipeline cache
- Update PipelineBuilder to accept and use pipeline cache for both graphics and compute pipelines

Pipeline caches store driver-specific compiled pipeline data, significantly reducing shader compilation time on subsequent application runs.