### PR TITLE
Fix inconsistent default heightScale values

### DIFF
--- a/src/core/FrameData.h
+++ b/src/core/FrameData.h
@@ -46,7 +46,7 @@ struct FrameData {
 
     // Terrain parameters (for systems that need terrain info)
     float terrainSize = 1024.0f;
-    float heightScale = 100.0f;
+    float heightScale = 0.0f;
 
     // Wind parameters (from WindSystem/EnvironmentSettings)
     glm::vec2 windDirection = glm::vec2(1.0f, 0.0f);

--- a/src/physics/PhysicsTerrainTileManager.h
+++ b/src/physics/PhysicsTerrainTileManager.h
@@ -27,7 +27,7 @@ public:
         float unloadRadius = 1200.0f;
         uint32_t maxTilesPerFrame = 2;
         float terrainSize = 16384.0f;
-        float heightScale = 235.0f;
+        float heightScale = 0.0f;
     };
 
     PhysicsTerrainTileManager() = default;

--- a/src/terrain/TerrainHeightMap.h
+++ b/src/terrain/TerrainHeightMap.h
@@ -91,7 +91,7 @@ private:
     VkQueue graphicsQueue = VK_NULL_HANDLE;
     VkCommandPool commandPool = VK_NULL_HANDLE;
     float terrainSize = 500.0f;
-    float heightScale = 50.0f;
+    float heightScale = 0.0f;
     uint32_t resolution = 512;
     uint32_t holeMaskResolution = 2048;  // Higher res for finer hole detail (~8m/texel on 16km terrain)
 

--- a/src/terrain/TerrainTileCache.h
+++ b/src/terrain/TerrainTileCache.h
@@ -216,7 +216,7 @@ private:
     // Configuration from metadata
     std::string cacheDirectory;
     float terrainSize = 16384.0f;
-    float heightScale = 235.0f;
+    float heightScale = 0.0f;
     float minAltitude = -15.0f;
     float maxAltitude = 220.0f;
     uint32_t tileResolution = 512;


### PR DESCRIPTION
Changed inconsistent default heightScale values to 0.0f to clearly indicate "not set yet" status, since actual values are always computed at runtime from config (heightScale = maxAltitude - minAltitude).