### PR TITLE
Optimize compute shader workgroup efficiency

### DIFF
--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -6,7 +6,9 @@
 #include "terrain_height_common.glsl"
 #include "instancing_common.glsl"
 
-layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+// 2D workgroup layout for better texture cache coherency - threads in the same
+// workgroup sample nearby terrain/displacement texels (16x16 = 256 threads)
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
 struct GrassInstance {
     vec4 positionAndFacing;  // xyz = position, w = facing angle
@@ -145,11 +147,14 @@ void calculateClump(vec2 worldPos, float clumpScale,
 }
 
 void main() {
-    uint idx = gl_GlobalInvocationID.x;
+    // 2D dispatch: use xy directly instead of computing from flattened index
+    // This eliminates expensive integer division/modulo and improves cache locality
+    uint gridX = gl_GlobalInvocationID.x;
+    uint gridZ = gl_GlobalInvocationID.y;
 
-    // Set vertexCount atomically
+    // Set vertexCount atomically (only first thread)
     // (buffer is pre-cleared to 0 by CPU, so atomicMax ensures it becomes 15)
-    if (idx == 0) {
+    if (gridX == 0 && gridZ == 0) {
         atomicMax(drawCmd.vertexCount, 15);  // 5 segments * 3 vertices per triangle
     }
 
@@ -158,10 +163,7 @@ void main() {
     // With 0.2m spacing = 200m x 200m area = 25 blades per square meter
     // Culling systems (distance, frustum, LOD) will reduce to ~100k rendered
     uint gridSize = 1000;
-    if (idx >= gridSize * gridSize) return;
-
-    uint gridX = idx % gridSize;
-    uint gridZ = idx / gridSize;
+    if (gridX >= gridSize || gridZ >= gridSize) return;
 
     // Map to world space (centered on origin)
     float spacing = 0.2;  // 200m x 200m coverage

--- a/src/vegetation/GrassSystem.cpp
+++ b/src/vegetation/GrassSystem.cpp
@@ -805,8 +805,10 @@ void GrassSystem::recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex
     vkCmdPushConstants(cmd, getComputePipelineHandles().pipelineLayout,
                        VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(GrassPushConstants), &grassPush);
 
-    // Dispatch: ceil(1,000,000 / 64) = 15,625 workgroups (1000x1000 grid)
-    vkCmdDispatch(cmd, 15625, 1, 1);
+    // Dispatch: 2D grid of workgroups for better texture cache coherency
+    // Grid: 1000x1000 blades, Workgroup: 16x16 threads
+    // ceil(1000/16) = 63 workgroups per dimension (63*63*256 = 1,016,064 threads)
+    vkCmdDispatch(cmd, 63, 63, 1);
 
     // Memory barrier: compute write -> vertex shader read (storage buffer) and indirect read
     // Note: This barrier ensures the compute results are visible when we draw from this buffer


### PR DESCRIPTION
Change grass.comp from 1D (64x1x1) to 2D (16x16x1) workgroup layout:
- Eliminates expensive integer division/modulo for grid coordinate calculation
- Improves texture cache coherency for heightmap and displacement sampling
- Uses gl_GlobalInvocationID.xy directly instead of computing from flattened index
- Dispatch now uses 63x63x1 instead of 15625x1x1 workgroups