### PR TITLE
Make descriptor pool sizes configurable

### DIFF
--- a/src/core/DescriptorManager.cpp
+++ b/src/core/DescriptorManager.cpp
@@ -167,8 +167,16 @@ void DescriptorManager::SetWriter::update() {
 // ============================================================================
 
 DescriptorManager::Pool::Pool(VkDevice device, uint32_t initialSetsPerPool)
-    : device(device), setsPerPool(initialSetsPerPool) {
+    : device(device), setsPerPool(initialSetsPerPool), poolSizes(DescriptorPoolSizes::standard()) {
     // Create initial pool
+    pools.push_back(createPool());
+}
+
+DescriptorManager::Pool::Pool(VkDevice device, uint32_t initialSetsPerPool, const DescriptorPoolSizes& sizes)
+    : device(device), setsPerPool(initialSetsPerPool), poolSizes(sizes) {
+    // Create initial pool with custom sizes
+    SDL_Log("DescriptorManager: Creating pool with custom sizes (UBO=%u, SSBO=%u, samplers=%u, storage=%u)",
+            sizes.uniformBuffers, sizes.storageBuffers, sizes.combinedImageSamplers, sizes.storageImages);
     pools.push_back(createPool());
 }
 

--- a/src/core/InitContext.h
+++ b/src/core/InitContext.h
@@ -36,4 +36,7 @@ struct InitContext {
     // Frame/swapchain info
     uint32_t framesInFlight = 3;
     VkExtent2D extent = {0, 0};
+
+    // Optional pool sizes hint for systems that create their own pools
+    std::optional<DescriptorPoolSizes> poolSizesHint;
 };

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -59,9 +59,16 @@ constexpr uint32_t PBR_HAS_HEIGHT_MAP    = (1u << 3);
 
 class Renderer {
 public:
+    // Configuration for renderer initialization
+    struct Config {
+        uint32_t setsPerPool = 64;
+        DescriptorPoolSizes descriptorPoolSizes = DescriptorPoolSizes::standard();
+    };
+
     struct InitInfo {
         SDL_Window* window;
         std::string resourcePath;
+        Config config{};  // Optional renderer configuration
     };
 
     /**
@@ -411,6 +418,7 @@ private:
 
     SDL_Window* window = nullptr;
     std::string resourcePath;
+    Config config_;  // Renderer configuration
 
     VulkanContext vulkanContext;
 

--- a/src/core/RendererInit.h
+++ b/src/core/RendererInit.h
@@ -73,13 +73,16 @@ public:
     /**
      * Build an InitContext from VulkanContext and common resources.
      * This is the single source of truth for creating the shared init context.
+     *
+     * @param poolSizes Optional pool sizes hint for systems that create their own pools
      */
     static InitContext buildContext(
         const VulkanContext& vulkanContext,
         VkCommandPool commandPool,
         DescriptorManager::Pool* descriptorPool,
         const std::string& resourcePath,
-        uint32_t framesInFlight
+        uint32_t framesInFlight,
+        std::optional<DescriptorPoolSizes> poolSizes = std::nullopt
     ) {
         InitContext ctx{};
         ctx.device = vulkanContext.getDevice();
@@ -92,6 +95,7 @@ public:
         ctx.resourcePath = resourcePath;
         ctx.framesInFlight = framesInFlight;
         ctx.extent = vulkanContext.getSwapchainExtent();
+        ctx.poolSizesHint = poolSizes;
         return ctx;
     }
 


### PR DESCRIPTION
Replace hard-coded PoolSizes struct with configurable DescriptorPoolSizes:
- Extract PoolSizes to public struct with builder pattern and presets
- Add minimal(), standard(), large() presets and scaled() method
- Add Pool constructor accepting custom DescriptorPoolSizes
- Add poolSizesHint to InitContext for subsystems
- Add Renderer::Config with setsPerPool and descriptorPoolSizes
- Update buildContext() to pass pool sizes hint to InitContext