### PR TITLE
Review atomicMax in GRASS

### DIFF
--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -152,10 +152,9 @@ void main() {
     uint gridX = gl_GlobalInvocationID.x;
     uint gridZ = gl_GlobalInvocationID.y;
 
-    // Set vertexCount atomically (only first thread)
-    // (buffer is pre-cleared to 0 by CPU, so atomicMax ensures it becomes 15)
+    // Set vertexCount (only first thread writes this constant value)
     if (gridX == 0 && gridZ == 0) {
-        atomicMax(drawCmd.vertexCount, 15);  // 5 segments * 3 vertices per triangle
+        drawCmd.vertexCount = 15;  // 5 segments * 3 vertices per triangle
     }
 
     // Generate grass positions in a grid pattern

--- a/shaders/instancing_common.glsl
+++ b/shaders/instancing_common.glsl
@@ -123,19 +123,21 @@ vec3 hash3D(vec3 p) {
 // ============================================================================
 // Indirect Draw Command Helpers
 // ============================================================================
-// NOTE: Atomic operations on DrawIndirectCommand fields must be done directly
-// on buffer storage variables in the shader, not through helper functions.
-// GLSL requires atomicMax/atomicAdd to operate on l-values from buffer storage.
+// Usage patterns for DrawIndirectCommand in compute shaders:
 //
-// Example usage in compute shaders:
 //   layout(std430, binding = X) buffer IndirectBuffer {
 //       DrawIndirectCommand drawCmd;
 //   };
 //
-//   // In main():
+//   // For constant values (vertexCount, instanceCount when known):
+//   // Use a single thread to write - no atomic needed
 //   if (gl_GlobalInvocationID.x == 0) {
-//       atomicMax(drawCmd.vertexCount, 4);  // Set vertex count (e.g., 4 for quad)
+//       drawCmd.vertexCount = 4;           // Constant value
+//       drawCmd.instanceCount = totalCount; // Known count
 //   }
-//   atomicMax(drawCmd.instanceCount, totalInstances);  // Set instance count
+//
+//   // For dynamic instance counting (each thread adds one instance):
+//   // Use atomicAdd to get unique slots
+//   uint slot = atomicAdd(drawCmd.instanceCount, 1);
 
 #endif // INSTANCING_COMMON_GLSL

--- a/shaders/leaf.comp
+++ b/shaders/leaf.comp
@@ -416,7 +416,7 @@ void main() {
 
     // Set vertex count for quad (4 vertices for triangle strip)
     if (idx == 0) {
-        atomicMax(drawCmd.vertexCount, 4);
+        drawCmd.vertexCount = 4;
     }
 
     float dt = push.deltaTime;
@@ -663,6 +663,8 @@ void main() {
         outputParticles[idx].flags &= ~FLAG_VISIBLE;
     }
 
-    // Update instance count
-    atomicMax(drawCmd.instanceCount, totalTarget);
+    // Update instance count (only thread 0 writes this constant value)
+    if (idx == 0) {
+        drawCmd.instanceCount = totalTarget;
+    }
 }

--- a/shaders/weather.comp
+++ b/shaders/weather.comp
@@ -241,7 +241,7 @@ void main() {
 
     // Set vertex count for quad (4 vertices for triangle strip)
     if (idx == 0) {
-        atomicMax(drawCmd.vertexCount, 4);
+        drawCmd.vertexCount = 4;
     }
 
     // Calculate target particle count based on intensity
@@ -360,6 +360,8 @@ void main() {
         outputParticles[idx].flags &= ~2u;  // Clear visible bit
     }
 
-    // Set instance count to target particles
-    atomicMax(drawCmd.instanceCount, targetParticles);
+    // Set instance count (only thread 0 writes this constant value)
+    if (idx == 0) {
+        drawCmd.instanceCount = targetParticles;
+    }
 }


### PR DESCRIPTION
- grass.comp: vertexCount only written by thread (0,0), no race condition
- leaf.comp: vertexCount and instanceCount only need single-threaded writes
- weather.comp: same pattern as leaf.comp
- instancing_common.glsl: updated documentation with correct usage patterns

atomicMax adds unnecessary overhead when only one thread writes a value. Use atomicAdd when each thread needs a unique slot (as grass.comp does correctly for instanceCount).