### PR TITLE
Add BCn texture compression and loading support

### DIFF
--- a/src/core/DDSLoader.h
+++ b/src/core/DDSLoader.h
@@ -1,0 +1,258 @@
+// DDS (DirectDraw Surface) File Format Loader
+// Supports BC1, BC4, BC5, and BC7 compressed textures
+
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <fstream>
+
+namespace DDSLoader {
+
+// DDS file magic number
+constexpr uint32_t DDS_MAGIC = 0x20534444; // "DDS "
+
+// Pixel format flags
+constexpr uint32_t DDPF_FOURCC = 0x00000004;
+
+// FourCC codes
+constexpr uint32_t FOURCC_DXT1 = 0x31545844; // "DXT1" - BC1
+constexpr uint32_t FOURCC_ATI1 = 0x31495441; // "ATI1" - BC4
+constexpr uint32_t FOURCC_ATI2 = 0x32495441; // "ATI2" - BC5
+constexpr uint32_t FOURCC_DX10 = 0x30315844; // "DX10" - Extended header
+
+// DXGI formats
+enum class DXGIFormat : uint32_t {
+    UNKNOWN                = 0,
+    BC1_UNORM              = 71,
+    BC1_UNORM_SRGB         = 72,
+    BC4_UNORM              = 80,
+    BC4_SNORM              = 81,
+    BC5_UNORM              = 83,
+    BC5_SNORM              = 84,
+    BC7_UNORM              = 98,
+    BC7_UNORM_SRGB         = 99,
+};
+
+enum class ResourceDimension : uint32_t {
+    UNKNOWN   = 0,
+    BUFFER    = 1,
+    TEXTURE1D = 2,
+    TEXTURE2D = 3,
+    TEXTURE3D = 4,
+};
+
+#pragma pack(push, 1)
+
+struct PixelFormat {
+    uint32_t size;
+    uint32_t flags;
+    uint32_t fourCC;
+    uint32_t rgbBitCount;
+    uint32_t rBitMask;
+    uint32_t gBitMask;
+    uint32_t bBitMask;
+    uint32_t aBitMask;
+};
+
+struct Header {
+    uint32_t size;
+    uint32_t flags;
+    uint32_t height;
+    uint32_t width;
+    uint32_t pitchOrLinearSize;
+    uint32_t depth;
+    uint32_t mipMapCount;
+    uint32_t reserved1[11];
+    PixelFormat pixelFormat;
+    uint32_t caps;
+    uint32_t caps2;
+    uint32_t caps3;
+    uint32_t caps4;
+    uint32_t reserved2;
+};
+
+struct HeaderDX10 {
+    DXGIFormat dxgiFormat;
+    ResourceDimension resourceDimension;
+    uint32_t miscFlag;
+    uint32_t arraySize;
+    uint32_t miscFlags2;
+};
+
+#pragma pack(pop)
+
+// Loaded DDS image
+struct Image {
+    uint32_t width;
+    uint32_t height;
+    uint32_t mipLevels;
+    VkFormat format;
+    uint32_t blockSize;  // Bytes per 4x4 block
+    std::vector<uint8_t> data;
+
+    bool isValid() const { return !data.empty() && format != VK_FORMAT_UNDEFINED; }
+
+    // Calculate size of a mip level
+    uint32_t getMipSize(uint32_t level) const {
+        uint32_t mipWidth = std::max(1u, width >> level);
+        uint32_t mipHeight = std::max(1u, height >> level);
+        uint32_t blockWidth = (mipWidth + 3) / 4;
+        uint32_t blockHeight = (mipHeight + 3) / 4;
+        return blockWidth * blockHeight * blockSize;
+    }
+
+    // Get offset to a mip level in data
+    uint32_t getMipOffset(uint32_t level) const {
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < level; i++) {
+            offset += getMipSize(i);
+        }
+        return offset;
+    }
+
+    // Get dimensions of a mip level
+    void getMipDimensions(uint32_t level, uint32_t& w, uint32_t& h) const {
+        w = std::max(1u, width >> level);
+        h = std::max(1u, height >> level);
+    }
+};
+
+// Get block size for Vulkan BCn format
+inline uint32_t getBlockSize(VkFormat format) {
+    switch (format) {
+        case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+        case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+        case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+        case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+        case VK_FORMAT_BC4_UNORM_BLOCK:
+        case VK_FORMAT_BC4_SNORM_BLOCK:
+            return 8;
+        case VK_FORMAT_BC5_UNORM_BLOCK:
+        case VK_FORMAT_BC5_SNORM_BLOCK:
+        case VK_FORMAT_BC7_UNORM_BLOCK:
+        case VK_FORMAT_BC7_SRGB_BLOCK:
+            return 16;
+        default:
+            return 0;
+    }
+}
+
+// Check if format is a BCn compressed format
+inline bool isBCFormat(VkFormat format) {
+    return getBlockSize(format) > 0;
+}
+
+// Read a DDS file
+inline Image load(const std::string& path) {
+    Image result{};
+    result.format = VK_FORMAT_UNDEFINED;
+    result.blockSize = 0;
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        return result;
+    }
+
+    // Read and verify magic
+    uint32_t magic;
+    file.read(reinterpret_cast<char*>(&magic), 4);
+    if (magic != DDS_MAGIC) {
+        return result;
+    }
+
+    // Read header
+    Header header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+
+    if (header.size != 124 || header.pixelFormat.size != 32) {
+        return result;
+    }
+
+    result.width = header.width;
+    result.height = header.height;
+    result.mipLevels = std::max(1u, header.mipMapCount);
+
+    // Determine format
+    bool hasDX10 = (header.pixelFormat.flags & DDPF_FOURCC) &&
+                   (header.pixelFormat.fourCC == FOURCC_DX10);
+
+    if (hasDX10) {
+        HeaderDX10 dx10Header;
+        file.read(reinterpret_cast<char*>(&dx10Header), sizeof(dx10Header));
+
+        switch (dx10Header.dxgiFormat) {
+            case DXGIFormat::BC1_UNORM:
+                result.format = VK_FORMAT_BC1_RGB_UNORM_BLOCK;
+                break;
+            case DXGIFormat::BC1_UNORM_SRGB:
+                result.format = VK_FORMAT_BC1_RGB_SRGB_BLOCK;
+                break;
+            case DXGIFormat::BC4_UNORM:
+                result.format = VK_FORMAT_BC4_UNORM_BLOCK;
+                break;
+            case DXGIFormat::BC4_SNORM:
+                result.format = VK_FORMAT_BC4_SNORM_BLOCK;
+                break;
+            case DXGIFormat::BC5_UNORM:
+                result.format = VK_FORMAT_BC5_UNORM_BLOCK;
+                break;
+            case DXGIFormat::BC5_SNORM:
+                result.format = VK_FORMAT_BC5_SNORM_BLOCK;
+                break;
+            case DXGIFormat::BC7_UNORM:
+                result.format = VK_FORMAT_BC7_UNORM_BLOCK;
+                break;
+            case DXGIFormat::BC7_UNORM_SRGB:
+                result.format = VK_FORMAT_BC7_SRGB_BLOCK;
+                break;
+            default:
+                return result;
+        }
+    } else if (header.pixelFormat.flags & DDPF_FOURCC) {
+        switch (header.pixelFormat.fourCC) {
+            case FOURCC_DXT1:
+                result.format = VK_FORMAT_BC1_RGB_UNORM_BLOCK;
+                break;
+            case FOURCC_ATI1:
+                result.format = VK_FORMAT_BC4_UNORM_BLOCK;
+                break;
+            case FOURCC_ATI2:
+                result.format = VK_FORMAT_BC5_UNORM_BLOCK;
+                break;
+            default:
+                return result;
+        }
+    } else {
+        return result;
+    }
+
+    result.blockSize = getBlockSize(result.format);
+
+    // Calculate total data size (all mip levels)
+    uint32_t totalSize = 0;
+    uint32_t mipWidth = result.width;
+    uint32_t mipHeight = result.height;
+    for (uint32_t i = 0; i < result.mipLevels; i++) {
+        uint32_t blockWidth = (mipWidth + 3) / 4;
+        uint32_t blockHeight = (mipHeight + 3) / 4;
+        totalSize += blockWidth * blockHeight * result.blockSize;
+        mipWidth = std::max(1u, mipWidth / 2);
+        mipHeight = std::max(1u, mipHeight / 2);
+    }
+
+    // Read data
+    result.data.resize(totalSize);
+    file.read(reinterpret_cast<char*>(result.data.data()), totalSize);
+
+    if (!file.good()) {
+        result.data.clear();
+        result.format = VK_FORMAT_UNDEFINED;
+    }
+
+    return result;
+}
+
+} // namespace DDSLoader

--- a/src/core/Texture.h
+++ b/src/core/Texture.h
@@ -21,6 +21,8 @@ public:
     VkSampler getSampler() const { return sampler; }
 
 private:
+    bool loadDDS(const std::string& path, VmaAllocator allocator, VkDevice device,
+                 VkCommandPool commandPool, VkQueue queue, bool useSRGB);
     bool transitionImageLayout(VkDevice device, VkCommandPool commandPool, VkQueue queue,
                                VkImage image, VkImageLayout oldLayout, VkImageLayout newLayout);
     bool copyBufferToImage(VkDevice device, VkCommandPool commandPool, VkQueue queue,

--- a/src/terrain/VirtualTextureSystem.cpp
+++ b/src/terrain/VirtualTextureSystem.cpp
@@ -232,7 +232,7 @@ void VirtualTextureSystem::recordPendingTileUploads(VkCommandBuffer cmd, uint32_
         // This uses per-frame staging buffers to avoid race conditions
         (*cache)->recordTileUpload(tile.id, tile.pixels.data(),
                                    tile.width, tile.height,
-                                   cmd, frameIndex);
+                                   tile.format, cmd, frameIndex);
 
         // Update page table (CPU-side, will be uploaded via recordUpload)
         uint32_t slotsPerAxis = config.getCacheTilesPerAxis();

--- a/src/terrain/VirtualTextureTileLoader.h
+++ b/src/terrain/VirtualTextureTileLoader.h
@@ -119,7 +119,7 @@ private:
 
     void workerLoop();
     bool loadTileFromDisk(TileId id, LoadedTile& tile);
-    std::string getTilePath(TileId id) const;
+    std::string getTilePath(TileId id, bool dds = false) const;
 };
 
 } // namespace VirtualTexture

--- a/src/terrain/VirtualTextureTypes.h
+++ b/src/terrain/VirtualTextureTypes.h
@@ -102,15 +102,47 @@ struct FeedbackEntry {
     }
 };
 
+// Tile compression format
+enum class TileFormat : uint8_t {
+    RGBA8 = 0,      // Uncompressed RGBA8
+    BC1 = 1,        // BC1/DXT1 compressed (RGB, 4bpp)
+    BC1_SRGB = 2,   // BC1 sRGB
+    BC4 = 3,        // BC4 compressed (single channel, 4bpp)
+    BC5 = 4,        // BC5 compressed (two channels, 8bpp)
+    BC7 = 5,        // BC7 compressed (RGBA, 8bpp)
+    BC7_SRGB = 6    // BC7 sRGB
+};
+
 // Loaded tile data ready for upload
 struct LoadedTile {
     TileId id;
-    std::vector<uint8_t> pixels;    // RGBA8 data
+    std::vector<uint8_t> pixels;    // RGBA8 or compressed data
     uint32_t width = 0;
     uint32_t height = 0;
+    TileFormat format = TileFormat::RGBA8;
 
     bool isValid() const {
         return !pixels.empty() && width > 0 && height > 0;
+    }
+
+    bool isCompressed() const {
+        return format != TileFormat::RGBA8;
+    }
+
+    // Get bytes per 4x4 block for compressed formats
+    uint32_t getBlockSize() const {
+        switch (format) {
+            case TileFormat::BC1:
+            case TileFormat::BC1_SRGB:
+            case TileFormat::BC4:
+                return 8;
+            case TileFormat::BC5:
+            case TileFormat::BC7:
+            case TileFormat::BC7_SRGB:
+                return 16;
+            default:
+                return 0;
+        }
     }
 };
 

--- a/tools/common/bc_compress.h
+++ b/tools/common/bc_compress.h
@@ -1,0 +1,404 @@
+// BCn Texture Compression Utilities
+// BC1: RGB compression (4 bpp) - good for albedo textures
+// BC4: Single channel compression (4 bpp) - good for grayscale
+// BC5: Two channel compression (8 bpp) - good for normal maps
+// BC7: High quality RGBA compression (8 bpp) - best quality
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace BCCompress {
+
+// Block size constants
+constexpr uint32_t BLOCK_SIZE = 4;
+constexpr uint32_t BC1_BLOCK_BYTES = 8;
+constexpr uint32_t BC4_BLOCK_BYTES = 8;
+constexpr uint32_t BC5_BLOCK_BYTES = 16;
+constexpr uint32_t BC7_BLOCK_BYTES = 16;
+
+// Color utilities
+inline uint16_t packRGB565(uint8_t r, uint8_t g, uint8_t b) {
+    return static_cast<uint16_t>(((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3));
+}
+
+inline void unpackRGB565(uint16_t c, uint8_t& r, uint8_t& g, uint8_t& b) {
+    r = static_cast<uint8_t>(((c >> 11) & 0x1F) * 255 / 31);
+    g = static_cast<uint8_t>(((c >> 5) & 0x3F) * 255 / 63);
+    b = static_cast<uint8_t>((c & 0x1F) * 255 / 31);
+}
+
+// Simple color distance for endpoint selection
+inline int colorDistance(const uint8_t* c1, const uint8_t* c2) {
+    int dr = static_cast<int>(c1[0]) - static_cast<int>(c2[0]);
+    int dg = static_cast<int>(c1[1]) - static_cast<int>(c2[1]);
+    int db = static_cast<int>(c1[2]) - static_cast<int>(c2[2]);
+    return dr * dr + dg * dg + db * db;
+}
+
+// Compress a 4x4 block to BC1 format
+// pixels: 16 pixels, 4 bytes each (RGBA)
+// output: 8 bytes BC1 compressed block
+inline void compressBlockBC1(const uint8_t* pixels, uint8_t* output) {
+    // Find min/max colors in the block
+    uint8_t minColor[3] = {255, 255, 255};
+    uint8_t maxColor[3] = {0, 0, 0};
+
+    for (int i = 0; i < 16; i++) {
+        const uint8_t* p = pixels + i * 4;
+        for (int c = 0; c < 3; c++) {
+            minColor[c] = std::min(minColor[c], p[c]);
+            maxColor[c] = std::max(maxColor[c], p[c]);
+        }
+    }
+
+    // Inset the bounding box to improve quality
+    uint8_t inset[3];
+    for (int c = 0; c < 3; c++) {
+        int range = maxColor[c] - minColor[c];
+        int insetVal = range >> 4;
+        minColor[c] = static_cast<uint8_t>(std::min(255, minColor[c] + insetVal));
+        maxColor[c] = static_cast<uint8_t>(std::max(0, maxColor[c] - insetVal));
+    }
+
+    uint16_t c0 = packRGB565(maxColor[0], maxColor[1], maxColor[2]);
+    uint16_t c1 = packRGB565(minColor[0], minColor[1], minColor[2]);
+
+    // Ensure c0 > c1 for 4-color mode
+    if (c0 < c1) {
+        std::swap(c0, c1);
+        std::swap(maxColor[0], minColor[0]);
+        std::swap(maxColor[1], minColor[1]);
+        std::swap(maxColor[2], minColor[2]);
+    }
+
+    // Write endpoint colors
+    output[0] = c0 & 0xFF;
+    output[1] = (c0 >> 8) & 0xFF;
+    output[2] = c1 & 0xFF;
+    output[3] = (c1 >> 8) & 0xFF;
+
+    // Calculate palette colors (4-color mode: c0 > c1)
+    uint8_t palette[4][3];
+    for (int c = 0; c < 3; c++) {
+        palette[0][c] = maxColor[c];
+        palette[1][c] = minColor[c];
+        palette[2][c] = static_cast<uint8_t>((2 * maxColor[c] + minColor[c] + 1) / 3);
+        palette[3][c] = static_cast<uint8_t>((maxColor[c] + 2 * minColor[c] + 1) / 3);
+    }
+
+    // Encode indices
+    uint32_t indices = 0;
+    for (int i = 0; i < 16; i++) {
+        const uint8_t* p = pixels + i * 4;
+
+        // Find closest palette color
+        int bestIdx = 0;
+        int bestDist = colorDistance(p, palette[0]);
+        for (int j = 1; j < 4; j++) {
+            int dist = colorDistance(p, palette[j]);
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = j;
+            }
+        }
+
+        indices |= (bestIdx << (i * 2));
+    }
+
+    output[4] = indices & 0xFF;
+    output[5] = (indices >> 8) & 0xFF;
+    output[6] = (indices >> 16) & 0xFF;
+    output[7] = (indices >> 24) & 0xFF;
+}
+
+// Compress a 4x4 block to BC4 format (single channel)
+// pixels: 16 single-channel values
+// output: 8 bytes BC4 compressed block
+inline void compressBlockBC4(const uint8_t* pixels, uint8_t* output) {
+    // Find min/max values
+    uint8_t minVal = 255;
+    uint8_t maxVal = 0;
+
+    for (int i = 0; i < 16; i++) {
+        minVal = std::min(minVal, pixels[i]);
+        maxVal = std::max(maxVal, pixels[i]);
+    }
+
+    // Write endpoints
+    output[0] = maxVal;
+    output[1] = minVal;
+
+    // Calculate palette (8 values when alpha0 > alpha1)
+    uint8_t palette[8];
+    palette[0] = maxVal;
+    palette[1] = minVal;
+
+    if (maxVal > minVal) {
+        for (int i = 1; i < 7; i++) {
+            palette[i + 1] = static_cast<uint8_t>(((7 - i) * maxVal + i * minVal + 3) / 7);
+        }
+    } else {
+        for (int i = 1; i < 5; i++) {
+            palette[i + 1] = static_cast<uint8_t>(((5 - i) * maxVal + i * minVal + 2) / 5);
+        }
+        palette[6] = 0;
+        palette[7] = 255;
+    }
+
+    // Encode 3-bit indices (48 bits = 6 bytes)
+    uint64_t indices = 0;
+    for (int i = 0; i < 16; i++) {
+        uint8_t val = pixels[i];
+
+        // Find closest palette value
+        int bestIdx = 0;
+        int bestDist = std::abs(static_cast<int>(val) - static_cast<int>(palette[0]));
+        for (int j = 1; j < 8; j++) {
+            int dist = std::abs(static_cast<int>(val) - static_cast<int>(palette[j]));
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = j;
+            }
+        }
+
+        indices |= (static_cast<uint64_t>(bestIdx) << (i * 3));
+    }
+
+    // Write 6 bytes of indices
+    for (int i = 0; i < 6; i++) {
+        output[2 + i] = static_cast<uint8_t>((indices >> (i * 8)) & 0xFF);
+    }
+}
+
+// Compress a 4x4 block to BC5 format (two channels, e.g., for normal maps)
+// pixels: 16 pixels, 4 bytes each (RGBA, uses R and G)
+// output: 16 bytes BC5 compressed block
+inline void compressBlockBC5(const uint8_t* pixels, uint8_t* output) {
+    // Extract R and G channels
+    uint8_t redChannel[16];
+    uint8_t greenChannel[16];
+
+    for (int i = 0; i < 16; i++) {
+        redChannel[i] = pixels[i * 4 + 0];
+        greenChannel[i] = pixels[i * 4 + 1];
+    }
+
+    // Compress each channel with BC4
+    compressBlockBC4(redChannel, output);
+    compressBlockBC4(greenChannel, output + 8);
+}
+
+// BC7 Mode 6 compression (high quality RGBA)
+// This is a simplified single-mode encoder for quality
+inline void compressBlockBC7Mode6(const uint8_t* pixels, uint8_t* output) {
+    // Mode 6: 4 subsets, 7 bits color, 7 bits alpha, 4-bit indices
+    // For simplicity, we use a basic BC7 mode 6 encoding
+
+    // Find RGBA endpoints
+    uint8_t minColor[4] = {255, 255, 255, 255};
+    uint8_t maxColor[4] = {0, 0, 0, 0};
+
+    for (int i = 0; i < 16; i++) {
+        const uint8_t* p = pixels + i * 4;
+        for (int c = 0; c < 4; c++) {
+            minColor[c] = std::min(minColor[c], p[c]);
+            maxColor[c] = std::max(maxColor[c], p[c]);
+        }
+    }
+
+    // Clear output
+    std::memset(output, 0, 16);
+
+    // Mode 6: bit 6 set (0b01000000 = 0x40)
+    output[0] = 0x40;
+
+    // Quantize endpoints to 7 bits
+    uint8_t ep0[4], ep1[4];
+    for (int c = 0; c < 4; c++) {
+        ep0[c] = maxColor[c] >> 1;
+        ep1[c] = minColor[c] >> 1;
+    }
+
+    // Pack endpoints (7 bits each, 4 channels, 2 endpoints = 56 bits)
+    // Bit layout for Mode 6:
+    // Bits 0-6: mode (6 = 0b0100000)
+    // Bits 7-13: R0, Bits 14-20: R1
+    // Bits 21-27: G0, Bits 28-34: G1
+    // Bits 35-41: B0, Bits 42-48: B1
+    // Bits 49-55: A0, Bits 56-62: A1
+    // Bits 63: P-bit
+    // Bits 64-127: 4-bit indices
+
+    uint64_t lo = 0x40; // Mode 6
+    lo |= (static_cast<uint64_t>(ep0[0] & 0x7F) << 7);
+    lo |= (static_cast<uint64_t>(ep1[0] & 0x7F) << 14);
+    lo |= (static_cast<uint64_t>(ep0[1] & 0x7F) << 21);
+    lo |= (static_cast<uint64_t>(ep1[1] & 0x7F) << 28);
+    lo |= (static_cast<uint64_t>(ep0[2] & 0x7F) << 35);
+    lo |= (static_cast<uint64_t>(ep1[2] & 0x7F) << 42);
+    lo |= (static_cast<uint64_t>(ep0[3] & 0x7F) << 49);
+    lo |= (static_cast<uint64_t>(ep1[3] & 0x7F) << 56);
+
+    // P-bit at bit 63
+    lo |= (static_cast<uint64_t>(1) << 63);
+
+    // Calculate palette (16 values with linear interpolation)
+    int palette[16][4];
+    for (int c = 0; c < 4; c++) {
+        int e0 = (ep0[c] << 1) | 1;
+        int e1 = (ep1[c] << 1) | 1;
+        for (int i = 0; i < 16; i++) {
+            palette[i][c] = ((15 - i) * e0 + i * e1 + 7) / 15;
+        }
+    }
+
+    // Find best indices for each pixel
+    uint64_t hi = 0;
+    for (int i = 0; i < 16; i++) {
+        const uint8_t* p = pixels + i * 4;
+
+        int bestIdx = 0;
+        int bestDist = INT32_MAX;
+        for (int j = 0; j < 16; j++) {
+            int dist = 0;
+            for (int c = 0; c < 4; c++) {
+                int d = static_cast<int>(p[c]) - palette[j][c];
+                dist += d * d;
+            }
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestIdx = j;
+            }
+        }
+
+        hi |= (static_cast<uint64_t>(bestIdx) << (i * 4));
+    }
+
+    // Write output
+    std::memcpy(output, &lo, 8);
+    std::memcpy(output + 8, &hi, 8);
+}
+
+// High-level compression functions
+
+struct CompressedImage {
+    std::vector<uint8_t> data;
+    uint32_t width;
+    uint32_t height;
+    uint32_t blockWidth;  // Width in blocks
+    uint32_t blockHeight; // Height in blocks
+};
+
+enum class BCFormat {
+    BC1,  // RGB, 4 bpp
+    BC4,  // R, 4 bpp
+    BC5,  // RG, 8 bpp (normal maps)
+    BC7   // RGBA, 8 bpp (high quality)
+};
+
+// Get bytes per block for format
+inline uint32_t getBytesPerBlock(BCFormat format) {
+    switch (format) {
+        case BCFormat::BC1: return BC1_BLOCK_BYTES;
+        case BCFormat::BC4: return BC4_BLOCK_BYTES;
+        case BCFormat::BC5: return BC5_BLOCK_BYTES;
+        case BCFormat::BC7: return BC7_BLOCK_BYTES;
+        default: return 0;
+    }
+}
+
+// Compress RGBA image to BCn format
+// Input: RGBA pixels (4 bytes per pixel)
+// Returns: Compressed image data
+inline CompressedImage compressImage(const uint8_t* pixels, uint32_t width, uint32_t height, BCFormat format) {
+    CompressedImage result;
+    result.width = width;
+    result.height = height;
+    result.blockWidth = (width + 3) / 4;
+    result.blockHeight = (height + 3) / 4;
+
+    uint32_t bytesPerBlock = getBytesPerBlock(format);
+    result.data.resize(result.blockWidth * result.blockHeight * bytesPerBlock);
+
+    uint8_t blockPixels[16 * 4]; // 4x4 block, RGBA
+
+    for (uint32_t by = 0; by < result.blockHeight; by++) {
+        for (uint32_t bx = 0; bx < result.blockWidth; bx++) {
+            // Extract 4x4 block (with clamping at edges)
+            for (uint32_t py = 0; py < 4; py++) {
+                for (uint32_t px = 0; px < 4; px++) {
+                    uint32_t srcX = std::min(bx * 4 + px, width - 1);
+                    uint32_t srcY = std::min(by * 4 + py, height - 1);
+                    const uint8_t* src = pixels + (srcY * width + srcX) * 4;
+                    uint8_t* dst = blockPixels + (py * 4 + px) * 4;
+                    std::memcpy(dst, src, 4);
+                }
+            }
+
+            // Compress block
+            uint8_t* output = result.data.data() + (by * result.blockWidth + bx) * bytesPerBlock;
+
+            switch (format) {
+                case BCFormat::BC1:
+                    compressBlockBC1(blockPixels, output);
+                    break;
+                case BCFormat::BC4: {
+                    // Extract red channel only
+                    uint8_t redChannel[16];
+                    for (int i = 0; i < 16; i++) {
+                        redChannel[i] = blockPixels[i * 4];
+                    }
+                    compressBlockBC4(redChannel, output);
+                    break;
+                }
+                case BCFormat::BC5:
+                    compressBlockBC5(blockPixels, output);
+                    break;
+                case BCFormat::BC7:
+                    compressBlockBC7Mode6(blockPixels, output);
+                    break;
+            }
+        }
+    }
+
+    return result;
+}
+
+// Decompress BC1 block for verification/preview
+inline void decompressBlockBC1(const uint8_t* input, uint8_t* pixels) {
+    uint16_t c0 = input[0] | (input[1] << 8);
+    uint16_t c1 = input[2] | (input[3] << 8);
+    uint32_t indices = input[4] | (input[5] << 8) | (input[6] << 16) | (input[7] << 24);
+
+    uint8_t palette[4][4];
+    unpackRGB565(c0, palette[0][0], palette[0][1], palette[0][2]);
+    unpackRGB565(c1, palette[1][0], palette[1][1], palette[1][2]);
+    palette[0][3] = palette[1][3] = 255;
+
+    if (c0 > c1) {
+        for (int c = 0; c < 3; c++) {
+            palette[2][c] = static_cast<uint8_t>((2 * palette[0][c] + palette[1][c] + 1) / 3);
+            palette[3][c] = static_cast<uint8_t>((palette[0][c] + 2 * palette[1][c] + 1) / 3);
+        }
+        palette[2][3] = palette[3][3] = 255;
+    } else {
+        for (int c = 0; c < 3; c++) {
+            palette[2][c] = static_cast<uint8_t>((palette[0][c] + palette[1][c]) / 2);
+        }
+        palette[2][3] = 255;
+        palette[3][0] = palette[3][1] = palette[3][2] = 0;
+        palette[3][3] = 0; // Transparent black
+    }
+
+    for (int i = 0; i < 16; i++) {
+        int idx = (indices >> (i * 2)) & 3;
+        std::memcpy(pixels + i * 4, palette[idx], 4);
+    }
+}
+
+} // namespace BCCompress

--- a/tools/common/dds_file.h
+++ b/tools/common/dds_file.h
@@ -1,0 +1,342 @@
+// DDS (DirectDraw Surface) File Format Reader/Writer
+// Supports BC1, BC4, BC5, and BC7 compressed textures
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <cstring>
+
+namespace DDS {
+
+// DDS file magic number
+constexpr uint32_t DDS_MAGIC = 0x20534444; // "DDS "
+
+// Pixel format flags
+constexpr uint32_t DDPF_FOURCC = 0x00000004;
+
+// Header flags
+constexpr uint32_t DDSD_CAPS        = 0x00000001;
+constexpr uint32_t DDSD_HEIGHT      = 0x00000002;
+constexpr uint32_t DDSD_WIDTH       = 0x00000004;
+constexpr uint32_t DDSD_PIXELFORMAT = 0x00001000;
+constexpr uint32_t DDSD_MIPMAPCOUNT = 0x00020000;
+constexpr uint32_t DDSD_LINEARSIZE  = 0x00080000;
+
+// Caps flags
+constexpr uint32_t DDSCAPS_TEXTURE = 0x00001000;
+
+// FourCC codes
+constexpr uint32_t FOURCC_DXT1 = 0x31545844; // "DXT1" - BC1
+constexpr uint32_t FOURCC_ATI1 = 0x31495441; // "ATI1" - BC4
+constexpr uint32_t FOURCC_ATI2 = 0x32495441; // "ATI2" - BC5
+constexpr uint32_t FOURCC_DX10 = 0x30315844; // "DX10" - Extended header
+
+// DXGI formats (for DX10 extended header)
+enum class DXGIFormat : uint32_t {
+    UNKNOWN                = 0,
+    BC1_UNORM              = 71,
+    BC1_UNORM_SRGB         = 72,
+    BC4_UNORM              = 80,
+    BC4_SNORM              = 81,
+    BC5_UNORM              = 83,
+    BC5_SNORM              = 84,
+    BC7_UNORM              = 98,
+    BC7_UNORM_SRGB         = 99,
+};
+
+// Resource dimension
+enum class ResourceDimension : uint32_t {
+    UNKNOWN   = 0,
+    BUFFER    = 1,
+    TEXTURE1D = 2,
+    TEXTURE2D = 3,
+    TEXTURE3D = 4,
+};
+
+#pragma pack(push, 1)
+
+struct PixelFormat {
+    uint32_t size;
+    uint32_t flags;
+    uint32_t fourCC;
+    uint32_t rgbBitCount;
+    uint32_t rBitMask;
+    uint32_t gBitMask;
+    uint32_t bBitMask;
+    uint32_t aBitMask;
+};
+
+struct Header {
+    uint32_t size;
+    uint32_t flags;
+    uint32_t height;
+    uint32_t width;
+    uint32_t pitchOrLinearSize;
+    uint32_t depth;
+    uint32_t mipMapCount;
+    uint32_t reserved1[11];
+    PixelFormat pixelFormat;
+    uint32_t caps;
+    uint32_t caps2;
+    uint32_t caps3;
+    uint32_t caps4;
+    uint32_t reserved2;
+};
+
+struct HeaderDX10 {
+    DXGIFormat dxgiFormat;
+    ResourceDimension resourceDimension;
+    uint32_t miscFlag;
+    uint32_t arraySize;
+    uint32_t miscFlags2;
+};
+
+#pragma pack(pop)
+
+// BC format enumeration
+enum class Format {
+    BC1,
+    BC1_SRGB,
+    BC4,
+    BC5,
+    BC7,
+    BC7_SRGB,
+    UNKNOWN
+};
+
+// Get bytes per block for format
+inline uint32_t getBytesPerBlock(Format format) {
+    switch (format) {
+        case Format::BC1:
+        case Format::BC1_SRGB:
+        case Format::BC4:
+            return 8;
+        case Format::BC5:
+        case Format::BC7:
+        case Format::BC7_SRGB:
+            return 16;
+        default:
+            return 0;
+    }
+}
+
+// Calculate data size for a mip level
+inline uint32_t calculateMipSize(uint32_t width, uint32_t height, Format format) {
+    uint32_t blockWidth = (width + 3) / 4;
+    uint32_t blockHeight = (height + 3) / 4;
+    return blockWidth * blockHeight * getBytesPerBlock(format);
+}
+
+// Loaded DDS image
+struct Image {
+    uint32_t width;
+    uint32_t height;
+    uint32_t mipLevels;
+    Format format;
+    std::vector<uint8_t> data;
+
+    bool isValid() const { return !data.empty() && format != Format::UNKNOWN; }
+};
+
+// Write a DDS file
+inline bool write(const std::string& path, uint32_t width, uint32_t height,
+                  Format format, const void* data, uint32_t dataSize) {
+    std::ofstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    // Write magic
+    uint32_t magic = DDS_MAGIC;
+    file.write(reinterpret_cast<const char*>(&magic), 4);
+
+    // Prepare header
+    Header header{};
+    header.size = 124;
+    header.flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT | DDSD_LINEARSIZE;
+    header.height = height;
+    header.width = width;
+    header.pitchOrLinearSize = dataSize;
+    header.depth = 1;
+    header.mipMapCount = 1;
+    header.caps = DDSCAPS_TEXTURE;
+
+    // Pixel format
+    header.pixelFormat.size = 32;
+    header.pixelFormat.flags = DDPF_FOURCC;
+
+    bool useDX10 = (format == Format::BC7 || format == Format::BC7_SRGB);
+
+    if (useDX10) {
+        header.pixelFormat.fourCC = FOURCC_DX10;
+    } else {
+        switch (format) {
+            case Format::BC1:
+            case Format::BC1_SRGB:
+                header.pixelFormat.fourCC = FOURCC_DXT1;
+                break;
+            case Format::BC4:
+                header.pixelFormat.fourCC = FOURCC_ATI1;
+                break;
+            case Format::BC5:
+                header.pixelFormat.fourCC = FOURCC_ATI2;
+                break;
+            default:
+                return false;
+        }
+    }
+
+    file.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    // Write DX10 header if needed
+    if (useDX10) {
+        HeaderDX10 dx10Header{};
+        dx10Header.resourceDimension = ResourceDimension::TEXTURE2D;
+        dx10Header.arraySize = 1;
+
+        switch (format) {
+            case Format::BC7:
+                dx10Header.dxgiFormat = DXGIFormat::BC7_UNORM;
+                break;
+            case Format::BC7_SRGB:
+                dx10Header.dxgiFormat = DXGIFormat::BC7_UNORM_SRGB;
+                break;
+            default:
+                break;
+        }
+
+        file.write(reinterpret_cast<const char*>(&dx10Header), sizeof(dx10Header));
+    }
+
+    // Write data
+    file.write(reinterpret_cast<const char*>(data), dataSize);
+
+    return file.good();
+}
+
+// Read a DDS file
+inline Image read(const std::string& path) {
+    Image result{};
+    result.format = Format::UNKNOWN;
+
+    std::ifstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        return result;
+    }
+
+    // Read and verify magic
+    uint32_t magic;
+    file.read(reinterpret_cast<char*>(&magic), 4);
+    if (magic != DDS_MAGIC) {
+        return result;
+    }
+
+    // Read header
+    Header header;
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+
+    if (header.size != 124 || header.pixelFormat.size != 32) {
+        return result;
+    }
+
+    result.width = header.width;
+    result.height = header.height;
+    result.mipLevels = std::max(1u, header.mipMapCount);
+
+    // Determine format
+    bool hasDX10 = (header.pixelFormat.flags & DDPF_FOURCC) &&
+                   (header.pixelFormat.fourCC == FOURCC_DX10);
+
+    if (hasDX10) {
+        HeaderDX10 dx10Header;
+        file.read(reinterpret_cast<char*>(&dx10Header), sizeof(dx10Header));
+
+        switch (dx10Header.dxgiFormat) {
+            case DXGIFormat::BC1_UNORM:
+                result.format = Format::BC1;
+                break;
+            case DXGIFormat::BC1_UNORM_SRGB:
+                result.format = Format::BC1_SRGB;
+                break;
+            case DXGIFormat::BC4_UNORM:
+            case DXGIFormat::BC4_SNORM:
+                result.format = Format::BC4;
+                break;
+            case DXGIFormat::BC5_UNORM:
+            case DXGIFormat::BC5_SNORM:
+                result.format = Format::BC5;
+                break;
+            case DXGIFormat::BC7_UNORM:
+                result.format = Format::BC7;
+                break;
+            case DXGIFormat::BC7_UNORM_SRGB:
+                result.format = Format::BC7_SRGB;
+                break;
+            default:
+                return result;
+        }
+    } else if (header.pixelFormat.flags & DDPF_FOURCC) {
+        switch (header.pixelFormat.fourCC) {
+            case FOURCC_DXT1:
+                result.format = Format::BC1;
+                break;
+            case FOURCC_ATI1:
+                result.format = Format::BC4;
+                break;
+            case FOURCC_ATI2:
+                result.format = Format::BC5;
+                break;
+            default:
+                return result;
+        }
+    } else {
+        return result;
+    }
+
+    // Calculate total data size (all mip levels)
+    uint32_t totalSize = 0;
+    uint32_t mipWidth = result.width;
+    uint32_t mipHeight = result.height;
+    for (uint32_t i = 0; i < result.mipLevels; i++) {
+        totalSize += calculateMipSize(mipWidth, mipHeight, result.format);
+        mipWidth = std::max(1u, mipWidth / 2);
+        mipHeight = std::max(1u, mipHeight / 2);
+    }
+
+    // Read data
+    result.data.resize(totalSize);
+    file.read(reinterpret_cast<char*>(result.data.data()), totalSize);
+
+    if (!file.good()) {
+        result.data.clear();
+        result.format = Format::UNKNOWN;
+    }
+
+    return result;
+}
+
+// Get Vulkan format for DDS format
+inline uint32_t getVulkanFormat(Format format) {
+    // VkFormat values
+    constexpr uint32_t VK_FORMAT_BC1_RGB_UNORM_BLOCK = 131;
+    constexpr uint32_t VK_FORMAT_BC1_RGB_SRGB_BLOCK = 132;
+    constexpr uint32_t VK_FORMAT_BC4_UNORM_BLOCK = 139;
+    constexpr uint32_t VK_FORMAT_BC5_UNORM_BLOCK = 141;
+    constexpr uint32_t VK_FORMAT_BC7_UNORM_BLOCK = 145;
+    constexpr uint32_t VK_FORMAT_BC7_SRGB_BLOCK = 146;
+
+    switch (format) {
+        case Format::BC1:      return VK_FORMAT_BC1_RGB_UNORM_BLOCK;
+        case Format::BC1_SRGB: return VK_FORMAT_BC1_RGB_SRGB_BLOCK;
+        case Format::BC4:      return VK_FORMAT_BC4_UNORM_BLOCK;
+        case Format::BC5:      return VK_FORMAT_BC5_UNORM_BLOCK;
+        case Format::BC7:      return VK_FORMAT_BC7_UNORM_BLOCK;
+        case Format::BC7_SRGB: return VK_FORMAT_BC7_SRGB_BLOCK;
+        default:               return 0;
+    }
+}
+
+} // namespace DDS

--- a/tools/tile_generator/TileCompositor.h
+++ b/tools/tile_generator/TileCompositor.h
@@ -31,6 +31,9 @@ struct TileCompositorConfig {
     float subZoneNoiseScale = 0.01f;     // Noise frequency for sub-zone blending
     float subZoneBlendStrength = 0.3f;   // Max blend amount for sub-zones
 
+    // BCn compression option
+    bool useCompression = false;         // Output BC1 compressed DDS instead of PNG
+
     // Get tile size in world units
     float getTileSize() const {
         return terrainSize / tilesPerAxis;

--- a/tools/tile_generator/main.cpp
+++ b/tools/tile_generator/main.cpp
@@ -23,6 +23,7 @@ void printUsage(const char* programName) {
     SDL_Log("  --max-mip <n>         Maximum mip level (default: 9)");
     SDL_Log("  --single-mip <n>      Generate only a single mip level");
     SDL_Log("  --single-tile <x,y,m> Generate a single tile at x,y,mip level");
+    SDL_Log("  --compress, --dds     Output BC1 compressed DDS files (default: PNG)");
     SDL_Log("  --help                Show this help message");
 }
 
@@ -45,6 +46,8 @@ struct GeneratorOptions {
     uint32_t singleTileX = 0;
     uint32_t singleTileY = 0;
     uint32_t singleTileMip = 0;
+
+    bool useCompression = false;  // Output BC1 compressed DDS files
 };
 
 bool parseArguments(int argc, char* argv[], GeneratorOptions& opts) {
@@ -100,6 +103,9 @@ bool parseArguments(int argc, char* argv[], GeneratorOptions& opts) {
                 return false;
             }
         }
+        else if (arg == "--compress" || arg == "--dds" || arg == "-c") {
+            opts.useCompression = true;
+        }
         else {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unknown argument: %s", arg.c_str());
             return false;
@@ -140,6 +146,7 @@ int main(int argc, char* argv[]) {
     SDL_Log("Tile resolution: %u px", opts.tileResolution);
     SDL_Log("Tiles/axis:     %u", opts.tilesPerAxis);
     SDL_Log("Max mip levels: %u", opts.maxMipLevels);
+    SDL_Log("Output format:  %s", opts.useCompression ? "BC1 DDS (compressed)" : "PNG");
 
     // Setup compositor config
     VirtualTexture::TileCompositorConfig config;
@@ -147,6 +154,7 @@ int main(int argc, char* argv[]) {
     config.tileResolution = opts.tileResolution;
     config.tilesPerAxis = opts.tilesPerAxis;
     config.maxMipLevels = opts.maxMipLevels;
+    config.useCompression = opts.useCompression;
 
     // Create compositor
     VirtualTexture::TileCompositor compositor;


### PR DESCRIPTION
Implements GPU-ready BCn compressed texture pipeline:

Tools:
- Add bc_compress.h header-only BCn encoder (BC1 for RGB, BC5 for normals)
- Add dds_file.h for writing DDS files with BCn data
- Update tile_generator with --compress flag for BC1 DDS output
- Update material_texture_gen with BC1/BC5 compression support

Engine:
- Add DDSLoader.h for loading DDS files with BCn format detection
- Update Texture class to load DDS files with BC1/BC5 support
- Update VirtualTextureTileLoader with DDS/PNG fallback loading
- Update VirtualTextureCache to support BC1 format cache texture
- Add TileFormat enum to VirtualTextureTypes for format tracking
- Update VirtualTextureSystem to pass format to cache upload

Benefits:
- 4x memory reduction for albedo textures (RGBA8 -> BC1)
- Better normal map quality with BC5 two-channel compression
- Reduced disk I/O with smaller compressed tile files
- Backward compatible: falls back to PNG if DDS not found