### PR TITLE
Refactor renderer to use getter methods for interfaces

### DIFF
--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -74,18 +74,18 @@ constexpr uint32_t PBR_HAS_AO_MAP        = (1u << 2);
 constexpr uint32_t PBR_HAS_HEIGHT_MAP    = (1u << 3);
 
 
-class Renderer : public ILocationControl,
-                  public IWeatherControl,
-                  public IEnvironmentControl,
-                  public IPostProcessControl,
-                  public ITerrainControl,
-                  public IWaterControl,
-                  public ITreeControl,
-                  public IDebugControl,
-                  public IProfilerControl,
-                  public IPerformanceControl,
-                  public ISceneControl,
-                  public IPlayerControl {
+class Renderer : private ILocationControl,
+                  private IWeatherControl,
+                  private IEnvironmentControl,
+                  private IPostProcessControl,
+                  private ITerrainControl,
+                  private IWaterControl,
+                  private ITreeControl,
+                  private IDebugControl,
+                  private IProfilerControl,
+                  private IPerformanceControl,
+                  private ISceneControl,
+                  private IPlayerControl {
 public:
     // Configuration for renderer initialization
     struct Config {
@@ -155,6 +155,32 @@ public:
     // Access to VulkanContext
     VulkanContext& getVulkanContext() { return vulkanContext; }
     const VulkanContext& getVulkanContext() const { return vulkanContext; }
+
+    // Interface accessors - provide access to GUI-facing control interfaces
+    ILocationControl& getLocationControl() { return *this; }
+    const ILocationControl& getLocationControl() const { return *this; }
+    IWeatherControl& getWeatherControl() { return *this; }
+    const IWeatherControl& getWeatherControl() const { return *this; }
+    IEnvironmentControl& getEnvironmentControl() { return *this; }
+    const IEnvironmentControl& getEnvironmentControl() const { return *this; }
+    IPostProcessControl& getPostProcessControl() { return *this; }
+    const IPostProcessControl& getPostProcessControl() const { return *this; }
+    ITerrainControl& getTerrainControl() { return *this; }
+    const ITerrainControl& getTerrainControl() const { return *this; }
+    IWaterControl& getWaterControl() { return *this; }
+    const IWaterControl& getWaterControl() const { return *this; }
+    ITreeControl& getTreeControl() { return *this; }
+    const ITreeControl& getTreeControl() const { return *this; }
+    IDebugControl& getDebugControl() { return *this; }
+    const IDebugControl& getDebugControl() const { return *this; }
+    IProfilerControl& getProfilerControl() { return *this; }
+    const IProfilerControl& getProfilerControl() const { return *this; }
+    IPerformanceControl& getPerformanceControl() { return *this; }
+    const IPerformanceControl& getPerformanceControl() const { return *this; }
+    ISceneControl& getSceneControl() { return *this; }
+    const ISceneControl& getSceneControl() const { return *this; }
+    IPlayerControl& getPlayerControl() { return *this; }
+    const IPlayerControl& getPlayerControl() const { return *this; }
 
     // GUI rendering callback (called during swapchain render pass)
     using GuiRenderCallback = std::function<void(VkCommandBuffer)>;

--- a/src/gui/GuiSystem.cpp
+++ b/src/gui/GuiSystem.cpp
@@ -296,52 +296,52 @@ void GuiSystem::render(Renderer& renderer, const Camera& camera, float deltaTime
 
         if (ImGui::BeginTabBar("ControlTabs")) {
             if (ImGui::BeginTabItem("Time")) {
-                // TimeSystem implements ITimeSystem directly, Renderer implements ILocationControl
-                GuiTimeTab::render(renderer.getTimeSystem(), static_cast<ILocationControl&>(renderer));
+                // TimeSystem implements ITimeSystem directly, Renderer provides ILocationControl
+                GuiTimeTab::render(renderer.getTimeSystem(), renderer.getLocationControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Weather")) {
-                GuiWeatherTab::render(static_cast<IWeatherControl&>(renderer));
+                GuiWeatherTab::render(renderer.getWeatherControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Environment")) {
-                GuiEnvironmentTab::render(static_cast<IEnvironmentControl&>(renderer), environmentTabState);
+                GuiEnvironmentTab::render(renderer.getEnvironmentControl(), environmentTabState);
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Post FX")) {
-                GuiPostFXTab::render(static_cast<IPostProcessControl&>(renderer));
+                GuiPostFXTab::render(renderer.getPostProcessControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Terrain")) {
-                GuiTerrainTab::render(static_cast<ITerrainControl&>(renderer));
+                GuiTerrainTab::render(renderer.getTerrainControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Water")) {
-                GuiWaterTab::render(static_cast<IWaterControl&>(renderer));
+                GuiWaterTab::render(renderer.getWaterControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Trees")) {
-                GuiTreeTab::render(static_cast<ITreeControl&>(renderer));
+                GuiTreeTab::render(renderer.getTreeControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Player")) {
-                GuiPlayerTab::render(static_cast<IPlayerControl&>(renderer), playerSettings);
+                GuiPlayerTab::render(renderer.getPlayerControl(), playerSettings);
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("IK")) {
-                GuiIKTab::render(static_cast<ISceneControl&>(renderer), camera, ikDebugSettings);
+                GuiIKTab::render(renderer.getSceneControl(), camera, ikDebugSettings);
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Debug")) {
-                GuiDebugTab::render(static_cast<IDebugControl&>(renderer));
+                GuiDebugTab::render(renderer.getDebugControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Perf")) {
-                GuiPerformanceTab::render(static_cast<IPerformanceControl&>(renderer));
+                GuiPerformanceTab::render(renderer.getPerformanceControl());
                 ImGui::EndTabItem();
             }
             if (ImGui::BeginTabItem("Profiler")) {
-                GuiProfilerTab::render(static_cast<IProfilerControl&>(renderer));
+                GuiProfilerTab::render(renderer.getProfilerControl());
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();
@@ -354,7 +354,7 @@ void GuiSystem::render(Renderer& renderer, const Camera& camera, float deltaTime
 
     // Skeleton/IK debug overlay
     if (ikDebugSettings.showSkeleton || ikDebugSettings.showIKTargets) {
-        GuiIKTab::renderSkeletonOverlay(static_cast<ISceneControl&>(renderer), camera, ikDebugSettings, playerSettings.showCapeColliders);
+        GuiIKTab::renderSkeletonOverlay(renderer.getSceneControl(), camera, ikDebugSettings, playerSettings.showCapeColliders);
     }
 }
 


### PR DESCRIPTION
Replace public interface inheritance with private inheritance and add getter methods for each interface (getTerrainControl(), getWaterControl(), etc.). This decouples external code from the Renderer class hierarchy while maintaining the same functionality through composition-style access.

- Change Renderer's inheritance from public to private for all 12 interfaces
- Add getter methods that return references to each interface
- Update GuiSystem.cpp to use getter methods instead of static_cast