### PR TITLE
Refactor large renderer component

### DIFF
--- a/src/core/controls/EnvironmentControlSubsystem.cpp
+++ b/src/core/controls/EnvironmentControlSubsystem.cpp
@@ -117,6 +117,10 @@ float EnvironmentControlSubsystem::getLeafIntensity() const {
     return leaf_.getIntensity();
 }
 
+void EnvironmentControlSubsystem::spawnConfetti(const glm::vec3& position, float velocity, float count, float coneAngle) {
+    leaf_.spawnConfetti(position, velocity, count, coneAngle);
+}
+
 // Cloud style and parameters
 void EnvironmentControlSubsystem::toggleCloudStyle() {
     useParaboloidClouds_ = !useParaboloidClouds_;

--- a/src/core/controls/EnvironmentControlSubsystem.h
+++ b/src/core/controls/EnvironmentControlSubsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "interfaces/IEnvironmentControl.h"
+#include <glm/glm.hpp>
 
 class FroxelSystem;
 class AtmosphereLUTSystem;
@@ -62,6 +63,7 @@ public:
     // Leaves/particles
     void setLeafIntensity(float intensity) override;
     float getLeafIntensity() const override;
+    void spawnConfetti(const glm::vec3& position, float velocity, float count, float coneAngle) override;
 
     // Cloud style and parameters
     void toggleCloudStyle() override;

--- a/src/core/interfaces/IEnvironmentControl.h
+++ b/src/core/interfaces/IEnvironmentControl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glm/glm.hpp>
+
 struct AtmosphereParams;
 struct EnvironmentSettings;
 
@@ -44,6 +46,7 @@ public:
     // Leaves/particles
     virtual void setLeafIntensity(float intensity) = 0;
     virtual float getLeafIntensity() const = 0;
+    virtual void spawnConfetti(const glm::vec3& position, float velocity = 8.0f, float count = 100.0f, float coneAngle = 0.5f) = 0;
 
     // Cloud style and parameters
     virtual void toggleCloudStyle() = 0;

--- a/src/gui/GuiInterfaces.h
+++ b/src/gui/GuiInterfaces.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Forward declarations for all GUI control interfaces
+class ITimeSystem;
+class ILocationControl;
+class IWeatherState;
+class IEnvironmentControl;
+class IPostProcessState;
+class ICloudShadowControl;
+class ITerrainControl;
+class IWaterControl;
+class ITreeControl;
+class IDebugControl;
+class IProfilerControl;
+class IPerformanceControl;
+class ISceneControl;
+class IPlayerControl;
+struct EnvironmentSettings;
+
+/**
+ * GuiInterfaces - Aggregates all control interfaces needed by the GUI system.
+ *
+ * This struct allows GuiSystem to receive all its dependencies directly,
+ * breaking the dependency on Renderer. The Application is responsible for
+ * building this struct from RendererSystems.
+ */
+struct GuiInterfaces {
+    ITimeSystem& time;
+    ILocationControl& location;
+    IWeatherState& weather;
+    IEnvironmentControl& environment;
+    IPostProcessState& postProcess;
+    ICloudShadowControl& cloudShadow;
+    ITerrainControl& terrain;
+    IWaterControl& water;
+    ITreeControl& tree;
+    IDebugControl& debug;
+    IProfilerControl& profiler;
+    IPerformanceControl& performance;
+    ISceneControl& scene;
+    IPlayerControl& player;
+    EnvironmentSettings& environmentSettings;
+};

--- a/src/gui/GuiSystem.h
+++ b/src/gui/GuiSystem.h
@@ -10,8 +10,8 @@
 #include "GuiIKTab.h"
 #include "GuiPlayerTab.h"
 #include "GuiEnvironmentTab.h"
+#include "GuiInterfaces.h"
 
-class Renderer;
 class Camera;
 
 class GuiSystem {
@@ -35,7 +35,7 @@ public:
 
     void processEvent(const SDL_Event& event);
     void beginFrame();
-    void render(Renderer& renderer, const Camera& camera, float deltaTime, float fps);
+    void render(GuiInterfaces& interfaces, const Camera& camera, float deltaTime, float fps);
     void endFrame(VkCommandBuffer cmd);
     void cancelFrame();  // End frame without rendering (for early returns)
 
@@ -60,7 +60,7 @@ private:
     void cleanup();
 
     void setupStyle();
-    void renderDashboard(Renderer& renderer, const Camera& camera, float fps);
+    void renderDashboard(GuiInterfaces& interfaces, const Camera& camera, float fps);
     void renderPositionPanel(const Camera& camera);
 
     VkDevice device_ = VK_NULL_HANDLE;  // Stored for cleanup


### PR DESCRIPTION
GuiSystem now receives control interfaces directly via GuiInterfaces struct instead of depending on Renderer. This breaks the dependency chain where GUI code needed to go through Renderer to access controls.

- Add GuiInterfaces struct to aggregate all control interfaces
- Update GuiSystem::render() to take GuiInterfaces& instead of Renderer&
- Update Application to build GuiInterfaces from RendererSystems
- Update Application hotkey handlers to use systems directly
- Add spawnConfetti() to IEnvironmentControl interface