### PR TITLE
Ensure RAII is used consistently throughout

### DIFF
--- a/src/animation/SkinnedMeshRenderer.h
+++ b/src/animation/SkinnedMeshRenderer.h
@@ -14,6 +14,7 @@
 #include "RenderableBuilder.h"
 #include "GlobalBufferManager.h"
 #include "BufferUtils.h"
+#include "core/VulkanRAII.h"
 
 class AnimatedCharacter;
 
@@ -92,9 +93,9 @@ public:
     void setExtent(VkExtent2D newExtent) { extent = newExtent; }
 
     // Accessors for ShadowSystem integration
-    VkDescriptorSetLayout getDescriptorSetLayout() const { return descriptorSetLayout; }
-    VkPipelineLayout getPipelineLayout() const { return pipelineLayout; }
-    VkPipeline getPipeline() const { return pipeline; }
+    VkDescriptorSetLayout getDescriptorSetLayout() const { return descriptorSetLayout_.get(); }
+    VkPipelineLayout getPipelineLayout() const { return pipelineLayout_.get(); }
+    VkPipeline getPipeline() const { return pipeline_.get(); }
     VkDescriptorSet getDescriptorSet(uint32_t frameIndex) const { return descriptorSets[frameIndex]; }
 
 private:
@@ -116,10 +117,10 @@ private:
     uint32_t framesInFlight = 0;
     AddCommonBindingsCallback addCommonBindings;
 
-    // Created resources
-    VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
-    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-    VkPipeline pipeline = VK_NULL_HANDLE;
+    // Created resources (RAII-managed)
+    ManagedDescriptorSetLayout descriptorSetLayout_;
+    ManagedPipelineLayout pipelineLayout_;
+    ManagedPipeline pipeline_;
 
     std::vector<VkDescriptorSet> descriptorSets;
     BufferUtils::PerFrameBufferSet boneMatricesBuffers;

--- a/src/atmosphere/CloudShadowSystem.h
+++ b/src/atmosphere/CloudShadowSystem.h
@@ -76,7 +76,7 @@ public:
                       const glm::vec3& cameraPos);
 
     // Accessors for shader binding
-    VkImageView getShadowMapView() const { return shadowMapView; }
+    VkImageView getShadowMapView() const { return shadowMapView_.get(); }
     VkSampler getShadowMapSampler() const { return shadowMapSampler.get(); }
 
     // Get the world-to-shadow-UV matrix for sampling in fragment shaders
@@ -118,10 +118,9 @@ private:
     VkImageView cloudMapLUTView = VK_NULL_HANDLE;
     VkSampler cloudMapLUTSampler = VK_NULL_HANDLE;
 
-    // Cloud shadow map (R16F - stores shadow attenuation 0=full shadow, 1=no shadow)
-    VkImage shadowMap = VK_NULL_HANDLE;
-    VmaAllocation shadowMapAllocation = VK_NULL_HANDLE;
-    VkImageView shadowMapView = VK_NULL_HANDLE;
+    // Cloud shadow map (R16F - stores shadow attenuation 0=full shadow, 1=no shadow) - RAII-managed
+    ManagedImage shadowMap_;
+    ManagedImageView shadowMapView_;
     ManagedSampler shadowMapSampler;
 
     // Compute pipeline (RAII-managed)


### PR DESCRIPTION
Convert manual resource management to RAII wrappers in three systems:

- SkinnedMeshRenderer: Use ManagedDescriptorSetLayout, ManagedPipelineLayout, ManagedPipeline instead of raw VkDescriptorSetLayout, VkPipelineLayout, VkPipeline

- CloudShadowSystem: Use ManagedImage and ManagedImageView for shadow map resources instead of raw VkImage/VmaAllocation/VkImageView

- FroxelSystem: Use ManagedImage and ManagedImageView arrays for double-buffered scattering volumes and integrated volume

This eliminates manual vkDestroy*/vmaDestroyImage calls in cleanup() methods, reducing code and ensuring exception-safe resource management.