### PR TITLE
Refactor duplicated tree system logic

### DIFF
--- a/shaders/leaf.vert
+++ b/shaders/leaf.vert
@@ -6,6 +6,7 @@ const int NUM_CASCADES = 4;
 
 #include "bindings.glsl"
 #include "ubo_common.glsl"
+#include "quaternion.glsl"
 
 // Leaf particle states
 const uint STATE_INACTIVE = 0;
@@ -54,13 +55,6 @@ layout(location = 2) out vec3 fragWorldPos;
 layout(location = 3) flat out uint fragLeafType;
 layout(location = 4) flat out uint fragState;
 layout(location = 5) out float fragDistToCamera;
-
-// Rotate vector by quaternion
-vec3 rotateByQuat(vec3 v, vec4 q) {
-    vec3 qvec = q.xyz;
-    float qw = q.w;
-    return v + 2.0 * cross(qvec, cross(qvec, v) + qw * v);
-}
 
 void main() {
     // gl_InstanceIndex = which particle

--- a/shaders/quaternion.glsl
+++ b/shaders/quaternion.glsl
@@ -1,0 +1,72 @@
+// Quaternion utility functions for GPU shaders
+// Shared between all vegetation and instancing shaders
+//
+// Usage in shaders: #include "quaternion.glsl"
+
+#ifndef QUATERNION_GLSL
+#define QUATERNION_GLSL
+
+// Rotate a vector by a quaternion
+// q = quaternion (x, y, z, w) where w is the scalar component
+vec3 rotateByQuat(vec3 v, vec4 q) {
+    vec3 t = 2.0 * cross(q.xyz, v);
+    return v + q.w * t + cross(q.xyz, t);
+}
+
+// Quaternion multiplication: q1 * q2
+// Returns the quaternion representing rotation q1 followed by q2
+vec4 quatMul(vec4 q1, vec4 q2) {
+    return vec4(
+        q1.w * q2.xyz + q2.w * q1.xyz + cross(q1.xyz, q2.xyz),
+        q1.w * q2.w - dot(q1.xyz, q2.xyz)
+    );
+}
+
+// Convert a 3x3 rotation matrix to a quaternion
+// Handles all cases using the Shepperd method for numerical stability
+vec4 mat3ToQuat(mat3 m) {
+    float trace = m[0][0] + m[1][1] + m[2][2];
+    vec4 q;
+
+    if (trace > 0.0) {
+        float s = 0.5 / sqrt(trace + 1.0);
+        q.w = 0.25 / s;
+        q.x = (m[2][1] - m[1][2]) * s;
+        q.y = (m[0][2] - m[2][0]) * s;
+        q.z = (m[1][0] - m[0][1]) * s;
+    } else if (m[0][0] > m[1][1] && m[0][0] > m[2][2]) {
+        float s = 2.0 * sqrt(1.0 + m[0][0] - m[1][1] - m[2][2]);
+        q.w = (m[2][1] - m[1][2]) / s;
+        q.x = 0.25 * s;
+        q.y = (m[0][1] + m[1][0]) / s;
+        q.z = (m[0][2] + m[2][0]) / s;
+    } else if (m[1][1] > m[2][2]) {
+        float s = 2.0 * sqrt(1.0 + m[1][1] - m[0][0] - m[2][2]);
+        q.w = (m[0][2] - m[2][0]) / s;
+        q.x = (m[0][1] + m[1][0]) / s;
+        q.y = 0.25 * s;
+        q.z = (m[1][2] + m[2][1]) / s;
+    } else {
+        float s = 2.0 * sqrt(1.0 + m[2][2] - m[0][0] - m[1][1]);
+        q.w = (m[1][0] - m[0][1]) / s;
+        q.x = (m[0][2] + m[2][0]) / s;
+        q.y = (m[1][2] + m[2][1]) / s;
+        q.z = 0.25 * s;
+    }
+
+    return normalize(q);
+}
+
+// Create a quaternion from an axis and angle (in radians)
+vec4 quatFromAxisAngle(vec3 axis, float angle) {
+    float halfAngle = angle * 0.5;
+    float s = sin(halfAngle);
+    return vec4(axis * s, cos(halfAngle));
+}
+
+// Get the conjugate of a quaternion (inverts the rotation for unit quaternions)
+vec4 quatConjugate(vec4 q) {
+    return vec4(-q.xyz, q.w);
+}
+
+#endif // QUATERNION_GLSL

--- a/shaders/tree_geometry.comp
+++ b/shaders/tree_geometry.comp
@@ -2,6 +2,7 @@
 #extension GL_GOOGLE_include_directive : enable
 
 #include "bindings.h"
+#include "quaternion.glsl"
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -63,13 +64,6 @@ layout(std140, set = 0, binding = BINDING_TREE_PARAMS) uniform TreeParams {
     float textureScaleU;
     float textureScaleV;
 };
-
-// Quaternion multiplication
-vec3 rotateByQuat(vec3 v, vec4 q) {
-    vec3 u = q.xyz;
-    float s = q.w;
-    return 2.0 * dot(u, v) * u + (s*s - dot(u, u)) * v + 2.0 * s * cross(u, v);
-}
 
 void main() {
     uint branchIdx = gl_GlobalInvocationID.x;

--- a/shaders/tree_leaf.comp
+++ b/shaders/tree_leaf.comp
@@ -2,6 +2,7 @@
 #extension GL_GOOGLE_include_directive : enable
 
 #include "bindings.h"
+#include "quaternion.glsl"
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -50,13 +51,6 @@ layout(std140, set = 0, binding = BINDING_TREE_LEAF_PARAMS) uniform LeafParams {
     float padding1;
     float padding2;
 };
-
-// Quaternion rotation
-vec3 rotateByQuat(vec3 v, vec4 q) {
-    vec3 u = q.xyz;
-    float s = q.w;
-    return 2.0 * dot(u, v) * u + (s*s - dot(u, u)) * v + 2.0 * s * cross(u, v);
-}
 
 void main() {
     uint leafIdx = gl_GlobalInvocationID.x;

--- a/shaders/tree_leaf.vert
+++ b/shaders/tree_leaf.vert
@@ -62,7 +62,7 @@ void main() {
     vec3 scaledPos = inPosition * leafSize;
 
     // Rotate by world-space orientation quaternion
-    vec3 rotatedPos = rotateByQuatWorld(scaledPos, worldOrientation);
+    vec3 rotatedPos = rotateByQuat(scaledPos, worldOrientation);
 
     // World position (already in world space from compute shader)
     vec3 worldPos = worldPosition + rotatedPos;
@@ -93,7 +93,7 @@ void main() {
 
     // Compute normal from world-space orientation
     vec3 localNormal = vec3(0.0, 0.0, 1.0);
-    vec3 worldNormal = rotateByQuatWorld(localNormal, worldOrientation);
+    vec3 worldNormal = rotateByQuat(localNormal, worldOrientation);
     fragNormal = normalize(worldNormal);
 
     fragTexCoord = inTexCoord;

--- a/shaders/tree_leaf_instance.glsl
+++ b/shaders/tree_leaf_instance.glsl
@@ -6,6 +6,8 @@
 #ifndef TREE_LEAF_INSTANCE_GLSL
 #define TREE_LEAF_INSTANCE_GLSL
 
+#include "quaternion.glsl"
+
 // Per-leaf instance data - 32 bytes per leaf
 // std430 layout for SSBO
 struct LeafInstance {
@@ -28,11 +30,5 @@ const vec2 LEAF_QUAD_UVS[4] = vec2[4](
     vec2(1.0, 1.0),  // Bottom-right
     vec2(1.0, 0.0)   // Top-right
 );
-
-// Rotate vector by quaternion
-vec3 rotateByQuat(vec3 v, vec4 q) {
-    vec3 t = 2.0 * cross(q.xyz, v);
-    return v + q.w * t + cross(q.xyz, t);
-}
 
 #endif // TREE_LEAF_INSTANCE_GLSL

--- a/shaders/tree_leaf_shadow.vert
+++ b/shaders/tree_leaf_shadow.vert
@@ -37,7 +37,7 @@ void main() {
     vec3 scaledPos = inPosition * leafSize;
 
     // Rotate by world-space orientation quaternion
-    vec3 rotatedPos = rotateByQuatWorld(scaledPos, worldOrientation);
+    vec3 rotatedPos = rotateByQuat(scaledPos, worldOrientation);
 
     // World position (already in world space from compute shader)
     vec3 worldPos = worldPosition + rotatedPos;

--- a/shaders/tree_leaf_world.glsl
+++ b/shaders/tree_leaf_world.glsl
@@ -6,6 +6,8 @@
 #ifndef TREE_LEAF_WORLD_GLSL
 #define TREE_LEAF_WORLD_GLSL
 
+#include "quaternion.glsl"
+
 // Per-leaf instance data in WORLD space - 48 bytes per leaf (std430)
 // After compute culling, leaves are output in world-space with tree index
 struct WorldLeafInstance {
@@ -24,53 +26,5 @@ struct TreeRenderData {
     vec4 tintAndParams;      // rgb = leaf tint, a = autumn hue shift
     vec4 windPhaseAndLOD;    // x = wind phase offset, y = LOD blend factor, zw = reserved
 };
-
-// Rotate vector by quaternion (same as tree_leaf_instance.glsl)
-vec3 rotateByQuatWorld(vec3 v, vec4 q) {
-    vec3 t = 2.0 * cross(q.xyz, v);
-    return v + q.w * t + cross(q.xyz, t);
-}
-
-// Quaternion multiplication: q1 * q2
-vec4 quatMul(vec4 q1, vec4 q2) {
-    return vec4(
-        q1.w * q2.xyz + q2.w * q1.xyz + cross(q1.xyz, q2.xyz),
-        q1.w * q2.w - dot(q1.xyz, q2.xyz)
-    );
-}
-
-// Convert 3x3 rotation matrix to quaternion
-vec4 mat3ToQuat(mat3 m) {
-    float trace = m[0][0] + m[1][1] + m[2][2];
-    vec4 q;
-
-    if (trace > 0.0) {
-        float s = 0.5 / sqrt(trace + 1.0);
-        q.w = 0.25 / s;
-        q.x = (m[2][1] - m[1][2]) * s;
-        q.y = (m[0][2] - m[2][0]) * s;
-        q.z = (m[1][0] - m[0][1]) * s;
-    } else if (m[0][0] > m[1][1] && m[0][0] > m[2][2]) {
-        float s = 2.0 * sqrt(1.0 + m[0][0] - m[1][1] - m[2][2]);
-        q.w = (m[2][1] - m[1][2]) / s;
-        q.x = 0.25 * s;
-        q.y = (m[0][1] + m[1][0]) / s;
-        q.z = (m[0][2] + m[2][0]) / s;
-    } else if (m[1][1] > m[2][2]) {
-        float s = 2.0 * sqrt(1.0 + m[1][1] - m[0][0] - m[2][2]);
-        q.w = (m[0][2] - m[2][0]) / s;
-        q.x = (m[0][1] + m[1][0]) / s;
-        q.y = 0.25 * s;
-        q.z = (m[1][2] + m[2][1]) / s;
-    } else {
-        float s = 2.0 * sqrt(1.0 + m[2][2] - m[0][0] - m[1][1]);
-        q.w = (m[1][0] - m[0][1]) / s;
-        q.x = (m[0][2] + m[2][0]) / s;
-        q.y = (m[1][2] + m[2][1]) / s;
-        q.z = 0.25 * s;
-    }
-
-    return normalize(q);
-}
 
 #endif // TREE_LEAF_WORLD_GLSL

--- a/src/vegetation/CullCommon.h
+++ b/src/vegetation/CullCommon.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <cstdint>
+
+/**
+ * Common culling data structures and utilities shared across vegetation culling systems.
+ * These structures are designed to match GPU shader layouts (std140/std430).
+ */
+
+// Common culling fields that appear in multiple uniform structs
+struct CullFrustumData {
+    glm::vec4 cameraPosition;       // xyz = camera pos, w = unused
+    glm::vec4 frustumPlanes[6];     // 6 frustum planes for culling
+};
+
+// Helper to populate frustum data from camera state
+inline void populateFrustumData(CullFrustumData& data, const glm::vec3& cameraPos, const glm::vec4* frustumPlanes) {
+    data.cameraPosition = glm::vec4(cameraPos, 1.0f);
+    for (int i = 0; i < 6; ++i) {
+        data.frustumPlanes[i] = frustumPlanes[i];
+    }
+}
+
+// Helper to extract frustum planes from a view-projection matrix
+// Uses Gribb/Hartmann plane extraction method with GLM column-major matrix
+inline void extractFrustumPlanes(const glm::mat4& viewProj, glm::vec4* outPlanes) {
+    // GLM is column-major, so transpose to get row access for Gribb/Hartmann extraction
+    glm::mat4 m = glm::transpose(viewProj);
+
+    // Left plane: row3 + row0
+    outPlanes[0] = m[3] + m[0];
+    // Right plane: row3 - row0
+    outPlanes[1] = m[3] - m[0];
+    // Bottom plane: row3 + row1
+    outPlanes[2] = m[3] + m[1];
+    // Top plane: row3 - row1
+    outPlanes[3] = m[3] - m[1];
+    // Near plane: row3 + row2
+    outPlanes[4] = m[3] + m[2];
+    // Far plane: row3 - row2
+    outPlanes[5] = m[3] - m[2];
+
+    // Normalize the planes
+    for (int i = 0; i < 6; ++i) {
+        float len = glm::length(glm::vec3(outPlanes[i]));
+        if (len > 0.0001f) {
+            outPlanes[i] /= len;
+        }
+    }
+}
+
+// ============================================================================
+// Common LOD Parameters
+// ============================================================================
+// These constants define consistent LOD behavior across all tree subsystems.
+// Screen-space error: HIGH when close (large on screen), LOW when far (small)
+// Logic: close (high error) = full detail, far (low error) = impostor/cull
+
+// Screen-space error LOD thresholds (used by TreeLODSystem and ImpostorCullSystem)
+namespace TreeLODConstants {
+    constexpr float ERROR_THRESHOLD_FULL = 4.0f;        // Above: full geometry (close trees)
+    constexpr float ERROR_THRESHOLD_IMPOSTOR = 1.0f;    // Below: full impostor (far trees)
+    constexpr float ERROR_THRESHOLD_CULL = 0.25f;       // Below: cull entirely (very far)
+
+    // Distance-based LOD thresholds (used by TreeLeafCulling for leaf instances)
+    // These should be consistent with screen-space error when possible
+    constexpr float FULL_DETAIL_DISTANCE = 250.0f;      // Full geometry below this
+    constexpr float MAX_DRAW_DISTANCE = 500.0f;         // Maximum leaf visibility
+    constexpr float LOD_TRANSITION_START = 150.0f;      // Start transitioning LOD
+    constexpr float LOD_TRANSITION_END = 250.0f;        // Finish transitioning LOD
+
+    // Hysteresis to prevent LOD flickering at boundaries
+    constexpr float HYSTERESIS = 5.0f;
+    constexpr float BLEND_RANGE = 10.0f;
+}
+
+// Number of leaf types (must match tree_leaf_cull.comp NUM_LEAF_TYPES)
+constexpr uint32_t NUM_LEAF_TYPES = 4;
+
+// Leaf type indices (oak=0, ash=1, aspen=2, pine=3)
+constexpr uint32_t LEAF_TYPE_OAK = 0;
+constexpr uint32_t LEAF_TYPE_ASH = 1;
+constexpr uint32_t LEAF_TYPE_ASPEN = 2;
+constexpr uint32_t LEAF_TYPE_PINE = 3;

--- a/src/vegetation/GrassSystem.cpp
+++ b/src/vegetation/GrassSystem.cpp
@@ -1,4 +1,5 @@
 #include "GrassSystem.h"
+#include "CullCommon.h"
 #include "ShaderLoader.h"
 #include "PipelineBuilder.h"
 #include "DescriptorManager.h"
@@ -689,30 +690,7 @@ void GrassSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos
     uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
 
     // Extract frustum planes from view-projection matrix
-    // Each plane equation: ax + by + cz + d = 0
-    // Using row-major extraction (GLM is column-major, so we transpose conceptually)
-    glm::mat4 m = glm::transpose(viewProj);
-
-    // Left:   row3 + row0
-    uniforms.frustumPlanes[0] = m[3] + m[0];
-    // Right:  row3 - row0
-    uniforms.frustumPlanes[1] = m[3] - m[0];
-    // Bottom: row3 + row1
-    uniforms.frustumPlanes[2] = m[3] + m[1];
-    // Top:    row3 - row1
-    uniforms.frustumPlanes[3] = m[3] - m[1];
-    // Near:   row3 + row2
-    uniforms.frustumPlanes[4] = m[3] + m[2];
-    // Far:    row3 - row2
-    uniforms.frustumPlanes[5] = m[3] - m[2];
-
-    // Normalize planes
-    for (int i = 0; i < 6; i++) {
-        float len = glm::length(glm::vec3(uniforms.frustumPlanes[i]));
-        if (len > 0.0001f) {
-            uniforms.frustumPlanes[i] /= len;
-        }
-    }
+    extractFrustumPlanes(viewProj, uniforms.frustumPlanes);
 
     // Update displacement region to follow camera
     displacementRegionCenter = glm::vec2(cameraPos.x, cameraPos.z);

--- a/src/vegetation/ImpostorCullSystem.h
+++ b/src/vegetation/ImpostorCullSystem.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "CullCommon.h"
 #include "core/VulkanRAII.h"
 #include "core/DescriptorManager.h"
 #include "core/BufferUtils.h"
@@ -102,15 +103,15 @@ public:
     // Screen error is HIGH when close (object large on screen), LOW when far (object small)
     // Logic: close (high error) = full geometry, far (low error) = impostor/cull
     struct LODParams {
-        float fullDetailDistance = 250.0f;
+        float fullDetailDistance = TreeLODConstants::FULL_DETAIL_DISTANCE;
         float impostorDistance = 50000.0f;
-        float hysteresis = 5.0f;
-        float blendRange = 10.0f;
+        float hysteresis = TreeLODConstants::HYSTERESIS;
+        float blendRange = TreeLODConstants::BLEND_RANGE;
         bool useScreenSpaceError = true;
         float tanHalfFOV = 1.0f;  // tan(fov/2)
-        float errorThresholdFull = 4.0f;       // Above this error: use full geometry (close trees)
-        float errorThresholdImpostor = 1.0f;   // Below this error: use full impostor (far trees)
-        float errorThresholdCull = 0.25f;      // Below this error: cull entirely (very far trees)
+        float errorThresholdFull = TreeLODConstants::ERROR_THRESHOLD_FULL;
+        float errorThresholdImpostor = TreeLODConstants::ERROR_THRESHOLD_IMPOSTOR;
+        float errorThresholdCull = TreeLODConstants::ERROR_THRESHOLD_CULL;
     };
 
     // Temporal coherence settings

--- a/src/vegetation/LeafSystem.cpp
+++ b/src/vegetation/LeafSystem.cpp
@@ -1,4 +1,5 @@
 #include "LeafSystem.h"
+#include "CullCommon.h"
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
 #include "VulkanBarriers.h"
@@ -473,21 +474,7 @@ void LeafSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos,
     uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
 
     // Extract frustum planes from view-projection matrix
-    glm::mat4 m = glm::transpose(viewProj);
-    uniforms.frustumPlanes[0] = m[3] + m[0];  // Left
-    uniforms.frustumPlanes[1] = m[3] - m[0];  // Right
-    uniforms.frustumPlanes[2] = m[3] + m[1];  // Bottom
-    uniforms.frustumPlanes[3] = m[3] - m[1];  // Top
-    uniforms.frustumPlanes[4] = m[3] + m[2];  // Near
-    uniforms.frustumPlanes[5] = m[3] - m[2];  // Far
-
-    // Normalize planes
-    for (int i = 0; i < 6; i++) {
-        float len = glm::length(glm::vec3(uniforms.frustumPlanes[i]));
-        if (len > 0.0001f) {
-            uniforms.frustumPlanes[i] /= len;
-        }
-    }
+    extractFrustumPlanes(viewProj, uniforms.frustumPlanes);
 
     // Player data for disruption
     uniforms.playerPosition = glm::vec4(playerPos, 0.5f);  // w = player collision radius

--- a/src/vegetation/TreeImpostorAtlas.h
+++ b/src/vegetation/TreeImpostorAtlas.h
@@ -9,6 +9,7 @@
 #include <array>
 
 #include "TreeOptions.h"
+#include "CullCommon.h"
 #include "core/VulkanRAII.h"
 #include "core/DescriptorManager.h"
 
@@ -57,23 +58,23 @@ struct TreeImpostorArchetype {
 // LOD settings with hysteresis support
 struct TreeLODSettings {
     // Distance thresholds (used when useScreenSpaceError = false)
-    float fullDetailDistance = 250.0f;     // Full geometry below this
+    float fullDetailDistance = TreeLODConstants::FULL_DETAIL_DISTANCE;
     float impostorDistance = 50000.0f;     // Impostors visible up to this distance (very far)
 
     // Hysteresis (prevents flickering at LOD boundaries)
-    float hysteresis = 5.0f;               // Dead zone for LOD transitions
+    float hysteresis = TreeLODConstants::HYSTERESIS;
 
     // Blending characteristics
-    float blendRange = 10.0f;              // Distance over which to blend LODs
+    float blendRange = TreeLODConstants::BLEND_RANGE;
     float blendExponent = 1.0f;            // Blend curve (1.0 = linear)
 
     // Screen-space error LOD
     // Screen error is HIGH when close (object large on screen), LOW when far (object small)
     // Logic: close (high error) = full geometry, far (low error) = impostor/cull
     bool useScreenSpaceError = true;       // Use screen-space error instead of distance
-    float errorThresholdFull = 4.0f;       // Above this error: use full geometry (close trees)
-    float errorThresholdImpostor = 1.0f;   // Below this error: use full impostor (far trees)
-    float errorThresholdCull = 0.25f;      // Below this error: cull entirely (very far trees)
+    float errorThresholdFull = TreeLODConstants::ERROR_THRESHOLD_FULL;
+    float errorThresholdImpostor = TreeLODConstants::ERROR_THRESHOLD_IMPOSTOR;
+    float errorThresholdCull = TreeLODConstants::ERROR_THRESHOLD_CULL;
 
     // Impostor settings
     bool enableImpostors = true;

--- a/src/vegetation/TreeLeafCulling.cpp
+++ b/src/vegetation/TreeLeafCulling.cpp
@@ -14,6 +14,7 @@ std::unique_ptr<TreeLeafCulling> TreeLeafCulling::create(const InitInfo& info) {
 }
 
 TreeLeafCulling::~TreeLeafCulling() {
+    // Cleanup triple-buffered output buffers
     for (size_t i = 0; i < cullOutputBuffers_.size(); ++i) {
         if (cullOutputBuffers_[i] != VK_NULL_HANDLE) {
             vmaDestroyBuffer(allocator_, cullOutputBuffers_[i], cullOutputAllocations_[i]);
@@ -25,41 +26,29 @@ TreeLeafCulling::~TreeLeafCulling() {
         }
     }
 
-    for (size_t i = 0; i < cullUniformBuffers_.buffers.size(); ++i) {
-        if (cullUniformBuffers_.buffers[i] != VK_NULL_HANDLE) {
-            vmaDestroyBuffer(allocator_, cullUniformBuffers_.buffers[i], cullUniformBuffers_.allocations[i]);
-        }
-    }
+    // Use helper for per-frame buffer sets
+    BufferUtils::destroyBuffers(allocator_, cullUniformBuffers_);
+    BufferUtils::destroyBuffers(allocator_, cellCullUniformBuffers_);
+    BufferUtils::destroyBuffers(allocator_, treeFilterUniformBuffers_);
 
+    // Cleanup single buffers
     if (treeDataBuffer_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, treeDataBuffer_, treeDataAllocation_);
     }
     if (treeRenderDataBuffer_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, treeRenderDataBuffer_, treeRenderDataAllocation_);
     }
-
     if (visibleCellBuffer_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, visibleCellBuffer_, visibleCellAllocation_);
     }
     if (cellCullIndirectBuffer_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, cellCullIndirectBuffer_, cellCullIndirectAllocation_);
     }
-    for (size_t i = 0; i < cellCullUniformBuffers_.buffers.size(); ++i) {
-        if (cellCullUniformBuffers_.buffers[i] != VK_NULL_HANDLE) {
-            vmaDestroyBuffer(allocator_, cellCullUniformBuffers_.buffers[i], cellCullUniformBuffers_.allocations[i]);
-        }
-    }
-
     if (visibleTreeBuffer_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, visibleTreeBuffer_, visibleTreeAllocation_);
     }
     if (leafCullIndirectDispatch_ != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator_, leafCullIndirectDispatch_, leafCullIndirectDispatchAllocation_);
-    }
-    for (size_t i = 0; i < treeFilterUniformBuffers_.buffers.size(); ++i) {
-        if (treeFilterUniformBuffers_.buffers[i] != VK_NULL_HANDLE) {
-            vmaDestroyBuffer(allocator_, treeFilterUniformBuffers_.buffers[i], treeFilterUniformBuffers_.allocations[i]);
-        }
     }
 }
 

--- a/src/vegetation/TreeLeafCulling.h
+++ b/src/vegetation/TreeLeafCulling.h
@@ -9,6 +9,7 @@
 #include <array>
 
 #include "TreeSpatialIndex.h"
+#include "CullCommon.h"
 #include "core/VulkanRAII.h"
 #include "core/DescriptorManager.h"
 #include "BufferUtils.h"
@@ -16,14 +17,6 @@
 // Forward declarations
 class TreeSystem;
 class TreeLODSystem;
-
-// Number of leaf types (must match tree_leaf_cull.comp NUM_LEAF_TYPES)
-constexpr uint32_t NUM_LEAF_TYPES = 4;
-// Leaf type indices (oak=0, ash=1, aspen=2, pine=3)
-constexpr uint32_t LEAF_TYPE_OAK = 0;
-constexpr uint32_t LEAF_TYPE_ASH = 1;
-constexpr uint32_t LEAF_TYPE_ASPEN = 2;
-constexpr uint32_t LEAF_TYPE_PINE = 3;
 
 // Uniforms for tree leaf culling compute shader (must match shader layout)
 struct TreeLeafCullUniforms {
@@ -118,9 +111,9 @@ public:
     };
 
     struct CullingParams {
-        float maxDrawDistance = 250.0f;
-        float lodTransitionStart = 150.0f;
-        float lodTransitionEnd = 250.0f;
+        float maxDrawDistance = TreeLODConstants::FULL_DETAIL_DISTANCE;
+        float lodTransitionStart = TreeLODConstants::LOD_TRANSITION_START;
+        float lodTransitionEnd = TreeLODConstants::LOD_TRANSITION_END;
         float maxLodDropRate = 0.75f;
     };
 


### PR DESCRIPTION
- Create shared quaternion.glsl with rotateByQuat, quatMul, mat3ToQuat utilities
- Create CullCommon.h with shared frustum extraction and LOD constants
- Unify LOD settings across TreeLeafCulling, ImpostorCullSystem, TreeImpostorAtlas
- Remove duplicated rotateByQuat implementations from 5 shader files
- Remove duplicated frustum plane extraction from GrassSystem and LeafSystem
- Use BufferUtils::destroyBuffers helper in TreeLeafCulling destructor
- Add TreeLODConstants namespace for consistent LOD thresholds

Net reduction: 38 lines of duplicated code removed.