### PR TITLE
Review Descriptor Set Update Initialization

### DIFF
--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -509,7 +509,21 @@ bool Renderer::initSubsystems(const InitContext& initCtx) {
             if (impostorCull && treeLOD) {
                 impostorCull->updateTreeData(*treeSystem, treeLOD->getImpostorAtlas());
                 impostorCull->updateArchetypeData(treeLOD->getImpostorAtlas());
+                impostorCull->initializeDescriptorSets();
                 SDL_Log("ImpostorCullSystem: Updated with %u trees", impostorCull->getTreeCount());
+            }
+
+            // Initialize TreeLODSystem descriptor sets now that impostors are generated
+            if (treeLOD) {
+                treeLOD->initializeDescriptorSets(
+                    systems_->globalBuffers().uniformBuffers.buffers,
+                    systems_->shadow().getShadowImageView(),
+                    systems_->shadow().getShadowSampler());
+
+                // If GPU culling is available, update instance buffer binding
+                if (impostorCull) {
+                    treeLOD->initializeGPUCulledDescriptors(impostorCull->getVisibleImpostorBuffer());
+                }
             }
         }
     }

--- a/src/vegetation/ImpostorCullSystem.h
+++ b/src/vegetation/ImpostorCullSystem.h
@@ -169,6 +169,9 @@ public:
     // Get tree count
     uint32_t getTreeCount() const { return treeCount_; }
 
+    // Initialize static descriptor set bindings (call once after buffers are created)
+    void initializeDescriptorSets();
+
 private:
     ImpostorCullSystem() = default;
     bool initInternal(const InitInfo& info);
@@ -179,7 +182,7 @@ private:
     bool allocateDescriptorSets();
     bool createBuffers();
 
-    void updateDescriptorSets(uint32_t frameIndex, VkImageView hiZPyramidView, VkSampler hiZSampler);
+    void updateHiZDescriptor(uint32_t frameIndex, VkImageView hiZPyramidView, VkSampler hiZSampler);
 
     VkDevice device_ = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice_ = VK_NULL_HANDLE;

--- a/src/vegetation/TreeLODSystem.h
+++ b/src/vegetation/TreeLODSystem.h
@@ -142,9 +142,12 @@ public:
     void setGPUCullingEnabled(bool enabled) { gpuCullingEnabled_ = enabled; }
     bool isGPUCullingEnabled() const { return gpuCullingEnabled_; }
 
-    // Update descriptor sets
-    void updateDescriptorSets(uint32_t frameIndex, VkBuffer uniformBuffer,
-                              VkImageView shadowMap, VkSampler shadowSampler);
+    // Initialize descriptor sets with static bindings (call once during init)
+    void initializeDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
+                                  VkImageView shadowMap, VkSampler shadowSampler);
+
+    // Initialize GPU-culled descriptor sets with the GPU instance buffer (call once when GPU culling is enabled)
+    void initializeGPUCulledDescriptors(VkBuffer gpuInstanceBuffer);
 
     VkDevice getDevice() const { return device_; }
 


### PR DESCRIPTION
Performance optimization: descriptor sets that don't change per-frame should only be updated during initialization, not every render call.

Changes:
- ImpostorCullSystem: Add initializeDescriptorSets() for static bindings, rename updateDescriptorSets to updateHiZDescriptor for Hi-Z only updates, fix buggy condition (|| should be &&) that caused updates every frame
- TreeLODSystem: Add initializeDescriptorSets() and initializeGPUCulledDescriptors() for one-time binding of atlas textures, shadow maps, UBOs, and instance buffers. Remove per-frame vkUpdateDescriptorSets calls from all render methods.
- RendererInitPhases: Call initialization methods after buffers are created