### PR TITLE
Size tree imposters to match instance bounds

### DIFF
--- a/src/vegetation/ImpostorCullSystem.cpp
+++ b/src/vegetation/ImpostorCullSystem.cpp
@@ -303,22 +303,21 @@ void ImpostorCullSystem::updateTreeData(const TreeSystem& treeSystem, const Tree
             0.0f, 0.0f
         );
 
-        // Compute per-tree sizing from actual mesh bounds (at scale=1)
+        // Compute per-tree sizing from full tree bounds (branches + leaves)
         if (tree.meshIndex < treeSystem.getMeshCount()) {
-            const auto& meshBounds = treeSystem.getBranchMesh(tree.meshIndex).getBounds();
-            glm::vec3 minB = meshBounds.min;
-            glm::vec3 maxB = meshBounds.max;
+            const auto& fullBounds = treeSystem.getFullTreeBounds(tree.meshIndex);
+            glm::vec3 minB = fullBounds.min;
+            glm::vec3 maxB = fullBounds.max;
             glm::vec3 extent = maxB - minB;
 
+            // Use horizontal radius for tighter billboard fit (not 3D bounding sphere)
             float horizontalRadius = std::max(extent.x, extent.z) * 0.5f;
             float halfHeight = extent.y * 0.5f;
-            float boundingSphereRadius = glm::length(extent) * 0.5f;
 
-            // Billboard sizing: hSize uses bounding sphere for horizontal coverage,
+            // Billboard sizing: hSize uses horizontal extent for tighter fit,
             // vSize uses half height to prevent ground penetration.
             // The billboard center is at centerHeight, and extends vSize up/down.
-            // If vSize > centerHeight, the billboard bottom would go below ground.
-            float hSize = boundingSphereRadius * TreeLODConstants::IMPOSTOR_SIZE_MARGIN;
+            float hSize = horizontalRadius * TreeLODConstants::IMPOSTOR_SIZE_MARGIN;
             float vSize = halfHeight * TreeLODConstants::IMPOSTOR_SIZE_MARGIN;
             float centerHeight = (minB.y + maxB.y) * 0.5f;
 

--- a/src/vegetation/TreeLODSystem.cpp
+++ b/src/vegetation/TreeLODSystem.cpp
@@ -753,21 +753,19 @@ void TreeLODSystem::update(float deltaTime, const glm::vec3& cameraPos, const Tr
             instance.archetypeIndex = state.archetypeIndex;
             instance.blendFactor = state.blendFactor;
 
-            // Use actual tree mesh bounds instead of archetype bounds
-            // Each tree has its own procedurally generated mesh with potentially different bounds
+            // Use full tree bounds (branches + leaves) for accurate imposter sizing
             if (tree.meshIndex < treeSystem.getMeshCount()) {
-                const auto& meshBounds = treeSystem.getBranchMesh(tree.meshIndex).getBounds();
-                glm::vec3 minB = meshBounds.min;
-                glm::vec3 maxB = meshBounds.max;
+                const auto& fullBounds = treeSystem.getFullTreeBounds(tree.meshIndex);
+                glm::vec3 minB = fullBounds.min;
+                glm::vec3 maxB = fullBounds.max;
                 glm::vec3 extent = maxB - minB;
 
-                // Billboard sizing: hSize uses bounding sphere for horizontal coverage,
+                // Billboard sizing: hSize uses horizontal extent for tighter fit,
                 // vSize uses half height to prevent ground penetration.
                 float horizontalRadius = std::max(extent.x, extent.z) * 0.5f;
                 float halfHeight = extent.y * 0.5f;
-                float boundingSphereRadius = glm::length(extent) * 0.5f;
 
-                float hSize = boundingSphereRadius * TreeLODConstants::IMPOSTOR_SIZE_MARGIN * tree.scale;
+                float hSize = horizontalRadius * TreeLODConstants::IMPOSTOR_SIZE_MARGIN * tree.scale;
                 float vSize = halfHeight * TreeLODConstants::IMPOSTOR_SIZE_MARGIN * tree.scale;
 
                 instance.hSize = hSize;

--- a/src/vegetation/TreeSystem.h
+++ b/src/vegetation/TreeSystem.h
@@ -134,6 +134,9 @@ public:
     const std::vector<LeafInstanceGPU>& getLeafInstances(uint32_t meshIndex) const { return leafInstancesPerTree_[meshIndex]; }
     const TreeOptions& getTreeOptions(uint32_t meshIndex) const { return treeOptions_[meshIndex]; }
 
+    // Get full tree bounds (branches + leaves) for accurate imposter sizing
+    const AABB& getFullTreeBounds(uint32_t meshIndex) const { return fullTreeBounds_[meshIndex]; }
+
 private:
     TreeSystem() = default;  // Private: use factory
 
@@ -185,6 +188,9 @@ private:
 
     // Raw mesh data (stored for collision generation)
     std::vector<TreeMeshData> treeMeshData_;
+
+    // Full tree bounds (branches + leaves) per mesh - for accurate imposter sizing
+    std::vector<AABB> fullTreeBounds_;
 
     // Textures indexed by type name (e.g., "oak", "pine", "ash")
     // Using RAIIAdapter for automatic cleanup matching RockSystem pattern


### PR DESCRIPTION
- Store full tree AABB (branches + leaves) per mesh in TreeSystem
- Use horizontal radius instead of 3D bounding sphere for billboard width
- Include leaf instances when computing tree bounds

The previous code used the 3D bounding sphere diagonal for hSize, making billboards much wider than necessary. Now uses the horizontal extent which provides a tighter fit closer to the actual tree canopy.