### PR TITLE
Fix grass shadow deformation animation

### DIFF
--- a/shaders/grass.vert
+++ b/shaders/grass.vert
@@ -6,6 +6,7 @@ const int NUM_CASCADES = 4;
 
 #include "bindings.glsl"
 #include "ubo_common.glsl"
+#include "grass_blade_common.glsl"
 
 struct GrassInstance {
     vec4 positionAndFacing;  // xyz = position, w = facing angle
@@ -27,155 +28,11 @@ layout(push_constant) uniform PushConstants {
     float time;
 } push;
 
-// Perlin noise implementation for wind variation
-// Uses the same permutation table as CPU for consistency
-const int perm[512] = int[512](
-    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
-    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
-    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
-    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
-    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
-    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
-    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
-    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
-    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
-    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
-    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
-    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
-    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
-    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
-    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
-    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180,
-    // Repeat for wrap-around
-    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
-    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
-    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
-    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
-    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
-    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
-    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
-    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
-    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
-    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
-    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
-    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
-    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
-    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
-    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
-    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
-);
-
-float fade(float t) {
-    return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
-}
-
-float grad(int hash, float x, float y) {
-    int h = hash & 7;
-    float u = h < 4 ? x : y;
-    float v = h < 4 ? y : x;
-    return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -2.0 * v : 2.0 * v);
-}
-
-float perlinNoise(float x, float y) {
-    int X = int(floor(x)) & 255;
-    int Y = int(floor(y)) & 255;
-
-    x -= floor(x);
-    y -= floor(y);
-
-    float u = fade(x);
-    float v = fade(y);
-
-    int A = perm[X] + Y;
-    int AA = perm[A];
-    int AB = perm[A + 1];
-    int B = perm[X + 1] + Y;
-    int BA = perm[B];
-    int BB = perm[B + 1];
-
-    float res = mix(
-        mix(grad(perm[AA], x, y),
-            grad(perm[BA], x - 1.0, y), u),
-        mix(grad(perm[AB], x, y - 1.0),
-            grad(perm[BB], x - 1.0, y - 1.0), u),
-        v
-    );
-
-    return (res + 1.0) * 0.5;
-}
-
-// Sample wind using scrolling Perlin noise
-// Multi-octave like: 0.7*sin(x/10) + 0.2*sin(x/5) + 0.1*sin(x/2.5)
-// Perlin noise approximates this - sampled at blade position, scrolls with wind
-float sampleWind(vec2 worldPos) {
-    vec2 windDir = wind.windDirectionAndStrength.xy;
-    float windStrength = wind.windDirectionAndStrength.z;
-    float windSpeed = wind.windDirectionAndStrength.w;
-    float windTime = wind.windParams.w;
-    float gustFreq = wind.windParams.x;
-    float gustAmp = wind.windParams.y;
-
-    // Scroll position in wind direction
-    vec2 scrolledPos = worldPos - windDir * windTime * windSpeed * 0.4;
-
-    // Three octaves: ~10m, ~5m, ~2.5m wavelengths
-    // baseFreq = 0.1 gives ~10m wavelength
-    float baseFreq = 0.1;
-    float n1 = perlinNoise(scrolledPos.x * baseFreq, scrolledPos.y * baseFreq);
-    float n2 = perlinNoise(scrolledPos.x * baseFreq * 2.0, scrolledPos.y * baseFreq * 2.0);
-    float n3 = perlinNoise(scrolledPos.x * baseFreq * 4.0, scrolledPos.y * baseFreq * 4.0);
-
-    // Weighted sum dominated by first octave (like 0.7 + 0.2 + 0.1)
-    float noise = n1 * 0.7 + n2 * 0.2 + n3 * 0.1;
-
-    // Add time-varying gust
-    float gust = (sin(windTime * gustFreq * 6.28318) * 0.5 + 0.5) * gustAmp;
-
-    return (noise + gust) * windStrength;
-}
-
 layout(location = 0) out vec3 fragColor;
 layout(location = 1) out vec3 fragNormal;
 layout(location = 2) out float fragHeight;
 layout(location = 3) out float fragClumpId;
 layout(location = 4) out vec3 fragWorldPos;
-
-// Quadratic Bezier evaluation
-vec3 bezier(vec3 p0, vec3 p1, vec3 p2, float t) {
-    float u = 1.0 - t;
-    return u * u * p0 + 2.0 * u * t * p1 + t * t * p2;
-}
-
-// Quadratic Bezier derivative
-vec3 bezierDerivative(vec3 p0, vec3 p1, vec3 p2, float t) {
-    float u = 1.0 - t;
-    return 2.0 * u * (p1 - p0) + 2.0 * t * (p2 - p1);
-}
-
-// Build orthonormal basis from terrain normal
-// Returns tangent (T) and bitangent (B) vectors
-void buildTerrainBasis(vec3 N, float facing, out vec3 T, out vec3 B) {
-    // Start with world up, but handle edge case where N is nearly vertical
-    vec3 up = vec3(0.0, 1.0, 0.0);
-    vec3 right = vec3(1.0, 0.0, 0.0);
-
-    // Choose a reference vector that's not parallel to N
-    vec3 ref = abs(N.y) < 0.99 ? up : right;
-
-    // First tangent perpendicular to N
-    T = normalize(cross(N, ref));
-    // Second tangent perpendicular to both
-    B = normalize(cross(N, T));
-
-    // Rotate tangent basis by facing angle around N
-    float cs = cos(facing);
-    float sn = sin(facing);
-    vec3 T_rotated = T * cs + B * sn;
-    vec3 B_rotated = -T * sn + B * cs;
-
-    T = T_rotated;
-    B = B_rotated;
-}
 
 void main() {
     // With indirect draw:
@@ -197,14 +54,22 @@ void main() {
     // B = bitangent (perpendicular to T on terrain surface)
     // N = terrain normal (grass "up" direction)
     vec3 T, B;
-    buildTerrainBasis(terrainNormal, facing, T, B);
+    grassBuildTerrainBasis(terrainNormal, facing, T, B);
 
     // Wind animation using noise-based wind system
     vec2 windDir = wind.windDirectionAndStrength.xy;
     float windTime = wind.windParams.w;
 
     // Sample wind strength at this blade's position
-    float windSample = sampleWind(vec2(basePos.x, basePos.z));
+    float windSample = grassSampleWind(
+        vec2(basePos.x, basePos.z),
+        windDir,
+        wind.windDirectionAndStrength.z,  // windStrength
+        wind.windDirectionAndStrength.w,  // windSpeed
+        windTime,
+        wind.windParams.x,  // gustFreq
+        wind.windParams.y   // gustAmp
+    );
 
     // Per-blade phase offset for variation (prevents lockstep motion)
     float windPhase = bladeHash * 6.28318;
@@ -220,60 +85,14 @@ void main() {
     float windEffect = (windSample + phaseOffset) * 0.25;
     float windOffset = windEffect * cos(relativeWindAngle);
 
-    // Blade folding for short grass
-    // Shorter blades fold over more (like real lawn grass bending under weight)
-    // Height range is ~0.3-0.7, normalize to 0-1 for folding calculation
-    float normalizedHeight = clamp((height - 0.3) / 0.4, 0.0, 1.0);
+    // Calculate blade deformation (fold/droop) - shared with shadow pass
+    GrassBladeControlPoints cp = grassCalculateBladeDeformation(height, bladeHash, tilt, windOffset);
 
-    // Fold amount: short grass (0) folds a lot, tall grass (1) stays upright
-    // foldAmount ranges from 0.6 (short) to 0.1 (tall)
-    float foldAmount = mix(0.6, 0.1, normalizedHeight);
-
-    // Add per-blade variation to fold direction using hash
-    float foldDirection = (bladeHash - 0.5) * 2.0;  // -1 to 1
-    float foldX = foldDirection * foldAmount * height;
-
-    // Short grass also droops more - tip ends up lower relative to height
-    float droopFactor = mix(0.3, 0.0, normalizedHeight);  // 30% droop for shortest
-    float effectiveHeight = height * (1.0 - droopFactor);
-
-    // Bezier control points (in local blade space)
-    vec3 p0 = vec3(0.0, 0.0, 0.0);  // Base
-    vec3 p1 = vec3(windOffset * 0.3 + tilt * 0.5 + foldX * 0.5, height * 0.6, 0.0);  // Mid control - higher for fold
-    vec3 p2 = vec3(windOffset + tilt + foldX, effectiveHeight, 0.0);  // Tip - with fold and droop
-
-    // Triangle strip blade geometry: 15 vertices = 7 segments (8 height levels)
-    // Even vertices (0,2,4,6,8,10,12,14) are left side
-    // Odd vertices (1,3,5,7,9,11,13) are right side
-    // Vertex 14 is the tip point (width = 0)
-    uint vi = gl_VertexIndex;
-
-    // Number of segments and height levels
-    const uint NUM_SEGMENTS = 7;
-    const float baseWidth = 0.02;
-
-    // Calculate which height level this vertex is at
-    uint segmentIndex = vi / 2;  // 0-7
-    bool isRightSide = (vi % 2) == 1;
-
-    // Calculate t (position along blade, 0 = base, 1 = tip)
-    float t = float(segmentIndex) / float(NUM_SEGMENTS);
-
-    // Width tapers from base to tip (90% taper)
-    float widthAtT = baseWidth * (1.0 - t * 0.9);
-
-    // For the last vertex (tip), width is 0
-    if (vi == 14) {
-        widthAtT = 0.0;
-        t = 1.0;
-    }
-
-    // Offset left or right from center
-    float xOffset = isRightSide ? widthAtT : -widthAtT;
-
-    // Get position on bezier curve and offset by width
-    vec3 curvePos = bezier(p0, p1, p2, t);
-    vec3 localPos = curvePos + vec3(xOffset, 0.0, 0.0);
+    // Calculate blade vertex position
+    vec3 localPos;
+    float t;
+    float widthAtT;
+    grassCalculateBladeVertex(gl_VertexIndex, cp, localPos, t, widthAtT);
 
     // Blade's right vector (B - bitangent, perpendicular to facing in terrain plane)
     vec3 bladeRight = B;
@@ -304,7 +123,7 @@ void main() {
 
     // Calculate normal (perpendicular to blade surface)
     // Bezier tangent is in local space (X=width, Y=up, Z=forward)
-    vec3 localTangent = normalize(bezierDerivative(p0, p1, p2, t));
+    vec3 localTangent = normalize(grassBezierDerivative(cp.p0, cp.p1, cp.p2, t));
 
     // Transform tangent to world space using terrain basis
     vec3 worldTangent = B * localTangent.x +

--- a/shaders/grass_blade_common.glsl
+++ b/shaders/grass_blade_common.glsl
@@ -1,0 +1,238 @@
+/*
+ * grass_blade_common.glsl - Common grass blade geometry and deformation
+ *
+ * Provides shared functions for grass blade rendering and shadow passes.
+ * Both passes must use identical deformation to ensure shadow consistency.
+ */
+
+#ifndef GRASS_BLADE_COMMON_GLSL
+#define GRASS_BLADE_COMMON_GLSL
+
+// Perlin noise implementation for wind variation
+// Uses fixed permutation table for consistency
+const int grassPerm[512] = int[512](
+    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
+    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
+    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
+    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
+    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
+    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
+    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
+    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
+    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
+    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
+    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
+    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
+    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
+    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
+    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
+    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180,
+    // Repeat for wrap-around
+    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
+    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
+    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
+    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
+    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
+    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
+    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
+    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
+    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
+    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
+    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
+    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
+    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
+    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
+    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
+    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
+);
+
+float grassFade(float t) {
+    return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+}
+
+float grassGrad(int hash, float x, float y) {
+    int h = hash & 7;
+    float u = h < 4 ? x : y;
+    float v = h < 4 ? y : x;
+    return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -2.0 * v : 2.0 * v);
+}
+
+float grassPerlinNoise(float x, float y) {
+    int X = int(floor(x)) & 255;
+    int Y = int(floor(y)) & 255;
+
+    x -= floor(x);
+    y -= floor(y);
+
+    float u = grassFade(x);
+    float v = grassFade(y);
+
+    int A = grassPerm[X] + Y;
+    int AA = grassPerm[A];
+    int AB = grassPerm[A + 1];
+    int B = grassPerm[X + 1] + Y;
+    int BA = grassPerm[B];
+    int BB = grassPerm[B + 1];
+
+    float res = mix(
+        mix(grassGrad(grassPerm[AA], x, y),
+            grassGrad(grassPerm[BA], x - 1.0, y), u),
+        mix(grassGrad(grassPerm[AB], x, y - 1.0),
+            grassGrad(grassPerm[BB], x - 1.0, y - 1.0), u),
+        v
+    );
+
+    return (res + 1.0) * 0.5;
+}
+
+// Sample wind using scrolling Perlin noise
+// Multi-octave: 0.7*sin(x/10) + 0.2*sin(x/5) + 0.1*sin(x/2.5)
+// windDir: xy = normalized direction
+// windStrength: wind strength
+// windSpeed: wind speed
+// windTime: time for animation
+// gustFreq: gust frequency
+// gustAmp: gust amplitude
+float grassSampleWind(vec2 worldPos, vec2 windDir, float windStrength, float windSpeed,
+                      float windTime, float gustFreq, float gustAmp) {
+    // Scroll position in wind direction
+    vec2 scrolledPos = worldPos - windDir * windTime * windSpeed * 0.4;
+
+    // Three octaves: ~10m, ~5m, ~2.5m wavelengths
+    // baseFreq = 0.1 gives ~10m wavelength
+    float baseFreq = 0.1;
+    float n1 = grassPerlinNoise(scrolledPos.x * baseFreq, scrolledPos.y * baseFreq);
+    float n2 = grassPerlinNoise(scrolledPos.x * baseFreq * 2.0, scrolledPos.y * baseFreq * 2.0);
+    float n3 = grassPerlinNoise(scrolledPos.x * baseFreq * 4.0, scrolledPos.y * baseFreq * 4.0);
+
+    // Weighted sum dominated by first octave (like 0.7 + 0.2 + 0.1)
+    float noise = n1 * 0.7 + n2 * 0.2 + n3 * 0.1;
+
+    // Add time-varying gust
+    float gust = (sin(windTime * gustFreq * 6.28318) * 0.5 + 0.5) * gustAmp;
+
+    return (noise + gust) * windStrength;
+}
+
+// Quadratic Bezier evaluation
+vec3 grassBezier(vec3 p0, vec3 p1, vec3 p2, float t) {
+    float u = 1.0 - t;
+    return u * u * p0 + 2.0 * u * t * p1 + t * t * p2;
+}
+
+// Quadratic Bezier derivative
+vec3 grassBezierDerivative(vec3 p0, vec3 p1, vec3 p2, float t) {
+    float u = 1.0 - t;
+    return 2.0 * u * (p1 - p0) + 2.0 * t * (p2 - p1);
+}
+
+// Build orthonormal basis from terrain normal
+// Returns tangent (T) and bitangent (B) vectors
+void grassBuildTerrainBasis(vec3 N, float facing, out vec3 T, out vec3 B) {
+    // Start with world up, but handle edge case where N is nearly vertical
+    vec3 up = vec3(0.0, 1.0, 0.0);
+    vec3 right = vec3(1.0, 0.0, 0.0);
+
+    // Choose a reference vector that's not parallel to N
+    vec3 ref = abs(N.y) < 0.99 ? up : right;
+
+    // First tangent perpendicular to N
+    T = normalize(cross(N, ref));
+    // Second tangent perpendicular to both
+    B = normalize(cross(N, T));
+
+    // Rotate tangent basis by facing angle around N
+    float cs = cos(facing);
+    float sn = sin(facing);
+    vec3 T_rotated = T * cs + B * sn;
+    vec3 B_rotated = -T * sn + B * cs;
+
+    T = T_rotated;
+    B = B_rotated;
+}
+
+// Grass blade deformation result - Bezier control points
+struct GrassBladeControlPoints {
+    vec3 p0;  // Base
+    vec3 p1;  // Mid control
+    vec3 p2;  // Tip
+};
+
+// Calculate grass blade deformation including fold/droop for short grass
+// This function MUST be used by both render and shadow passes for consistency
+GrassBladeControlPoints grassCalculateBladeDeformation(
+    float height,
+    float bladeHash,
+    float tilt,
+    float windOffset
+) {
+    GrassBladeControlPoints result;
+
+    // Blade folding for short grass
+    // Shorter blades fold over more (like real lawn grass bending under weight)
+    // Height range is ~0.3-0.7, normalize to 0-1 for folding calculation
+    float normalizedHeight = clamp((height - 0.3) / 0.4, 0.0, 1.0);
+
+    // Fold amount: short grass (0) folds a lot, tall grass (1) stays upright
+    // foldAmount ranges from 0.6 (short) to 0.1 (tall)
+    float foldAmount = mix(0.6, 0.1, normalizedHeight);
+
+    // Add per-blade variation to fold direction using hash
+    float foldDirection = (bladeHash - 0.5) * 2.0;  // -1 to 1
+    float foldX = foldDirection * foldAmount * height;
+
+    // Short grass also droops more - tip ends up lower relative to height
+    float droopFactor = mix(0.3, 0.0, normalizedHeight);  // 30% droop for shortest
+    float effectiveHeight = height * (1.0 - droopFactor);
+
+    // Bezier control points (in local blade space)
+    result.p0 = vec3(0.0, 0.0, 0.0);  // Base
+    result.p1 = vec3(windOffset * 0.3 + tilt * 0.5 + foldX * 0.5, height * 0.6, 0.0);  // Mid control - higher for fold
+    result.p2 = vec3(windOffset + tilt + foldX, effectiveHeight, 0.0);  // Tip - with fold and droop
+
+    return result;
+}
+
+// Constants for blade geometry
+const uint GRASS_NUM_SEGMENTS = 7;
+const float GRASS_BASE_WIDTH = 0.02;
+
+// Calculate blade vertex position given vertex index
+// Returns: localPos in blade space, t (position along blade 0-1), widthAtT
+void grassCalculateBladeVertex(
+    uint vertexIndex,
+    GrassBladeControlPoints cp,
+    out vec3 localPos,
+    out float t,
+    out float widthAtT
+) {
+    // Triangle strip blade geometry: 15 vertices = 7 segments (8 height levels)
+    // Even vertices (0,2,4,6,8,10,12,14) are left side
+    // Odd vertices (1,3,5,7,9,11,13) are right side
+    // Vertex 14 is the tip point (width = 0)
+
+    // Calculate which height level this vertex is at
+    uint segmentIndex = vertexIndex / 2;  // 0-7
+    bool isRightSide = (vertexIndex % 2) == 1;
+
+    // Calculate t (position along blade, 0 = base, 1 = tip)
+    t = float(segmentIndex) / float(GRASS_NUM_SEGMENTS);
+
+    // Width tapers from base to tip (90% taper)
+    widthAtT = GRASS_BASE_WIDTH * (1.0 - t * 0.9);
+
+    // For the last vertex (tip), width is 0
+    if (vertexIndex == 14) {
+        widthAtT = 0.0;
+        t = 1.0;
+    }
+
+    // Offset left or right from center
+    float xOffset = isRightSide ? widthAtT : -widthAtT;
+
+    // Get position on bezier curve and offset by width
+    vec3 curvePos = grassBezier(cp.p0, cp.p1, cp.p2, t);
+    localPos = curvePos + vec3(xOffset, 0.0, 0.0);
+}
+
+#endif // GRASS_BLADE_COMMON_GLSL

--- a/shaders/grass_shadow.vert
+++ b/shaders/grass_shadow.vert
@@ -6,6 +6,7 @@ const int NUM_CASCADES = 4;
 
 #include "bindings.glsl"
 #include "ubo_common.glsl"
+#include "grass_blade_common.glsl"
 
 struct GrassInstance {
     vec4 positionAndFacing;  // xyz = position, w = facing angle
@@ -29,135 +30,8 @@ layout(push_constant) uniform PushConstants {
     int cascadeIndex;  // Which cascade we're rendering
 } push;
 
-// Perlin noise implementation (same as grass.vert for consistent shadows)
-const int perm[512] = int[512](
-    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
-    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
-    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
-    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
-    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
-    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
-    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
-    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
-    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
-    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
-    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
-    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
-    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
-    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
-    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
-    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180,
-    151,160,137,91,90,15,131,13,201,95,96,53,194,233,7,225,
-    140,36,103,30,69,142,8,99,37,240,21,10,23,190,6,148,
-    247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,
-    57,177,33,88,237,149,56,87,174,20,125,136,171,168,68,175,
-    74,165,71,134,139,48,27,166,77,146,158,231,83,111,229,122,
-    60,211,133,230,220,105,92,41,55,46,245,40,244,102,143,54,
-    65,25,63,161,1,216,80,73,209,76,132,187,208,89,18,169,
-    200,196,135,130,116,188,159,86,164,100,109,198,173,186,3,64,
-    52,217,226,250,124,123,5,202,38,147,118,126,255,82,85,212,
-    207,206,59,227,47,16,58,17,182,189,28,42,223,183,170,213,
-    119,248,152,2,44,154,163,70,221,153,101,155,167,43,172,9,
-    129,22,39,253,19,98,108,110,79,113,224,232,178,185,112,104,
-    218,246,97,228,251,34,242,193,238,210,144,12,191,179,162,241,
-    81,51,145,235,249,14,239,107,49,192,214,31,181,199,106,157,
-    184,84,204,176,115,121,50,45,127,4,150,254,138,236,205,93,
-    222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
-);
-
-float fade(float t) {
-    return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
-}
-
-float grad(int hash, float x, float y) {
-    int h = hash & 7;
-    float u = h < 4 ? x : y;
-    float v = h < 4 ? y : x;
-    return ((h & 1) != 0 ? -u : u) + ((h & 2) != 0 ? -2.0 * v : 2.0 * v);
-}
-
-float perlinNoise(float x, float y) {
-    int X = int(floor(x)) & 255;
-    int Y = int(floor(y)) & 255;
-
-    x -= floor(x);
-    y -= floor(y);
-
-    float u = fade(x);
-    float v = fade(y);
-
-    int A = perm[X] + Y;
-    int AA = perm[A];
-    int AB = perm[A + 1];
-    int B = perm[X + 1] + Y;
-    int BA = perm[B];
-    int BB = perm[B + 1];
-
-    float res = mix(
-        mix(grad(perm[AA], x, y),
-            grad(perm[BA], x - 1.0, y), u),
-        mix(grad(perm[AB], x, y - 1.0),
-            grad(perm[BB], x - 1.0, y - 1.0), u),
-        v
-    );
-
-    return (res + 1.0) * 0.5;
-}
-
-// Sample wind using scrolling Perlin noise
-// Must match grass.vert for consistent shadows
-float sampleWind(vec2 worldPos) {
-    vec2 windDir = wind.windDirectionAndStrength.xy;
-    float windStrength = wind.windDirectionAndStrength.z;
-    float windSpeed = wind.windDirectionAndStrength.w;
-    float windTime = wind.windParams.w;
-    float gustFreq = wind.windParams.x;
-    float gustAmp = wind.windParams.y;
-
-    // Scroll position in wind direction
-    vec2 scrolledPos = worldPos - windDir * windTime * windSpeed * 0.4;
-
-    // Three octaves: ~10m, ~5m, ~2.5m wavelengths
-    float baseFreq = 0.1;
-    float n1 = perlinNoise(scrolledPos.x * baseFreq, scrolledPos.y * baseFreq);
-    float n2 = perlinNoise(scrolledPos.x * baseFreq * 2.0, scrolledPos.y * baseFreq * 2.0);
-    float n3 = perlinNoise(scrolledPos.x * baseFreq * 4.0, scrolledPos.y * baseFreq * 4.0);
-
-    // Weighted sum dominated by first octave
-    float noise = n1 * 0.7 + n2 * 0.2 + n3 * 0.1;
-
-    // Add time-varying gust
-    float gust = (sin(windTime * gustFreq * 6.28318) * 0.5 + 0.5) * gustAmp;
-
-    return (noise + gust) * windStrength;
-}
-
 layout(location = 0) out float fragHeight;
 layout(location = 1) out float fragHash;
-
-// Quadratic Bezier evaluation
-vec3 bezier(vec3 p0, vec3 p1, vec3 p2, float t) {
-    float u = 1.0 - t;
-    return u * u * p0 + 2.0 * u * t * p1 + t * t * p2;
-}
-
-// Build orthonormal basis from terrain normal (same as grass.vert)
-void buildTerrainBasis(vec3 N, float facing, out vec3 T, out vec3 B) {
-    vec3 up = vec3(0.0, 1.0, 0.0);
-    vec3 right = vec3(1.0, 0.0, 0.0);
-    vec3 ref = abs(N.y) < 0.99 ? up : right;
-
-    T = normalize(cross(N, ref));
-    B = normalize(cross(N, T));
-
-    float cs = cos(facing);
-    float sn = sin(facing);
-    vec3 T_rotated = T * cs + B * sn;
-    vec3 B_rotated = -T * sn + B * cs;
-
-    T = T_rotated;
-    B = B_rotated;
-}
 
 void main() {
     // Get instance data using gl_InstanceIndex
@@ -171,14 +45,22 @@ void main() {
 
     // Build coordinate frame aligned to terrain surface
     vec3 T, B;
-    buildTerrainBasis(terrainNormal, facing, T, B);
+    grassBuildTerrainBasis(terrainNormal, facing, T, B);
 
     // Wind animation using noise-based wind system (must match grass.vert for consistent shadows)
     vec2 windDir = wind.windDirectionAndStrength.xy;
     float windTime = wind.windParams.w;
 
     // Sample wind strength at this blade's position
-    float windSample = sampleWind(vec2(basePos.x, basePos.z));
+    float windSample = grassSampleWind(
+        vec2(basePos.x, basePos.z),
+        windDir,
+        wind.windDirectionAndStrength.z,  // windStrength
+        wind.windDirectionAndStrength.w,  // windSpeed
+        windTime,
+        wind.windParams.x,  // gustFreq
+        wind.windParams.y   // gustAmp
+    );
 
     // Per-blade phase offset for variation (prevents lockstep motion)
     float windPhase = bladeHash * 6.28318;
@@ -190,32 +72,14 @@ void main() {
     float windEffect = (windSample + phaseOffset) * 0.25;
     float windOffset = windEffect * cos(relativeWindAngle);
 
-    // Bezier control points (in local blade space)
-    vec3 p0 = vec3(0.0, 0.0, 0.0);  // Base
-    vec3 p1 = vec3(windOffset * 0.3 + tilt * 0.5, height * 0.5, 0.0);  // Mid control
-    vec3 p2 = vec3(windOffset + tilt, height, 0.0);  // Tip
+    // Calculate blade deformation (fold/droop) - SAME as main render pass
+    GrassBladeControlPoints cp = grassCalculateBladeDeformation(height, bladeHash, tilt, windOffset);
 
-    // Triangle strip blade geometry: 15 vertices = 7 segments (8 height levels)
-    uint vi = gl_VertexIndex;
-    const uint NUM_SEGMENTS = 7;
-    const float baseWidth = 0.02;
-
-    uint segmentIndex = vi / 2;
-    bool isRightSide = (vi % 2) == 1;
-
-    float t = float(segmentIndex) / float(NUM_SEGMENTS);
-    float widthAtT = baseWidth * (1.0 - t * 0.9);
-
-    if (vi == 14) {
-        widthAtT = 0.0;
-        t = 1.0;
-    }
-
-    float xOffset = isRightSide ? widthAtT : -widthAtT;
-
-    // Get position on bezier curve
-    vec3 curvePos = bezier(p0, p1, p2, t);
-    vec3 localPos = curvePos + vec3(xOffset, 0.0, 0.0);
+    // Calculate blade vertex position
+    vec3 localPos;
+    float t;
+    float widthAtT;
+    grassCalculateBladeVertex(gl_VertexIndex, cp, localPos, t, widthAtT);
 
     // Transform from local blade space to world space using terrain basis
     // Local X = blade width direction (bitangent B)


### PR DESCRIPTION
Refactored grass shaders to use a shared include file (grass_blade_common.glsl) for blade deformation calculations. Both the main render pass (grass.vert) and shadow pass (grass_shadow.vert) now use the same grassCalculateBladeDeformation function, ensuring shadow geometry matches the rendered grass blades.

Previously, the shadow pass was missing the fold/droop calculations, causing shadows to have incorrect silhouettes compared to the rendered grass.