### PR TITLE
Remove legacy atlas keep octahedral

### DIFF
--- a/shaders/tree_impostor.frag
+++ b/shaders/tree_impostor.frag
@@ -19,11 +19,8 @@ layout(location = 2) in float fragBlendFactor;
 layout(location = 3) flat in int fragCellIndex;
 layout(location = 4) in mat3 fragImpostorToWorld;
 layout(location = 7) flat in uint fragArchetypeIndex;
-
-// Octahedral mode inputs
 layout(location = 8) in vec2 fragOctaUV;
 layout(location = 9) in vec3 fragViewDir;
-layout(location = 10) flat in int fragUseOctahedral;
 layout(location = 11) in vec2 fragLocalUV;   // Billboard local UV for frame sampling
 
 layout(location = 0) out vec4 outColor;
@@ -37,7 +34,7 @@ layout(binding = BINDING_TREE_IMPOSTOR_SHADOW_MAP) uniform sampler2DArrayShadow 
 
 layout(push_constant) uniform PushConstants {
     vec4 cameraPos;     // xyz = camera position, w = autumnHueShift
-    vec4 lodParams;     // x = useOctahedral, y = brightness, z = normal strength, w = unused
+    vec4 lodParams;     // x = unused, y = brightness, z = normal strength, w = unused
     vec4 atlasParams;   // x = enableFrameBlending, y = unused, z = unused, w = unused
 } push;
 
@@ -68,106 +65,99 @@ void main() {
     vec4 albedoAlpha;
     vec4 normalDepthAO;
 
-    if (fragUseOctahedral != 0) {
-        // Octahedral mode with optional frame blending
-        bool enableBlending = push.atlasParams.x > 0.5;
-        float gridSize = float(OCTA_GRID_SIZE);
+    // Octahedral mode with optional frame blending
+    bool enableBlending = push.atlasParams.x > 0.5;
+    float gridSize = float(OCTA_GRID_SIZE);
 
-        if (enableBlending) {
-            // Encode view direction to find which cells to blend
-            vec2 octaUV = hemiOctaEncode(fragViewDir);
-            vec2 scaledUV = octaUV * gridSize;
-            ivec2 cell = ivec2(floor(scaledUV));
-            cell = clamp(cell, ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
-            vec2 frac = fract(scaledUV);
+    if (enableBlending) {
+        // Encode view direction to find which cells to blend
+        vec2 octaUV = hemiOctaEncode(fragViewDir);
+        vec2 scaledUV = octaUV * gridSize;
+        ivec2 cell = ivec2(floor(scaledUV));
+        cell = clamp(cell, ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
+        vec2 frac = fract(scaledUV);
 
-            // Check if we're at the edge of the atlas where blending would wrap incorrectly
-            bool atEdge = cell.x == 0 || cell.x == OCTA_GRID_SIZE - 1 ||
-                          cell.y == 0 || cell.y == OCTA_GRID_SIZE - 1;
+        // Check if we're at the edge of the atlas where blending would wrap incorrectly
+        bool atEdge = cell.x == 0 || cell.x == OCTA_GRID_SIZE - 1 ||
+                      cell.y == 0 || cell.y == OCTA_GRID_SIZE - 1;
 
-            // Determine which triangle half we're in (for 3-frame blending)
-            bool upperTriangle = (frac.x + frac.y) < 1.0;
+        // Determine which triangle half we're in (for 3-frame blending)
+        bool upperTriangle = (frac.x + frac.y) < 1.0;
 
-            // Frame indices (cells)
-            ivec2 frame0 = cell;
-            ivec2 frame1 = clamp(cell + ivec2(1, 0), ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
-            ivec2 frame2 = upperTriangle
-                ? clamp(cell + ivec2(0, 1), ivec2(0), ivec2(OCTA_GRID_SIZE - 1))
-                : clamp(cell + ivec2(1, 1), ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
+        // Frame indices (cells)
+        ivec2 frame0 = cell;
+        ivec2 frame1 = clamp(cell + ivec2(1, 0), ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
+        ivec2 frame2 = upperTriangle
+            ? clamp(cell + ivec2(0, 1), ivec2(0), ivec2(OCTA_GRID_SIZE - 1))
+            : clamp(cell + ivec2(1, 1), ivec2(0), ivec2(OCTA_GRID_SIZE - 1));
 
-            // At edges, fall back to single-frame lookup to avoid artifacts
-            if (atEdge) {
-                vec2 frameUV0 = (vec2(frame0) + fragLocalUV) / gridSize;
-                albedoAlpha = sampleOctahedralFrame(frameUV0, fragArchetypeIndex);
-                normalDepthAO = sampleOctahedralNormal(frameUV0, fragArchetypeIndex);
-            } else {
-                // Compute blend weights using barycentric-like interpolation
-                float w0, w1, w2;
-                if (upperTriangle) {
-                    w0 = 1.0 - frac.x - frac.y;
-                    w1 = frac.x;
-                    w2 = frac.y;
-                } else {
-                    w0 = frac.x + frac.y - 1.0;
-                    w1 = 1.0 - frac.y;
-                    w2 = 1.0 - frac.x;
-                }
-                // Normalize weights
-                float wSum = w0 + w1 + w2;
-                w0 /= wSum; w1 /= wSum; w2 /= wSum;
-
-                // Compute atlas UVs for each frame using the billboard's local UV
-                vec2 frameUV0 = (vec2(frame0) + fragLocalUV) / gridSize;
-                vec2 frameUV1 = (vec2(frame1) + fragLocalUV) / gridSize;
-                vec2 frameUV2 = (vec2(frame2) + fragLocalUV) / gridSize;
-
-                // Sample all 3 frames
-                vec4 albedo0 = sampleOctahedralFrame(frameUV0, fragArchetypeIndex);
-                vec4 albedo1 = sampleOctahedralFrame(frameUV1, fragArchetypeIndex);
-                vec4 albedo2 = sampleOctahedralFrame(frameUV2, fragArchetypeIndex);
-
-                vec4 normal0 = sampleOctahedralNormal(frameUV0, fragArchetypeIndex);
-                vec4 normal1 = sampleOctahedralNormal(frameUV1, fragArchetypeIndex);
-                vec4 normal2 = sampleOctahedralNormal(frameUV2, fragArchetypeIndex);
-
-                // For trees, simple RGB blending makes them look denser because we're
-                // overlapping leaves from different viewpoints. Instead, use alpha-weighted
-                // selection: pick the frame that has the most solid content at this pixel,
-                // but transition smoothly between frames based on view direction.
-
-                // Compute effective weights: combine barycentric weight with alpha presence
-                // This makes us prefer frames where there's actual tree content
-                float eff0 = w0 * albedo0.a;
-                float eff1 = w1 * albedo1.a;
-                float eff2 = w2 * albedo2.a;
-                float effSum = eff0 + eff1 + eff2 + 0.001;
-
-                // Sharpen the selection to avoid blending multiple frames equally
-                // This reduces the "double density" effect
-                float sharpness = 4.0;
-                float sharp0 = pow(eff0 / effSum, sharpness);
-                float sharp1 = pow(eff1 / effSum, sharpness);
-                float sharp2 = pow(eff2 / effSum, sharpness);
-                float sharpSum = sharp0 + sharp1 + sharp2 + 0.001;
-                float finalW0 = sharp0 / sharpSum;
-                float finalW1 = sharp1 / sharpSum;
-                float finalW2 = sharp2 / sharpSum;
-
-                // Blend based on sharpened weights
-                albedoAlpha = albedo0 * finalW0 + albedo1 * finalW1 + albedo2 * finalW2;
-                normalDepthAO = normal0 * finalW0 + normal1 * finalW1 + normal2 * finalW2;
-
-                // Alpha: use the weighted blend (not max) to preserve actual density
-                albedoAlpha.a = albedo0.a * w0 + albedo1.a * w1 + albedo2.a * w2;
-            }
+        // At edges, fall back to single-frame lookup to avoid artifacts
+        if (atEdge) {
+            vec2 frameUV0 = (vec2(frame0) + fragLocalUV) / gridSize;
+            albedoAlpha = sampleOctahedralFrame(frameUV0, fragArchetypeIndex);
+            normalDepthAO = sampleOctahedralNormal(frameUV0, fragArchetypeIndex);
         } else {
-            // Single frame lookup (no blending) - use fragTexCoord which is already computed
-            vec3 atlasCoord = vec3(fragTexCoord, float(fragArchetypeIndex));
-            albedoAlpha = texture(albedoAlphaAtlas, atlasCoord);
-            normalDepthAO = texture(normalDepthAOAtlas, atlasCoord);
+            // Compute blend weights using barycentric-like interpolation
+            float w0, w1, w2;
+            if (upperTriangle) {
+                w0 = 1.0 - frac.x - frac.y;
+                w1 = frac.x;
+                w2 = frac.y;
+            } else {
+                w0 = frac.x + frac.y - 1.0;
+                w1 = 1.0 - frac.y;
+                w2 = 1.0 - frac.x;
+            }
+            // Normalize weights
+            float wSum = w0 + w1 + w2;
+            w0 /= wSum; w1 /= wSum; w2 /= wSum;
+
+            // Compute atlas UVs for each frame using the billboard's local UV
+            vec2 frameUV0 = (vec2(frame0) + fragLocalUV) / gridSize;
+            vec2 frameUV1 = (vec2(frame1) + fragLocalUV) / gridSize;
+            vec2 frameUV2 = (vec2(frame2) + fragLocalUV) / gridSize;
+
+            // Sample all 3 frames
+            vec4 albedo0 = sampleOctahedralFrame(frameUV0, fragArchetypeIndex);
+            vec4 albedo1 = sampleOctahedralFrame(frameUV1, fragArchetypeIndex);
+            vec4 albedo2 = sampleOctahedralFrame(frameUV2, fragArchetypeIndex);
+
+            vec4 normal0 = sampleOctahedralNormal(frameUV0, fragArchetypeIndex);
+            vec4 normal1 = sampleOctahedralNormal(frameUV1, fragArchetypeIndex);
+            vec4 normal2 = sampleOctahedralNormal(frameUV2, fragArchetypeIndex);
+
+            // For trees, simple RGB blending makes them look denser because we're
+            // overlapping leaves from different viewpoints. Instead, use alpha-weighted
+            // selection: pick the frame that has the most solid content at this pixel,
+            // but transition smoothly between frames based on view direction.
+
+            // Compute effective weights: combine barycentric weight with alpha presence
+            // This makes us prefer frames where there's actual tree content
+            float eff0 = w0 * albedo0.a;
+            float eff1 = w1 * albedo1.a;
+            float eff2 = w2 * albedo2.a;
+            float effSum = eff0 + eff1 + eff2 + 0.001;
+
+            // Sharpen the selection to avoid blending multiple frames equally
+            // This reduces the "double density" effect
+            float sharpness = 4.0;
+            float sharp0 = pow(eff0 / effSum, sharpness);
+            float sharp1 = pow(eff1 / effSum, sharpness);
+            float sharp2 = pow(eff2 / effSum, sharpness);
+            float sharpSum = sharp0 + sharp1 + sharp2 + 0.001;
+            float finalW0 = sharp0 / sharpSum;
+            float finalW1 = sharp1 / sharpSum;
+            float finalW2 = sharp2 / sharpSum;
+
+            // Blend based on sharpened weights
+            albedoAlpha = albedo0 * finalW0 + albedo1 * finalW1 + albedo2 * finalW2;
+            normalDepthAO = normal0 * finalW0 + normal1 * finalW1 + normal2 * finalW2;
+
+            // Alpha: use the weighted blend (not max) to preserve actual density
+            albedoAlpha.a = albedo0.a * w0 + albedo1.a * w1 + albedo2.a * w2;
         }
     } else {
-        // Legacy mode: direct texture lookup
+        // Single frame lookup (no blending) - use fragTexCoord which is already computed
         vec3 atlasCoord = vec3(fragTexCoord, float(fragArchetypeIndex));
         albedoAlpha = texture(albedoAlphaAtlas, atlasCoord);
         normalDepthAO = texture(normalDepthAOAtlas, atlasCoord);

--- a/src/gui/GuiTreeTab.cpp
+++ b/src/gui/GuiTreeTab.cpp
@@ -130,25 +130,15 @@ void GuiTreeTab::render(ITreeControl& treeControl) {
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.6f, 0.8f, 1.0f, 1.0f));
-            ImGui::Text("Octahedral Impostor Mode (Phase 6):");
+            ImGui::Text("Octahedral Impostor Atlas:");
             ImGui::PopStyleColor();
-            ImGui::Checkbox("Use Octahedral Mapping", &settings.useOctahedralMapping);
+            ImGui::Checkbox("Frame Blending", &settings.enableFrameBlending);
             if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Use octahedral (hemi-sphere) impostor atlas instead of legacy 17-view.\n"
-                                  "Provides smoother view transitions and better angle coverage.\n"
-                                  "8x8 grid = 64 views vs 17 discrete views.");
+                ImGui::SetTooltip("Blend between 3 nearest frames for smooth transitions.\n"
+                                  "Eliminates popping when view angle changes.\n"
+                                  "Slightly more expensive (3 texture lookups).");
             }
-            if (settings.useOctahedralMapping) {
-                ImGui::Checkbox("Frame Blending", &settings.enableFrameBlending);
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("Blend between 3 nearest frames for smooth transitions.\n"
-                                      "Eliminates popping when view angle changes.\n"
-                                      "Slightly more expensive (3 texture lookups).");
-                }
-                ImGui::TextColored(ImVec4(0.5f, 1.0f, 0.5f, 1.0f), "  Octahedral: 8x8 grid = 64 views");
-            } else {
-                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.5f, 1.0f), "  Legacy: 2x9 grid = 17 views");
-            }
+            ImGui::TextColored(ImVec4(0.5f, 1.0f, 0.5f, 1.0f), "  8x8 grid = 64 views");
 
             // Two-phase leaf culling toggle
             auto* treeRenderer = treeControl.getSystems().treeRenderer();
@@ -286,71 +276,24 @@ void GuiTreeTab::render(ITreeControl& treeControl) {
                     }
                 }
 
-                // Atlas texture preview buttons
+                // Atlas texture preview button
                 VkDescriptorSet previewSet = atlas->getPreviewDescriptorSet(0);
                 if (previewSet != VK_NULL_HANDLE) {
-                    if (ImGui::Button("Preview Legacy Atlas")) {
+                    if (ImGui::Button("Preview Atlas")) {
                         ImGui::OpenPopup("AtlasPreview");
                     }
 
-                    // Preview popup window
                     if (ImGui::BeginPopup("AtlasPreview")) {
-                        ImGui::Text("Legacy Impostor Atlas (9x2 cells, 256px each)");
-                        ImGui::Separator();
-
-                        // Draw atlas with cell grid overlay
-                        ImVec2 imageSize(ImpostorAtlasConfig::ATLAS_WIDTH * 0.5f,
-                                        ImpostorAtlasConfig::ATLAS_HEIGHT * 0.5f);
-
-                        ImVec2 cursorPos = ImGui::GetCursorScreenPos();
-                        ImGui::Image(reinterpret_cast<ImTextureID>(previewSet), imageSize);
-
-                        // Draw grid lines to show cells
-                        ImDrawList* drawList = ImGui::GetWindowDrawList();
-                        float cellW = imageSize.x / ImpostorAtlasConfig::CELLS_PER_ROW;
-                        float cellH = imageSize.y / ImpostorAtlasConfig::VERTICAL_LEVELS;
-                        ImU32 gridColor = IM_COL32(255, 255, 255, 80);
-
-                        // Vertical lines
-                        for (int x = 0; x <= ImpostorAtlasConfig::CELLS_PER_ROW; x++) {
-                            float px = cursorPos.x + x * cellW;
-                            drawList->AddLine(ImVec2(px, cursorPos.y),
-                                            ImVec2(px, cursorPos.y + imageSize.y), gridColor);
-                        }
-                        // Horizontal lines
-                        for (int y = 0; y <= ImpostorAtlasConfig::VERTICAL_LEVELS; y++) {
-                            float py = cursorPos.y + y * cellH;
-                            drawList->AddLine(ImVec2(cursorPos.x, py),
-                                            ImVec2(cursorPos.x + imageSize.x, py), gridColor);
-                        }
-
-                        ImGui::Spacing();
-                        ImGui::Text("Row 0: 8 horizon views (0-315 deg) + top-down");
-                        ImGui::Text("Row 1: 8 elevated views (45 deg elevation)");
-
-                        ImGui::EndPopup();
-                    }
-                }
-
-                // Octahedral atlas preview
-                ImGui::SameLine();
-                VkDescriptorSet octaPreviewSet = atlas->getOctahedralPreviewDescriptorSet(0);
-                if (octaPreviewSet != VK_NULL_HANDLE) {
-                    if (ImGui::Button("Preview Octahedral Atlas")) {
-                        ImGui::OpenPopup("OctaAtlasPreview");
-                    }
-
-                    if (ImGui::BeginPopup("OctaAtlasPreview")) {
                         ImGui::Text("Octahedral Impostor Atlas (8x8 grid, 256px cells)");
                         ImGui::Separator();
 
-                        // Draw octahedral atlas with grid overlay
-                        float scale = 0.4f;  // Smaller scale since it's larger
+                        // Draw atlas with grid overlay
+                        float scale = 0.4f;
                         ImVec2 imageSize(OctahedralAtlasConfig::ATLAS_WIDTH * scale,
                                         OctahedralAtlasConfig::ATLAS_HEIGHT * scale);
 
                         ImVec2 cursorPos = ImGui::GetCursorScreenPos();
-                        ImGui::Image(reinterpret_cast<ImTextureID>(octaPreviewSet), imageSize);
+                        ImGui::Image(reinterpret_cast<ImTextureID>(previewSet), imageSize);
 
                         // Draw grid lines
                         ImDrawList* drawList = ImGui::GetWindowDrawList();

--- a/src/vegetation/TreeImpostorAtlas.h
+++ b/src/vegetation/TreeImpostorAtlas.h
@@ -13,20 +13,6 @@
 #include "VulkanRAII.h"
 #include "DescriptorManager.h"
 
-// Legacy impostor atlas configuration (17-view discrete)
-// Layout: 2 rows x 9 columns = 18 cells (17 used, 1 unused)
-// Row 0: 8 horizon views (0-315 degrees) + 1 top-down
-// Row 1: 8 elevated views (45 degrees elevation) + 1 unused
-struct ImpostorAtlasConfig {
-    static constexpr int HORIZONTAL_ANGLES = 8;       // Views around the tree (every 45 degrees)
-    static constexpr int VERTICAL_LEVELS = 2;         // Horizon + 45 degree elevation
-    static constexpr int CELLS_PER_ROW = 9;           // 8 angles + 1 (top-down or unused)
-    static constexpr int TOTAL_CELLS = 17;            // 8 + 8 + 1 top-down
-    static constexpr int CELL_SIZE = 256;             // Pixels per cell (increased from 128)
-    static constexpr int ATLAS_WIDTH = CELLS_PER_ROW * CELL_SIZE;   // 2304 pixels
-    static constexpr int ATLAS_HEIGHT = VERTICAL_LEVELS * CELL_SIZE; // 512 pixels
-};
-
 // Octahedral impostor atlas configuration
 // Uses hemi-octahedral mapping for continuous view coverage
 // Grid is NxN where each cell is a captured view direction
@@ -80,9 +66,6 @@ struct TreeLODSettings {
     bool enableImpostors = true;
     float impostorBrightness = 1.0f;       // Brightness adjustment for impostors
     float normalStrength = 1.0f;           // How much normals affect lighting
-
-    // Octahedral impostor mode
-    bool useOctahedralMapping = true;      // Use octahedral vs legacy 17-view atlas
     bool enableFrameBlending = true;       // Blend between 3 nearest frames for smooth transitions
 
     // Seasonal effects (global for all impostors)
@@ -146,30 +129,16 @@ public:
     size_t getArchetypeCount() const { return archetypes_.size(); }
 
     // Get atlas array textures for binding (single array covers all archetypes)
-    // Returns octahedral or legacy atlas based on current settings
-    VkImageView getAlbedoAtlasArrayView() const;
-    VkImageView getNormalAtlasArrayView() const;
+    VkImageView getAlbedoAtlasArrayView() const { return octaAlbedoArrayView_.get(); }
+    VkImageView getNormalAtlasArrayView() const { return octaNormalArrayView_.get(); }
     VkSampler getAtlasSampler() const { return atlasSampler_.get(); }
-
-    // Get octahedral-specific atlas (for explicit access)
-    VkImageView getOctaAlbedoAtlasArrayView() const { return octaAlbedoArrayView_.get(); }
-    VkImageView getOctaNormalAtlasArrayView() const { return octaNormalArrayView_.get(); }
-
-    // Check if octahedral atlas is available
-    bool hasOctahedralAtlas() const { return octaAlbedoArrayImage_ != VK_NULL_HANDLE; }
-
-    // Legacy per-archetype access (for preview/debug)
-    VkImageView getAlbedoAtlasView(uint32_t archetypeIndex) const;
-    VkImageView getNormalAtlasView(uint32_t archetypeIndex) const;
 
     // LOD settings
     TreeLODSettings& getLODSettings() { return lodSettings_; }
     const TreeLODSettings& getLODSettings() const { return lodSettings_; }
 
     // Get atlas image for UI preview (lazy-initializes ImGui descriptor on first call)
-    VkImageView getPreviewImageView(uint32_t archetypeIndex) const;
     VkDescriptorSet getPreviewDescriptorSet(uint32_t archetypeIndex);
-    VkDescriptorSet getOctahedralPreviewDescriptorSet(uint32_t archetypeIndex);
 
 private:
     TreeImpostorAtlas() = default;
@@ -177,12 +146,9 @@ private:
 
     bool createRenderPass();
     bool createCapturePipeline();
-    bool createAtlasArrayTextures();  // Create the shared array textures (legacy)
-    bool createOctahedralAtlasArrayTextures();  // Create octahedral array textures
-    bool createAtlasResources(uint32_t archetypeIndex);  // Create per-layer framebuffer (legacy)
-    bool createOctahedralAtlasResources(uint32_t archetypeIndex);  // Octahedral per-layer
+    bool createAtlasArrayTextures();
+    bool createAtlasResources(uint32_t archetypeIndex);
     bool createSampler();
-    bool createPreviewDescriptorSets();
 
     // Octahedral rendering helpers
     void renderOctahedralCell(
@@ -202,22 +168,6 @@ private:
     // Hemi-octahedral encoding/decoding (matching GLSL)
     static glm::vec2 hemiOctaEncode(glm::vec3 dir);
     static glm::vec3 hemiOctaDecode(glm::vec2 uv);
-
-    // Render tree from a specific viewing angle to atlas cell
-    void renderToCell(
-        VkCommandBuffer cmd,
-        int cellX, int cellY,
-        float azimuth,           // Horizontal angle (0-360)
-        float elevation,         // Vertical angle (0 = horizon, 90 = top-down)
-        const Mesh& branchMesh,
-        const std::vector<LeafInstanceGPU>& leafInstances,
-        float horizontalRadius,      // Half of max horizontal dimension (X/Z)
-        float boundingSphereRadius,  // Full 3D bounding sphere radius for depth clipping
-        float halfHeight,            // Half of tree height (for billboard height)
-        float centerHeight,          // Height of tree center above origin
-        float baseY,                 // Y coordinate of tree base (for asymmetric projection)
-        VkDescriptorSet branchDescSet,
-        VkDescriptorSet leafDescSet);
 
     bool createLeafCapturePipeline();
     bool createLeafQuadMesh();
@@ -248,41 +198,19 @@ private:
     VmaAllocation leafQuadIndexAllocation_ = VK_NULL_HANDLE;
     uint32_t leafQuadIndexCount_ = 0;
 
-    // Per-archetype atlas textures
-    struct AtlasTextures {
-        VkImage albedoAlphaImage = VK_NULL_HANDLE;
-        VmaAllocation albedoAlphaAllocation = VK_NULL_HANDLE;
-        ManagedImageView albedoAlphaView;
-
-        VkImage normalDepthAOImage = VK_NULL_HANDLE;
-        VmaAllocation normalDepthAOAllocation = VK_NULL_HANDLE;
-        ManagedImageView normalDepthAOView;
-
-        VkImage depthImage = VK_NULL_HANDLE;
-        VmaAllocation depthAllocation = VK_NULL_HANDLE;
-        ManagedImageView depthView;
-
-        ManagedFramebuffer framebuffer;
-
-        // Preview descriptor for ImGui
-        VkDescriptorSet previewDescriptorSet = VK_NULL_HANDLE;
-    };
-    std::vector<AtlasTextures> atlasTextures_;
-
     // Archetype data
     std::vector<TreeImpostorArchetype> archetypes_;
 
     // Texture array for all archetypes (shared across all archetypes)
-    VkImage albedoArrayImage_ = VK_NULL_HANDLE;
-    VmaAllocation albedoArrayAllocation_ = VK_NULL_HANDLE;
-    ManagedImageView albedoArrayView_;  // View of entire array for shader binding
+    VkImage octaAlbedoArrayImage_ = VK_NULL_HANDLE;
+    VmaAllocation octaAlbedoArrayAllocation_ = VK_NULL_HANDLE;
+    ManagedImageView octaAlbedoArrayView_;
 
-    VkImage normalArrayImage_ = VK_NULL_HANDLE;
-    VmaAllocation normalArrayAllocation_ = VK_NULL_HANDLE;
-    ManagedImageView normalArrayView_;  // View of entire array for shader binding
+    VkImage octaNormalArrayImage_ = VK_NULL_HANDLE;
+    VmaAllocation octaNormalArrayAllocation_ = VK_NULL_HANDLE;
+    ManagedImageView octaNormalArrayView_;
 
     uint32_t maxArchetypes_ = 16;  // Maximum layers in the array
-    uint32_t currentArchetypeCount_ = 0;
 
     // Shared sampler for atlas textures
     ManagedSampler atlasSampler_;
@@ -298,17 +226,8 @@ private:
     VmaAllocation leafCaptureAllocation_ = VK_NULL_HANDLE;
     VkDeviceSize leafCaptureBufferSize_ = 0;
 
-    // Octahedral atlas resources
-    VkImage octaAlbedoArrayImage_ = VK_NULL_HANDLE;
-    VmaAllocation octaAlbedoArrayAllocation_ = VK_NULL_HANDLE;
-    ManagedImageView octaAlbedoArrayView_;
-
-    VkImage octaNormalArrayImage_ = VK_NULL_HANDLE;
-    VmaAllocation octaNormalArrayAllocation_ = VK_NULL_HANDLE;
-    ManagedImageView octaNormalArrayView_;
-
-    // Per-archetype octahedral atlas (depth buffers and framebuffers)
-    struct OctaAtlasTextures {
+    // Per-archetype atlas (depth buffers and framebuffers)
+    struct AtlasTextures {
         VkImage depthImage = VK_NULL_HANDLE;
         VmaAllocation depthAllocation = VK_NULL_HANDLE;
         ManagedImageView albedoView;   // View into octaAlbedoArrayImage_
@@ -317,5 +236,5 @@ private:
         ManagedFramebuffer framebuffer;
         VkDescriptorSet previewDescriptorSet = VK_NULL_HANDLE;
     };
-    std::vector<OctaAtlasTextures> octaAtlasTextures_;
+    std::vector<AtlasTextures> atlasTextures_;
 };

--- a/src/vegetation/TreeLODSystem.cpp
+++ b/src/vegetation/TreeLODSystem.cpp
@@ -1037,9 +1037,9 @@ void TreeLODSystem::renderImpostors(VkCommandBuffer cmd, uint32_t frameIndex,
     } pushConstants;
 
     pushConstants.cameraPos = glm::vec4(lastCameraPos_, settings.autumnHueShift);
-    // lodParams: x=useOctahedral, y=brightness, z=normalStrength, w=unused
+    // lodParams: x=unused, y=brightness, z=normalStrength, w=unused
     pushConstants.lodParams = glm::vec4(
-        settings.useOctahedralMapping ? 1.0f : 0.0f,
+        1.0f,
         settings.impostorBrightness,
         settings.normalStrength,
         0.0f
@@ -1092,9 +1092,9 @@ void TreeLODSystem::renderImpostorShadows(VkCommandBuffer cmd, uint32_t frameInd
     } pushConstants;
 
     pushConstants.cameraPos = glm::vec4(lastCameraPos_, 1.0f);
-    // lodParams: x=useOctahedral, y=brightness, z=normalStrength, w=unused
+    // lodParams: x=unused, y=brightness, z=normalStrength, w=unused
     pushConstants.lodParams = glm::vec4(
-        settings.useOctahedralMapping ? 1.0f : 0.0f,
+        1.0f,
         settings.impostorBrightness,
         settings.normalStrength,
         0.0f
@@ -1164,9 +1164,9 @@ void TreeLODSystem::renderImpostorsGPUCulled(VkCommandBuffer cmd, uint32_t frame
     } pushConstants;
 
     pushConstants.cameraPos = glm::vec4(lastCameraPos_, settings.autumnHueShift);
-    // lodParams: x=useOctahedral, y=brightness, z=normalStrength, w=unused
+    // lodParams: x=unused, y=brightness, z=normalStrength, w=unused
     pushConstants.lodParams = glm::vec4(
-        settings.useOctahedralMapping ? 1.0f : 0.0f,
+        1.0f,
         settings.impostorBrightness,
         settings.normalStrength,
         0.0f
@@ -1219,8 +1219,8 @@ void TreeLODSystem::renderImpostorShadowsGPUCulled(VkCommandBuffer cmd, uint32_t
         float _pad[3];
     } pushConstants;
     pushConstants.cameraPos = glm::vec4(lastCameraPos_, 0.0f);
-    // lodParams.x = useOctahedral - must match main rendering mode for correct atlas UV lookup
-    pushConstants.lodParams = glm::vec4(settings.useOctahedralMapping ? 1.0f : 0.0f, 0.0f, 0.0f, 0.0f);
+    // lodParams is unused in shadow shader but kept for struct compatibility
+    pushConstants.lodParams = glm::vec4(1.0f, 0.0f, 0.0f, 0.0f);
     pushConstants.cascadeIndex = cascadeIndex;
 
     vkCmdPushConstants(cmd, shadowPipelineLayout_.get(),


### PR DESCRIPTION
Remove the legacy 17-view discrete atlas system and simplify to use only the octahedral 64-view continuous atlas. This reduces code complexity and maintenance burden while keeping the superior octahedral mapping that provides smoother view transitions.

Changes:
- Remove ImpostorAtlasConfig struct and legacy configuration
- Remove useOctahedralMapping toggle from TreeLODSettings
- Remove legacy atlas resources and rendering code from TreeImpostorAtlas
- Simplify shaders to always use octahedral frame lookup
- Update GUI to remove octahedral toggle and legacy preview button
- Update TreeLODSystem push constants (hardcode octahedral mode)

Net reduction of ~750 lines of code.