### PR TITLE
Fix frustum culling tree rendering issue

### DIFF
--- a/shaders/tree_cell_cull.comp
+++ b/shaders/tree_cell_cull.comp
@@ -115,27 +115,17 @@ void main() {
     uint cellIdx = gl_GlobalInvocationID.x;
     uint localIdx = gl_LocalInvocationID.x;
 
-    // First thread initializes output buffers
-    if (cellIdx == 0) {
-        visibleCellCount = 0;
-        dispatchX = 0;
-        dispatchY = 1;
-        dispatchZ = 1;
-        totalVisibleTrees = 0;
-        for (uint i = 0; i < NUM_DISTANCE_BUCKETS; i++) {
-            bucketCounts[i] = 0;
-            bucketOffsets[i] = 0;
-        }
-    }
+    // NOTE: Output buffer initialization is done on CPU side via vkCmdFillBuffer/vkCmdUpdateBuffer
+    // BEFORE dispatch. Shader-side init with barrier() only syncs within a workgroup, causing
+    // race conditions when multiple workgroups run in parallel.
 
-    // Initialize shared memory
+    // Initialize shared memory for this workgroup
     if (localIdx < NUM_DISTANCE_BUCKETS) {
         sharedBucketCounts[localIdx] = 0;
     }
 
-    // Ensure initialization is complete before any thread proceeds
+    // Sync shared memory within workgroup
     barrier();
-    memoryBarrierBuffer();
 
     // Early exit if beyond cell count
     if (cellIdx >= numCells) {

--- a/shaders/tree_filter.comp
+++ b/shaders/tree_filter.comp
@@ -110,17 +110,9 @@ void main() {
     uint cellLocalIdx = gl_LocalInvocationID.x;  // Tree index within cell
     uint visibleCellIdx = gl_WorkGroupID.x;      // Which visible cell we're processing
 
-    // First thread in first workgroup initializes output buffers
-    if (gl_GlobalInvocationID.x == 0) {
-        visibleTreeCount = 0;
-        dispatchX = 0;
-        dispatchY = 1;
-        dispatchZ = 1;
-    }
-
-    // Ensure initialization is complete
-    barrier();
-    memoryBarrierBuffer();
+    // NOTE: Output buffer initialization is done on CPU side via vkCmdFillBuffer/vkCmdUpdateBuffer
+    // BEFORE dispatch. Shader-side init with barrier() only syncs within a workgroup,
+    // causing race conditions when multiple workgroups run in parallel.
 
     // Early exit if beyond visible cell count
     if (visibleCellIdx >= visibleCellCount) {

--- a/shaders/tree_leaf_cull.comp
+++ b/shaders/tree_leaf_cull.comp
@@ -50,20 +50,9 @@ layout(binding = BINDING_TREE_LEAF_CULL_UNIFORMS) uniform TreeLeafCullUniforms {
 void main() {
     uint globalIdx = gl_GlobalInvocationID.x;
 
-    // First thread initializes all indirect commands
-    if (globalIdx == 0) {
-        for (uint i = 0; i < NUM_LEAF_TYPES; i++) {
-            drawCmds[i].indexCount = 6;
-            drawCmds[i].instanceCount = 0;
-            drawCmds[i].firstIndex = 0;
-            drawCmds[i].vertexOffset = 0;
-            drawCmds[i].firstInstance = i * maxLeavesPerType;
-        }
-    }
-
-    // Ensure initialization is complete before any thread proceeds
-    barrier();
-    memoryBarrierBuffer();
+    // NOTE: Indirect command initialization is done on CPU side via vkCmdUpdateBuffer
+    // BEFORE dispatch. Shader-side init with barrier() only syncs within a workgroup,
+    // causing race conditions when multiple workgroups run in parallel.
 
     // Early exit if beyond total leaf count
     if (globalIdx >= totalLeafInstances) {

--- a/shaders/tree_leaf_cull_phase3.comp
+++ b/shaders/tree_leaf_cull_phase3.comp
@@ -107,24 +107,9 @@ void main() {
     uint localIdx = gl_LocalInvocationID.x;     // Leaf index within this tree
     uint visibleTreeIdx = gl_WorkGroupID.x;     // Which visible tree we're processing
 
-    // First thread in first workgroup initializes indirect commands
-    if (gl_GlobalInvocationID.x == 0) {
-        for (uint i = 0; i < NUM_LEAF_TYPES; i++) {
-            drawCmds[i].indexCount = 6;
-            drawCmds[i].instanceCount = 0;
-            drawCmds[i].firstIndex = 0;
-            drawCmds[i].vertexOffset = 0;
-            drawCmds[i].firstInstance = i * maxLeavesPerType;
-        }
-        // Initialize tier counts
-        for (uint i = 0; i < NUM_LEAF_TYPES * NUM_DISTANCE_TIERS; i++) {
-            tierCounts[i] = 0;
-        }
-    }
-
-    // Ensure initialization is complete
-    barrier();
-    memoryBarrierBuffer();
+    // NOTE: Indirect command and tierCounts initialization is done on CPU side via vkCmdUpdateBuffer
+    // BEFORE dispatch. Shader-side init with barrier() only syncs within a workgroup,
+    // causing race conditions when multiple workgroups run in parallel.
 
     // Early exit if beyond visible tree count
     if (visibleTreeIdx >= visibleTreeCount) {

--- a/src/vegetation/TreeLeafCulling.cpp
+++ b/src/vegetation/TreeLeafCulling.cpp
@@ -691,18 +691,27 @@ void TreeLeafCulling::recordCulling(VkCommandBuffer cmd, uint32_t frameIndex,
     }
 
     // Reset all 4 indirect draw commands (one per leaf type: oak, ash, aspen, pine)
+    // Also includes tierCounts for phase 3 distance-based budget allocation
     constexpr uint32_t NUM_LEAF_TYPES = 4;
-    VkDrawIndexedIndirectCommand resetCmds[NUM_LEAF_TYPES];
+    constexpr uint32_t NUM_DISTANCE_TIERS = 3;
+
+    // Structure matches shader's IndirectBuffer: drawCmds[4] followed by tierCounts[12]
+    struct {
+        VkDrawIndexedIndirectCommand drawCmds[NUM_LEAF_TYPES];
+        uint32_t tierCounts[NUM_LEAF_TYPES * NUM_DISTANCE_TIERS];
+    } indirectReset = {};
+
     for (uint32_t i = 0; i < NUM_LEAF_TYPES; ++i) {
-        resetCmds[i].indexCount = 6;       // Quad: 6 indices
-        resetCmds[i].instanceCount = 0;    // Will be set by compute shader
-        resetCmds[i].firstIndex = 0;
-        resetCmds[i].vertexOffset = 0;
-        resetCmds[i].firstInstance = i * maxLeavesPerType_;  // Base offset for each leaf type
+        indirectReset.drawCmds[i].indexCount = 6;       // Quad: 6 indices
+        indirectReset.drawCmds[i].instanceCount = 0;    // Will be set by compute shader
+        indirectReset.drawCmds[i].firstIndex = 0;
+        indirectReset.drawCmds[i].vertexOffset = 0;
+        indirectReset.drawCmds[i].firstInstance = i * maxLeavesPerType_;  // Base offset for each leaf type
     }
+    // tierCounts is already zero-initialized
 
     vkCmdUpdateBuffer(cmd, cullIndirectBuffers_[currentBufferSet_],
-                      0, sizeof(resetCmds), resetCmds);
+                      0, sizeof(indirectReset), &indirectReset);
 
     // Upload per-tree data
     vkCmdUpdateBuffer(cmd, treeDataBuffer_, 0,
@@ -757,6 +766,31 @@ void TreeLeafCulling::recordCulling(VkCommandBuffer cmd, uint32_t frameIndex,
         // Check if two-phase culling will be used so we can batch uniform updates
         bool useTwoPhase = twoPhaseEnabled_ && treeFilterPipeline_.get() != VK_NULL_HANDLE &&
                            visibleTreeBuffer_ != VK_NULL_HANDLE && !treeFilterDescriptorSets_.empty();
+
+        // Reset cell cull output buffers on CPU side BEFORE dispatch
+        // This is critical - shader-side initialization with barrier() only works within
+        // a workgroup, not across workgroups. Other workgroups may atomicAdd before
+        // workgroup 0 resets the counters, causing race conditions and flickering.
+
+        // Reset visible cell buffer: first uint is visibleCellCount
+        vkCmdFillBuffer(cmd, visibleCellBuffer_, 0, sizeof(uint32_t), 0);
+
+        // Reset cell cull indirect buffer: dispatchX/Y/Z, totalVisibleTrees, bucketCounts[8], bucketOffsets[8]
+        // Structure: { dispatchX=0, dispatchY=1, dispatchZ=1, totalVisibleTrees=0, bucketCounts[8]=0, bucketOffsets[8]=0 }
+        constexpr uint32_t NUM_DISTANCE_BUCKETS = 8;
+        uint32_t indirectReset[4 + NUM_DISTANCE_BUCKETS * 2] = {0, 1, 1, 0}; // dispatchX=0, Y=1, Z=1, totalTrees=0
+        // bucketCounts and bucketOffsets are already 0-initialized
+        vkCmdUpdateBuffer(cmd, cellCullIndirectBuffer_, 0, sizeof(indirectReset), indirectReset);
+
+        // If two-phase culling, also reset visible tree buffer and leaf cull indirect dispatch
+        if (useTwoPhase) {
+            // Reset visible tree buffer: first uint is visibleTreeCount
+            vkCmdFillBuffer(cmd, visibleTreeBuffer_, 0, sizeof(uint32_t), 0);
+
+            // Reset leaf cull indirect dispatch: { dispatchX=0, dispatchY=1, dispatchZ=1 }
+            uint32_t leafDispatchReset[3] = {0, 1, 1};
+            vkCmdUpdateBuffer(cmd, leafCullIndirectDispatch_, 0, sizeof(leafDispatchReset), leafDispatchReset);
+        }
 
         // Use vkCmdUpdateBuffer to avoid HOST→COMPUTE stall (keeps update on GPU timeline)
         vkCmdUpdateBuffer(cmd, cellCullUniformBuffers_.buffers[frameIndex], 0,


### PR DESCRIPTION
The tree culling compute shaders were using shader-side initialization with barrier() to reset output buffers, but barrier() only synchronizes threads within a single workgroup, not across all workgroups. This caused race conditions where some workgroups would start atomicAdd operations before workgroup 0 finished resetting counters, resulting in incorrect visible tree counts and visual flickering.

Fixed by moving buffer initialization to the CPU side using vkCmdFillBuffer and vkCmdUpdateBuffer before each compute dispatch:
- Reset visibleCellBuffer count before cell culling
- Reset cellCullIndirectBuffer dispatch params and bucket counts
- Reset visibleTreeBuffer and leafCullIndirectDispatch for two-phase culling
- Reset cullIndirectBuffers draw commands and tier counts