### PR TITLE
Refactor shader code

### DIFF
--- a/shaders/irradiance_lut.comp
+++ b/shaders/irradiance_lut.comp
@@ -16,6 +16,7 @@
 
 #include "bindings.glsl"
 #include "atmosphere_common.glsl"
+#include "lut_compute_common.glsl"
 
 layout(local_size_x = 8, local_size_y = 8) in;
 
@@ -37,12 +38,6 @@ layout(binding = BINDING_IRRADIANCE_UNIFORMS) uniform AtmosphereUniforms {
 const int HEMISPHERE_SAMPLES = 64;  // Number of hemisphere samples for irradiance
 const int MARCH_STEPS = 32;         // Steps along each ray
 
-// Sample transmittance LUT
-vec3 SampleTransmittance(float r, float mu) {
-    vec2 uv = TransmittanceLUTParamsToUV(r, mu, uAtmosphere.params);
-    return texture(transmittanceLUT, uv).rgb;
-}
-
 // Compute irradiance at a given altitude and sun angle
 // Returns separate Rayleigh and Mie contributions without phase functions
 // This allows clouds to apply their own phase function when sampling
@@ -57,8 +52,7 @@ void ComputeIrradiance(float altitude, float cosSunZenith,
     vec3 up = vec3(0.0, 1.0, 0.0);
 
     // Sun direction from zenith angle
-    float sinSunZenith = sqrt(max(0.0, 1.0 - cosSunZenith * cosSunZenith));
-    vec3 sunDir = vec3(sinSunZenith, cosSunZenith, 0.0);
+    vec3 sunDir = sunDirFromZenithCos(cosSunZenith);
 
     // Sample directions over the hemisphere to integrate irradiance
     // We integrate inscattered light from all directions to get total irradiance
@@ -92,22 +86,18 @@ void ComputeIrradiance(float altitude, float cosSunZenith,
         vec3 transmittance = vec3(1.0);
 
         for (int i = 0; i < MARCH_STEPS; i++) {
-            float t = (float(i) + 0.5) * stepSize;
+            float t = rayMarchStepT(i, stepSize);
             vec3 samplePos = pos + sampleDir * t;
             float sampleR = length(samplePos);
-            float sampleAlt = max(sampleR - uAtmosphere.params.planetRadius, 0.0);
+            float sampleAlt = radiusToAltitude(sampleR, uAtmosphere.params.planetRadius);
 
-            // Get atmospheric density at sample point
+            // Get atmospheric density and scattering at sample point
             vec3 density = GetAtmosphereDensity(sampleAlt, uAtmosphere.params);
-
-            // Scattering coefficients
-            vec3 rayleighScatter = density.x * uAtmosphere.params.rayleighScatteringBase;
-            vec3 mieScatter = vec3(density.y * uAtmosphere.params.mieScatteringBase);
+            vec3 rayleighScatter, mieScatter;
+            computeScattering(density, uAtmosphere.params, rayleighScatter, mieScatter);
 
             // Extinction for this segment
-            vec3 mieAbsorption = vec3(density.y * uAtmosphere.params.mieAbsorptionBase);
-            vec3 ozoneAbsorption = density.z * uAtmosphere.params.ozoneAbsorption;
-            vec3 extinction = rayleighScatter + mieScatter + mieAbsorption + ozoneAbsorption;
+            vec3 extinction = computeExtinction(density, uAtmosphere.params);
 
             // Transmittance from sample point to sun
             float muSun = dot(normalize(samplePos), sunDir);
@@ -115,7 +105,7 @@ void ComputeIrradiance(float altitude, float cosSunZenith,
 
             // Only accumulate if sun is visible from this point
             if (muSun > -0.2 && !RayIntersectsPlanet(sampleR, muSun, uAtmosphere.params.planetRadius)) {
-                sunTransmittance = SampleTransmittance(sampleR, muSun);
+                sunTransmittance = sampleTransmittanceLUT(transmittanceLUT, sampleR, muSun, uAtmosphere.params);
             }
 
             // Inscattered light at this sample (without phase function)
@@ -151,17 +141,15 @@ void main() {
     ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
     ivec2 lutSize = imageSize(rayleighIrradianceLUT);
 
-    if (texel.x >= lutSize.x || texel.y >= lutSize.y) {
+    if (isOutOfBounds(texel, lutSize)) {
         return;
     }
 
-    // UV coordinates [0, 1]
-    vec2 uv = (vec2(texel) + 0.5) / vec2(lutSize);
+    vec2 uv = texelToUV(texel, lutSize);
 
-    // X: cosine of sun zenith angle [-1, 1]
-    // Y: normalized altitude [0, 1]
-    float cosSunZenith = uv.x * 2.0 - 1.0;
-    float altitude = uv.y * (uAtmosphere.params.atmosphereRadius - uAtmosphere.params.planetRadius);
+    // Decode altitude and sun angle from UV
+    float altitude, cosSunZenith;
+    decodeAltitudeSunAngleLUT(uv, uAtmosphere.params, altitude, cosSunZenith);
 
     // Compute separate Rayleigh and Mie irradiance
     vec3 rayleighIrr, mieIrr;

--- a/shaders/lut_compute_common.glsl
+++ b/shaders/lut_compute_common.glsl
@@ -1,0 +1,145 @@
+// LUT Compute Shader Common Functions
+// Shared utilities for atmospheric LUT compute shaders:
+// - transmittance_lut.comp
+// - skyview_lut.comp
+// - irradiance_lut.comp
+// - multiscatter_lut.comp
+
+#ifndef LUT_COMPUTE_COMMON_GLSL
+#define LUT_COMPUTE_COMMON_GLSL
+
+// ============================================================================
+// Bounds Checking
+// ============================================================================
+
+// Check if texel is within LUT bounds, returns early if out of bounds
+// Usage: if (isOutOfBounds(texel, lutSize)) return;
+bool isOutOfBounds(ivec2 texel, ivec2 lutSize) {
+    return texel.x >= lutSize.x || texel.y >= lutSize.y;
+}
+
+// ============================================================================
+// UV Normalization
+// ============================================================================
+
+// Convert texel coordinates to normalized UV [0, 1] with half-pixel offset
+vec2 texelToUV(ivec2 texel, ivec2 lutSize) {
+    return (vec2(texel) + 0.5) / vec2(lutSize);
+}
+
+// ============================================================================
+// LUT Parameter Decoding
+// ============================================================================
+
+// Decode altitude and sun zenith angle from UV for irradiance/multiscatter LUTs
+// UV mapping:
+//   X: cosine of sun zenith angle [-1, 1] mapped from [0, 1]
+//   Y: normalized altitude [0, 1] over atmosphere height
+void decodeAltitudeSunAngleLUT(vec2 uv, AtmosphereParams params,
+                                out float altitude, out float cosSunZenith) {
+    cosSunZenith = uv.x * 2.0 - 1.0;
+    altitude = uv.y * (params.atmosphereRadius - params.planetRadius);
+}
+
+// ============================================================================
+// Transmittance LUT Sampling
+// ============================================================================
+
+// Sample transmittance LUT given altitude (r) and cosine of zenith angle (mu)
+// This is a parameterized version - pass the sampler explicitly
+vec3 sampleTransmittanceLUT(sampler2D transmittanceLUT, float r, float mu, AtmosphereParams params) {
+    vec2 uv = TransmittanceLUTParamsToUV(r, mu, params);
+    return texture(transmittanceLUT, uv).rgb;
+}
+
+// ============================================================================
+// Extinction Calculation
+// ============================================================================
+
+// Compute total extinction coefficients from atmospheric density
+// Returns vec3 extinction that can be used for Beer-Lambert law
+vec3 computeExtinction(vec3 density, AtmosphereParams params) {
+    vec3 rayleighExtinction = density.x * params.rayleighScatteringBase;
+    float mieExtinction = density.y * (params.mieScatteringBase + params.mieAbsorptionBase);
+    vec3 ozoneExtinction = density.z * params.ozoneAbsorption;
+    return rayleighExtinction + vec3(mieExtinction) + ozoneExtinction;
+}
+
+// Compute scattering coefficients (without absorption, for in-scattering)
+void computeScattering(vec3 density, AtmosphereParams params,
+                       out vec3 rayleighScatter, out vec3 mieScatter) {
+    rayleighScatter = density.x * params.rayleighScatteringBase;
+    mieScatter = vec3(density.y * params.mieScatteringBase);
+}
+
+// ============================================================================
+// Ray Marching Helpers
+// ============================================================================
+
+// Compute position along ray at step i with midpoint sampling
+// Returns distance t from ray origin
+float rayMarchStepT(int stepIndex, float stepSize) {
+    return (float(stepIndex) + 0.5) * stepSize;
+}
+
+// Calculate altitude and radius at a point along a ray
+// rayOrigin is typically vec3(0, r, 0) where r is planet radius + camera altitude
+// Returns radius from planet center
+float computeSampleRadius(vec3 rayOrigin, vec3 rayDir, float t) {
+    vec3 pos = rayOrigin + rayDir * t;
+    return length(pos);
+}
+
+// Calculate altitude from radius
+float radiusToAltitude(float r, float planetRadius) {
+    return max(r - planetRadius, 0.0);
+}
+
+// Combined helper: get altitude at ray march sample point
+float getSampleAltitude(vec3 rayOrigin, vec3 rayDir, float t, float planetRadius) {
+    float r = computeSampleRadius(rayOrigin, rayDir, t);
+    return radiusToAltitude(r, planetRadius);
+}
+
+// ============================================================================
+// Transmittance Computation
+// ============================================================================
+
+// Compute optical depth along a ray segment using trapezoidal integration
+// This is the core integration used in transmittance_lut.comp
+// Returns optical depth (use exp(-opticalDepth) for transmittance)
+vec3 integrateOpticalDepth(float r, float mu, float distance, int steps, AtmosphereParams params) {
+    float dx = distance / float(steps);
+    vec3 opticalDepth = vec3(0.0);
+
+    for (int i = 0; i <= steps; i++) {
+        float t = float(i) * dx;
+
+        // Current distance from planet center
+        float ri = sqrt(r * r + t * t + 2.0 * r * mu * t);
+        float altitude = ri - params.planetRadius;
+
+        // Get density and extinction at this point
+        vec3 density = GetAtmosphereDensity(altitude, params);
+        vec3 extinction = computeExtinction(density, params);
+
+        // Trapezoidal rule weights
+        float weight = (i == 0 || i == steps) ? 0.5 : 1.0;
+        opticalDepth += extinction * weight * dx;
+    }
+
+    return opticalDepth;
+}
+
+// ============================================================================
+// Sun Direction Construction
+// ============================================================================
+
+// Construct sun direction vector from cosine of zenith angle
+// Assumes sun is in XY plane (azimuth = 0)
+vec3 sunDirFromZenithCos(float cosSunZenith) {
+    float sinSunZenith = sqrt(max(0.0, 1.0 - cosSunZenith * cosSunZenith));
+    return vec3(sinSunZenith, cosSunZenith, 0.0);
+}
+
+#endif // LUT_COMPUTE_COMMON_GLSL

--- a/shaders/multiscatter_lut.comp
+++ b/shaders/multiscatter_lut.comp
@@ -4,6 +4,7 @@
 
 #include "bindings.glsl"
 #include "atmosphere_common.glsl"
+#include "lut_compute_common.glsl"
 
 layout(local_size_x = 8, local_size_y = 8) in;
 
@@ -20,17 +21,11 @@ layout(binding = BINDING_ATMO_MULTISCATTER) uniform AtmosphereUniforms {
 const int SAMPLE_COUNT = 64;
 const int MARCH_STEPS = 20;
 
-// Sample transmittance LUT
-vec3 SampleTransmittance(float r, float mu) {
-    vec2 uv = TransmittanceLUTParamsToUV(r, mu, uAtmosphere.params);
-    return texture(transmittanceLUT, uv).rgb;
-}
-
 // Compute single scattering contribution
 vec3 ComputeSingleScattering(float altitude, vec3 viewDir, float cosSunZenith) {
     float r = uAtmosphere.params.planetRadius + altitude;
     vec3 pos = vec3(0.0, r, 0.0);
-    vec3 sunDir = vec3(sqrt(1.0 - cosSunZenith * cosSunZenith), cosSunZenith, 0.0);
+    vec3 sunDir = sunDirFromZenithCos(cosSunZenith);
 
     // Ray march to accumulate single scattering
     float rayLength = DistanceToAtmosphereBoundary(r, dot(viewDir, normalize(pos)), uAtmosphere.params.atmosphereRadius);
@@ -38,35 +33,32 @@ vec3 ComputeSingleScattering(float altitude, vec3 viewDir, float cosSunZenith) {
 
     vec3 scattering = vec3(0.0);
 
+    // Phase functions (constant for the ray)
+    float cosTheta = dot(viewDir, sunDir);
+    float rayleighPhase = RayleighPhase(cosTheta);
+    float miePhase = HenyeyGreensteinPhase(cosTheta, uAtmosphere.params.mieAnisotropy);
+
     for (int i = 0; i < MARCH_STEPS; i++) {
-        float t = (float(i) + 0.5) * stepSize;
+        float t = rayMarchStepT(i, stepSize);
         vec3 samplePos = pos + viewDir * t;
         float sampleR = length(samplePos);
-        float sampleAlt = sampleR - uAtmosphere.params.planetRadius;
+        float sampleAlt = radiusToAltitude(sampleR, uAtmosphere.params.planetRadius);
 
-        // Get density
+        // Get density and scattering coefficients
         vec3 density = GetAtmosphereDensity(sampleAlt, uAtmosphere.params);
+        vec3 rayleighScatter, mieScatter;
+        computeScattering(density, uAtmosphere.params, rayleighScatter, mieScatter);
 
         // Get transmittance to sun
-        vec3 toSun = sunDir;
-        float muS = dot(normalize(samplePos), toSun);
-        vec3 transmittanceToSun = SampleTransmittance(sampleR, muS);
+        float muS = dot(normalize(samplePos), sunDir);
+        vec3 transmittanceToSun = sampleTransmittanceLUT(transmittanceLUT, sampleR, muS, uAtmosphere.params);
 
-        // Rayleigh and Mie scattering
-        vec3 rayleighScatter = density.x * uAtmosphere.params.rayleighScatteringBase;
-        float mieScatter = density.y * uAtmosphere.params.mieScatteringBase;
-
-        // Phase functions
-        float cosTheta = dot(viewDir, sunDir);
-        float rayleighPhase = RayleighPhase(cosTheta);
-        float miePhase = HenyeyGreensteinPhase(cosTheta, uAtmosphere.params.mieAnisotropy);
-
-        // Accumulate
-        vec3 localScatter = transmittanceToSun * (rayleighScatter * rayleighPhase + vec3(mieScatter * miePhase));
+        // Accumulate with phase functions
+        vec3 localScatter = transmittanceToSun * (rayleighScatter * rayleighPhase + mieScatter * miePhase);
 
         // Get transmittance from camera to sample
         float muView = dot(normalize(pos), viewDir);
-        vec3 transmittanceToView = SampleTransmittance(r, muView);
+        vec3 transmittanceToView = sampleTransmittanceLUT(transmittanceLUT, r, muView, uAtmosphere.params);
 
         scattering += localScatter * transmittanceToView * stepSize;
     }
@@ -78,17 +70,15 @@ void main() {
     ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
     ivec2 lutSize = imageSize(multiScatterLUT);
 
-    if (texel.x >= lutSize.x || texel.y >= lutSize.y) {
+    if (isOutOfBounds(texel, lutSize)) {
         return;
     }
 
-    // UV coordinates [0, 1]
-    vec2 uv = (vec2(texel) + 0.5) / vec2(lutSize);
+    vec2 uv = texelToUV(texel, lutSize);
 
-    // X: cosine of sun zenith angle [-1, 1]
-    // Y: normalized altitude [0, 1]
-    float cosSunZenith = uv.x * 2.0 - 1.0;
-    float altitude = uv.y * (uAtmosphere.params.atmosphereRadius - uAtmosphere.params.planetRadius);
+    // Decode altitude and sun angle from UV
+    float altitude, cosSunZenith;
+    decodeAltitudeSunAngleLUT(uv, uAtmosphere.params, altitude, cosSunZenith);
 
     // Integrate over hemisphere to get average multi-scatter contribution
     vec3 totalLuminance = vec3(0.0);

--- a/shaders/skyview_lut.comp
+++ b/shaders/skyview_lut.comp
@@ -4,6 +4,7 @@
 
 #include "bindings.glsl"
 #include "atmosphere_common.glsl"
+#include "lut_compute_common.glsl"
 
 layout(local_size_x = 16, local_size_y = 16) in;
 
@@ -19,12 +20,6 @@ layout(binding = BINDING_ATMO_UNIFORMS) uniform AtmosphereUniforms {
 } uAtmosphere;
 
 const int SKY_VIEW_STEPS = 30;
-
-// Sample transmittance LUT
-vec3 SampleTransmittance(float r, float mu) {
-    vec2 uv = TransmittanceLUTParamsToUV(r, mu, uAtmosphere.params);
-    return texture(transmittanceLUT, uv).rgb;
-}
 
 // Sample multi-scatter LUT
 vec2 SampleMultiScatter(float altitude, float cosSunZenith) {
@@ -61,12 +56,11 @@ void main() {
     ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
     ivec2 lutSize = imageSize(skyViewLUT);
 
-    if (texel.x >= lutSize.x || texel.y >= lutSize.y) {
+    if (isOutOfBounds(texel, lutSize)) {
         return;
     }
 
-    // UV coordinates [0, 1]
-    vec2 uv = (vec2(texel) + 0.5) / vec2(lutSize);
+    vec2 uv = texelToUV(texel, lutSize);
 
     // Decode view direction from UV
     vec3 viewDir = SkyViewUVToDirection(uv);
@@ -99,32 +93,29 @@ void main() {
     float miePhase = CornetteShanksMiePhase(cosTheta, uAtmosphere.params.mieAnisotropy);
 
     for (int i = 0; i < SKY_VIEW_STEPS; i++) {
-        float t = (float(i) + 0.5) * stepSize;
+        float t = rayMarchStepT(i, stepSize);
         vec3 pos = cameraPos + viewDir * t;
         float posR = length(pos);
-        float altitude = max(posR - uAtmosphere.params.planetRadius, 0.0);
+        float altitude = radiusToAltitude(posR, uAtmosphere.params.planetRadius);
 
-        // Get atmospheric density at this point
-        float rayleighDensity = exp(-altitude / uAtmosphere.params.rayleighScaleHeight);
-        float mieDensity = exp(-altitude / uAtmosphere.params.mieScaleHeight);
+        // Get atmospheric density and scattering at this point
+        vec3 density = GetAtmosphereDensity(altitude, uAtmosphere.params);
+        vec3 rayleighScatterBase, mieScatterBase;
+        computeScattering(density, uAtmosphere.params, rayleighScatterBase, mieScatterBase);
 
         // Get transmittance to sun (light reaching this point)
         float muS = dot(normalize(pos), sunDir);
-        vec3 sunTransmittance = SampleTransmittance(posR, muS);
+        vec3 sunTransmittance = sampleTransmittanceLUT(transmittanceLUT, posR, muS, uAtmosphere.params);
 
         // Local scattering with phase functions
-        vec3 rayleighScatter = rayleighDensity * uAtmosphere.params.rayleighScatteringBase * rayleighPhase;
-        vec3 mieScatter = mieDensity * vec3(uAtmosphere.params.mieScatteringBase) * miePhase;
+        vec3 rayleighScatter = rayleighScatterBase * rayleighPhase;
+        vec3 mieScatter = mieScatterBase * miePhase;
 
         // Total segment scattering (attenuated by sunlight reaching this point)
         vec3 segmentScatter = sunTransmittance * (rayleighScatter + mieScatter);
 
-        // Extinction coefficients
-        vec3 rayleighExt = rayleighDensity * uAtmosphere.params.rayleighScatteringBase;
-        float mieExt = mieDensity * (uAtmosphere.params.mieScatteringBase + uAtmosphere.params.mieAbsorptionBase);
-        vec3 extinction = rayleighExt + vec3(mieExt);
-
-        // Segment transmittance
+        // Extinction and segment transmittance
+        vec3 extinction = computeExtinction(density, uAtmosphere.params);
         vec3 segmentTransmittance = exp(-extinction * stepSize);
 
         // Simple integration (matching sky.frag approach)

--- a/shaders/transmittance_lut.comp
+++ b/shaders/transmittance_lut.comp
@@ -4,6 +4,7 @@
 
 #include "bindings.glsl"
 #include "atmosphere_common.glsl"
+#include "lut_compute_common.glsl"
 
 layout(local_size_x = 16, local_size_y = 16) in;
 
@@ -20,40 +21,8 @@ const int TRANSMITTANCE_STEPS = 40;
 
 // Compute transmittance along ray from (r, mu) to atmosphere boundary
 vec3 ComputeTransmittance(float r, float mu) {
-    // Distance to atmosphere boundary
     float distance = DistanceToAtmosphereBoundary(r, mu, uAtmosphere.params.atmosphereRadius);
-
-    // Step size for integration
-    float dx = distance / float(TRANSMITTANCE_STEPS);
-
-    // Accumulated optical depth (Rayleigh, Mie, Ozone)
-    vec3 opticalDepth = vec3(0.0);
-
-    // Trapezoidal integration
-    for (int i = 0; i <= TRANSMITTANCE_STEPS; i++) {
-        float t = float(i) * dx;
-
-        // Current distance from planet center
-        float ri = sqrt(r * r + t * t + 2.0 * r * mu * t);
-        float altitude = ri - uAtmosphere.params.planetRadius;
-
-        // Get density at this point
-        vec3 density = GetAtmosphereDensity(altitude, uAtmosphere.params);
-
-        // Compute extinction coefficients
-        vec3 rayleighExtinction = density.x * uAtmosphere.params.rayleighScatteringBase;
-        float mieExtinction = density.y * (uAtmosphere.params.mieScatteringBase + uAtmosphere.params.mieAbsorptionBase);
-        vec3 ozoneExtinction = density.z * uAtmosphere.params.ozoneAbsorption;
-
-        vec3 extinction = rayleighExtinction + vec3(mieExtinction) + ozoneExtinction;
-
-        // Trapezoidal rule weights
-        float weight = (i == 0 || i == TRANSMITTANCE_STEPS) ? 0.5 : 1.0;
-
-        opticalDepth += extinction * weight * dx;
-    }
-
-    // Transmittance = exp(-optical depth)
+    vec3 opticalDepth = integrateOpticalDepth(r, mu, distance, TRANSMITTANCE_STEPS, uAtmosphere.params);
     return exp(-opticalDepth);
 }
 
@@ -61,20 +30,17 @@ void main() {
     ivec2 texel = ivec2(gl_GlobalInvocationID.xy);
     ivec2 lutSize = imageSize(transmittanceLUT);
 
-    if (texel.x >= lutSize.x || texel.y >= lutSize.y) {
+    if (isOutOfBounds(texel, lutSize)) {
         return;
     }
 
-    // UV coordinates [0, 1]
-    vec2 uv = (vec2(texel) + 0.5) / vec2(lutSize);
+    vec2 uv = texelToUV(texel, lutSize);
 
     // Decode altitude and view zenith angle from UV
     float r, mu;
     UVToTransmittanceLUTParams(uv, r, mu, uAtmosphere.params);
 
-    // Compute transmittance
+    // Compute and store transmittance
     vec3 transmittance = ComputeTransmittance(r, mu);
-
-    // Store result
     imageStore(transmittanceLUT, texel, vec4(transmittance, 1.0));
 }


### PR DESCRIPTION
Extract common patterns from atmospheric LUT compute shaders into lut_compute_common.glsl:
- Bounds checking (isOutOfBounds)
- UV normalization (texelToUV)
- Transmittance LUT sampling (sampleTransmittanceLUT)
- Altitude/sun angle decoding (decodeAltitudeSunAngleLUT)
- Extinction calculation (computeExtinction)
- Scattering calculation (computeScattering)
- Ray marching helpers (rayMarchStepT, radiusToAltitude)
- Optical depth integration (integrateOpticalDepth)
- Sun direction construction (sunDirFromZenithCos)

Reduces code duplication across transmittance_lut.comp, skyview_lut.comp, irradiance_lut.comp, and multiscatter_lut.comp by ~65 lines total.