### PR TITLE
Refactor overlapping terrain shadow shaders

### DIFF
--- a/shaders/terrain/terrain_meshlet_shadow.vert
+++ b/shaders/terrain/terrain_meshlet_shadow.vert
@@ -14,45 +14,10 @@
 #define CBT_BUFFER_BINDING BINDING_TERRAIN_CBT_BUFFER
 #include "cbt.glsl"
 #include "leb.glsl"
-#include "../terrain_height_common.glsl"
+#include "terrain_shadow_base.glsl"
 
 // Meshlet vertex buffer (local UV coordinates in unit triangle)
 layout(location = 0) in vec2 inLocalUV;
-
-// Height map (global coarse LOD - fallback for distant terrain)
-layout(binding = BINDING_TERRAIN_HEIGHT_MAP) uniform sampler2D heightMapGlobal;
-
-// LOD tile array (high-res tiles near camera)
-layout(binding = BINDING_TERRAIN_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
-
-// Tile info buffer - world bounds for each active tile
-struct TileInfo {
-    vec4 worldBounds;    // xy = min corner, zw = max corner
-    vec4 uvScaleOffset;  // xy = scale, zw = offset
-    ivec4 layerIndex;    // x = layer index in tile array, yzw = padding
-};
-layout(std430, binding = BINDING_TERRAIN_TILE_INFO) readonly buffer TileInfoBuffer {
-    uint activeTileCount;
-    uint padding1;
-    uint padding2;
-    uint padding3;
-    TileInfo tiles[];
-};
-
-// Include tile cache common after defining prerequisites
-#include "../tile_cache_common.glsl"
-
-// Push constants for per-cascade matrix
-layout(push_constant) uniform PushConstants {
-    mat4 lightViewProj;
-    float terrainSize;
-    float heightScale;
-    int cascadeIndex;
-    int padding;
-};
-
-// Output UV for hole mask sampling in fragment shader
-layout(location = 0) out vec2 fragTexCoord;
 
 void main() {
     // gl_InstanceIndex tells us which CBT leaf node we're rendering
@@ -80,21 +45,6 @@ void main() {
     uv.x = dot(baryWeights, transformedX);
     uv.y = dot(baryWeights, transformedY);
 
-    // Compute world XZ position first (needed for tile lookup)
-    vec2 worldXZ = vec2(
-        (uv.x - 0.5) * terrainSize,
-        (uv.y - 0.5) * terrainSize
-    );
-
-    // Sample height with LOD tile support
-    float height = sampleHeightWithTileCache(heightMapGlobal, heightMapTiles, uv, worldXZ, heightScale, activeTileCount);
-
-    // Compute world position
-    vec3 worldPos = vec3(worldXZ.x, height, worldXZ.y);
-
-    // Transform to light space
-    gl_Position = lightViewProj * vec4(worldPos, 1.0);
-
-    // Pass UV for hole mask sampling
-    fragTexCoord = uv;
+    // Apply common shadow transformation
+    terrainShadowTransform(uv);
 }

--- a/shaders/terrain/terrain_shadow.vert
+++ b/shaders/terrain/terrain_shadow.vert
@@ -4,7 +4,10 @@
 
 /*
  * terrain_shadow.vert - Terrain shadow pass vertex shader
- * Simplified version for shadow map rendering
+ *
+ * Simplified version for shadow map rendering.
+ * Uses CBT leaf nodes directly with 3 vertices per triangle.
+ *
  * Height convention: see terrain_height_common.glsl
  */
 
@@ -13,41 +16,7 @@
 #define CBT_BUFFER_BINDING BINDING_TERRAIN_CBT_BUFFER
 #include "cbt.glsl"
 #include "leb.glsl"
-#include "../terrain_height_common.glsl"
-
-// Height map (global coarse LOD - fallback for distant terrain)
-layout(binding = BINDING_TERRAIN_HEIGHT_MAP) uniform sampler2D heightMapGlobal;
-
-// LOD tile array (high-res tiles near camera)
-layout(binding = BINDING_TERRAIN_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
-
-// Tile info buffer - world bounds for each active tile
-struct TileInfo {
-    vec4 worldBounds;    // xy = min corner, zw = max corner
-    vec4 uvScaleOffset;  // xy = scale, zw = offset
-    ivec4 layerIndex;    // x = layer index in tile array, yzw = padding
-};
-layout(std430, binding = BINDING_TERRAIN_TILE_INFO) readonly buffer TileInfoBuffer {
-    uint activeTileCount;
-    uint padding1;
-    uint padding2;
-    uint padding3;
-    TileInfo tiles[];
-};
-
-#include "../tile_cache_common.glsl"
-
-// Push constants for per-cascade matrix
-layout(push_constant) uniform PushConstants {
-    mat4 lightViewProj;
-    float terrainSize;
-    float heightScale;
-    int cascadeIndex;
-    int padding;
-};
-
-// Output UV for hole mask sampling in fragment shader
-layout(location = 0) out vec2 fragTexCoord;
+#include "terrain_shadow_base.glsl"
 
 void main() {
     // Determine which triangle and vertex
@@ -71,22 +40,6 @@ void main() {
         uv = v2;
     }
 
-    // Compute world XZ position first (needed for tile lookup)
-    vec2 worldXZ = vec2(
-        (uv.x - 0.5) * terrainSize,
-        (uv.y - 0.5) * terrainSize
-    );
-
-    // Sample height with tile cache support (~1m resolution near camera)
-    float height = sampleHeightWithTileCache(heightMapGlobal, heightMapTiles, uv,
-                                              worldXZ, heightScale, activeTileCount);
-
-    // Compute world position
-    vec3 worldPos = vec3(worldXZ.x, height, worldXZ.y);
-
-    // Transform to light space
-    gl_Position = lightViewProj * vec4(worldPos, 1.0);
-
-    // Pass UV for hole mask sampling
-    fragTexCoord = uv;
+    // Apply common shadow transformation
+    terrainShadowTransform(uv);
 }

--- a/shaders/terrain/terrain_shadow_base.glsl
+++ b/shaders/terrain/terrain_shadow_base.glsl
@@ -1,0 +1,85 @@
+/*
+ * terrain_shadow_base.glsl - Shared code for terrain shadow vertex shaders
+ *
+ * This file contains the common height sampling, tile cache, and transformation
+ * logic used by all terrain shadow vertex shaders:
+ *   - terrain_shadow.vert
+ *   - terrain_meshlet_shadow.vert
+ *   - terrain_shadow_culled.vert
+ *   - terrain_meshlet_shadow_culled.vert
+ *
+ * USAGE:
+ *   1. Include bindings.glsl, cbt.glsl, leb.glsl first
+ *   2. Include this file
+ *   3. In main(), compute UV then call terrainShadowTransform(uv)
+ *
+ * Height convention: see terrain_height_common.glsl
+ */
+
+#ifndef TERRAIN_SHADOW_BASE_GLSL
+#define TERRAIN_SHADOW_BASE_GLSL
+
+#include "../terrain_height_common.glsl"
+
+// Height map (global coarse LOD - fallback for distant terrain)
+layout(binding = BINDING_TERRAIN_HEIGHT_MAP) uniform sampler2D heightMapGlobal;
+
+// LOD tile array (high-res tiles near camera)
+layout(binding = BINDING_TERRAIN_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
+
+// Tile info buffer - world bounds for each active tile
+struct TileInfo {
+    vec4 worldBounds;    // xy = min corner, zw = max corner
+    vec4 uvScaleOffset;  // xy = scale, zw = offset
+    ivec4 layerIndex;    // x = layer index in tile array, yzw = padding
+};
+layout(std430, binding = BINDING_TERRAIN_TILE_INFO) readonly buffer TileInfoBuffer {
+    uint activeTileCount;
+    uint padding1;
+    uint padding2;
+    uint padding3;
+    TileInfo tiles[];
+};
+
+#include "../tile_cache_common.glsl"
+
+// Push constants for per-cascade matrix
+layout(push_constant) uniform PushConstants {
+    mat4 lightViewProj;
+    float terrainSize;
+    float heightScale;
+    int cascadeIndex;
+    int padding;
+};
+
+// Output UV for hole mask sampling in fragment shader
+layout(location = 0) out vec2 fragTexCoord;
+
+/*
+ * Transform terrain UV to light-space position for shadow rendering.
+ * Samples height with tile cache support and outputs to gl_Position and fragTexCoord.
+ *
+ * Call this from main() after computing the UV coordinates.
+ */
+void terrainShadowTransform(vec2 uv) {
+    // Compute world XZ position (needed for tile lookup)
+    vec2 worldXZ = vec2(
+        (uv.x - 0.5) * terrainSize,
+        (uv.y - 0.5) * terrainSize
+    );
+
+    // Sample height with tile cache support (~1m resolution near camera)
+    float height = sampleHeightWithTileCache(heightMapGlobal, heightMapTiles, uv,
+                                              worldXZ, heightScale, activeTileCount);
+
+    // Compute world position
+    vec3 worldPos = vec3(worldXZ.x, height, worldXZ.y);
+
+    // Transform to light space
+    gl_Position = lightViewProj * vec4(worldPos, 1.0);
+
+    // Pass UV for hole mask sampling
+    fragTexCoord = uv;
+}
+
+#endif // TERRAIN_SHADOW_BASE_GLSL

--- a/shaders/terrain/terrain_shadow_culled.vert
+++ b/shaders/terrain/terrain_shadow_culled.vert
@@ -17,47 +17,13 @@
 #define CBT_BUFFER_BINDING BINDING_TERRAIN_CBT_BUFFER
 #include "cbt.glsl"
 #include "leb.glsl"
-#include "../terrain_height_common.glsl"
-
-// Height map (global coarse LOD - fallback for distant terrain)
-layout(binding = BINDING_TERRAIN_HEIGHT_MAP) uniform sampler2D heightMapGlobal;
-
-// LOD tile array (high-res tiles near camera)
-layout(binding = BINDING_TERRAIN_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
-
-// Tile info buffer - world bounds for each active tile
-struct TileInfo {
-    vec4 worldBounds;    // xy = min corner, zw = max corner
-    vec4 uvScaleOffset;  // xy = scale, zw = offset
-    ivec4 layerIndex;    // x = layer index in tile array, yzw = padding
-};
-layout(std430, binding = BINDING_TERRAIN_TILE_INFO) readonly buffer TileInfoBuffer {
-    uint activeTileCount;
-    uint padding1;
-    uint padding2;
-    uint padding3;
-    TileInfo tiles[];
-};
-
-#include "../tile_cache_common.glsl"
+#include "terrain_shadow_base.glsl"
 
 // Shadow visible indices buffer: [count, index0, index1, ...]
 layout(std430, binding = BINDING_TERRAIN_SHADOW_VISIBLE) readonly buffer ShadowVisibleIndices {
     uint shadowVisibleCount;
     uint shadowIndices[];
 };
-
-// Push constants for per-cascade matrix
-layout(push_constant) uniform PushConstants {
-    mat4 lightViewProj;
-    float terrainSize;
-    float heightScale;
-    int cascadeIndex;
-    int padding;
-};
-
-// Output UV for hole mask sampling in fragment shader
-layout(location = 0) out vec2 fragTexCoord;
 
 void main() {
     // Determine which visible triangle and vertex within it
@@ -84,22 +50,6 @@ void main() {
         uv = v2;
     }
 
-    // Compute world XZ position first (needed for tile lookup)
-    vec2 worldXZ = vec2(
-        (uv.x - 0.5) * terrainSize,
-        (uv.y - 0.5) * terrainSize
-    );
-
-    // Sample height with tile cache support for ~1m resolution near camera
-    float height = sampleHeightWithTileCache(heightMapGlobal, heightMapTiles, uv,
-                                              worldXZ, heightScale, activeTileCount);
-
-    // Compute world position
-    vec3 worldPos = vec3(worldXZ.x, height, worldXZ.y);
-
-    // Transform to light space
-    gl_Position = lightViewProj * vec4(worldPos, 1.0);
-
-    // Pass UV for hole mask sampling
-    fragTexCoord = uv;
+    // Apply common shadow transformation
+    terrainShadowTransform(uv);
 }


### PR DESCRIPTION
Create terrain_shadow_base.glsl containing height sampling, tile cache access, and shadow transformation logic shared by all 4 terrain shadow vertex shaders. Each shader now only contains its UV computation logic.