### PR TITLE
Refactor shaders for better performance

### DIFF
--- a/shaders/cull_compute_common.glsl
+++ b/shaders/cull_compute_common.glsl
@@ -1,0 +1,158 @@
+// Common culling compute shader utilities
+// Provides shared frustum culling, distance culling, and subgroup-batched atomic patterns
+// for GPU-driven culling passes (tree cells, tree filtering, shadow culling, etc.)
+//
+// Usage: #include "cull_compute_common.glsl"
+//
+// Requires extensions:
+//   GL_KHR_shader_subgroup_ballot
+//   GL_KHR_shader_subgroup_arithmetic
+
+#ifndef CULL_COMPUTE_COMMON_GLSL
+#define CULL_COMPUTE_COMMON_GLSL
+
+// ============================================================================
+// AABB Frustum Culling
+// ============================================================================
+
+// Check if an AABB is at least partially inside the frustum
+// boundsMin, boundsMax: AABB extents in world space
+// planes: array of 6 frustum plane equations (nx, ny, nz, d)
+// Returns true if the AABB is at least partially inside the frustum
+bool isAABBInFrustum(vec3 boundsMin, vec3 boundsMax, vec4 planes[6]) {
+    // For each frustum plane, find the vertex of the AABB that is most
+    // in the direction of the plane normal. If this vertex is behind the plane,
+    // the AABB is completely outside the frustum.
+    for (int i = 0; i < 6; i++) {
+        vec3 normal = planes[i].xyz;
+
+        // Find the positive vertex (vertex most in direction of normal)
+        vec3 positiveVertex;
+        positiveVertex.x = (normal.x >= 0.0) ? boundsMax.x : boundsMin.x;
+        positiveVertex.y = (normal.y >= 0.0) ? boundsMax.y : boundsMin.y;
+        positiveVertex.z = (normal.z >= 0.0) ? boundsMax.z : boundsMin.z;
+
+        // Test if positive vertex is behind the plane
+        if (dot(vec4(positiveVertex, 1.0), planes[i]) < 0.0) {
+            return false;  // Completely outside this plane
+        }
+    }
+    return true;  // At least partially inside all planes
+}
+
+// ============================================================================
+// Sphere Frustum Culling
+// ============================================================================
+
+// Check if a bounding sphere is at least partially inside the frustum
+// center: sphere center in world space
+// radius: sphere radius
+// planes: array of 6 frustum plane equations (nx, ny, nz, d)
+// Returns true if the sphere is at least partially inside the frustum
+bool isSphereInFrustum(vec3 center, float radius, vec4 planes[6]) {
+    for (int i = 0; i < 6; i++) {
+        float dist = dot(planes[i].xyz, center) + planes[i].w;
+        if (dist < -radius) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ============================================================================
+// AABB Distance Culling
+// ============================================================================
+
+// Check if an AABB's closest point is within max distance from camera
+// boundsMin, boundsMax: AABB extents in world space
+// cameraPos: camera position in world space
+// maxDistance: maximum draw distance
+// Returns true if the AABB is within range
+bool isAABBInRange(vec3 boundsMin, vec3 boundsMax, vec3 cameraPos, float maxDistance) {
+    // Find closest point on AABB to camera
+    vec3 closestPoint;
+    closestPoint.x = clamp(cameraPos.x, boundsMin.x, boundsMax.x);
+    closestPoint.y = clamp(cameraPos.y, boundsMin.y, boundsMax.y);
+    closestPoint.z = clamp(cameraPos.z, boundsMin.z, boundsMax.z);
+
+    // Check if closest point is within range
+    float dist = length(closestPoint - cameraPos);
+    return dist <= maxDistance;
+}
+
+// ============================================================================
+// Distance Bucketing
+// ============================================================================
+
+// Number of distance buckets for prioritized processing
+const uint NUM_DISTANCE_BUCKETS = 8;
+
+// Calculate which distance bucket a cell belongs to based on distance
+// Bucket boundaries aligned with typical cell sizes:
+// 0-64m, 64-128m, 128-192m, 192-256m, 256-320m, 320-400m, 400-500m, 500m+
+uint getDistanceBucket(float dist) {
+    if (dist < 64.0) return 0;
+    if (dist < 128.0) return 1;
+    if (dist < 192.0) return 2;
+    if (dist < 256.0) return 3;
+    if (dist < 320.0) return 4;
+    if (dist < 400.0) return 5;
+    if (dist < 500.0) return 6;
+    return 7;
+}
+
+// Encode cell index with distance bucket (high 3 bits = bucket, low 29 bits = index)
+uint encodeCellWithBucket(uint cellIndex, uint bucket) {
+    return (bucket << 29) | (cellIndex & 0x1FFFFFFF);
+}
+
+// Decode cell index from encoded value
+uint decodeCellIndex(uint encoded) {
+    return encoded & 0x1FFFFFFF;
+}
+
+// Decode bucket from encoded value
+uint decodeBucket(uint encoded) {
+    return encoded >> 29;
+}
+
+// ============================================================================
+// Subgroup Batched Atomic Pattern (Documentation)
+// ============================================================================
+//
+// Use subgroup operations to batch atomic updates, reducing contention.
+// This pattern cannot be abstracted into a function because GLSL atomics
+// only work on buffer/shared memory l-values, not function parameters.
+//
+// Basic pattern for allocating slots from a counter:
+//
+//   uvec4 activeMask = subgroupBallot(true);
+//   uint activeCount = subgroupBallotBitCount(activeMask);
+//   uint laneOffset = subgroupBallotExclusiveBitCount(activeMask);
+//
+//   uint baseIdx = 0;
+//   if (subgroupElect()) {
+//       baseIdx = atomicAdd(myCounter, activeCount);
+//   }
+//   baseIdx = subgroupBroadcastFirst(baseIdx);
+//   uint slot = baseIdx + laneOffset;
+//
+// Per-category batching (for bucketing by type/group):
+//
+//   for (uint c = 0; c < NUM_CATEGORIES; c++) {
+//       uvec4 categoryMask = subgroupBallot(myCategory == c);
+//       uint categoryCount = subgroupBallotBitCount(categoryMask);
+//       if (categoryCount > 0) {
+//           uint electedLane = subgroupBallotFindLSB(categoryMask);
+//           uint baseSlot = 0;
+//           if (gl_SubgroupInvocationID == electedLane) {
+//               baseSlot = atomicAdd(counters[c], categoryCount);
+//           }
+//           baseSlot = subgroupBroadcast(baseSlot, electedLane);
+//           if (myCategory == c) {
+//               slot = baseSlot + subgroupBallotExclusiveBitCount(categoryMask);
+//           }
+//       }
+//   }
+
+#endif // CULL_COMPUTE_COMMON_GLSL

--- a/shaders/tree_branch_shadow_cull.comp
+++ b/shaders/tree_branch_shadow_cull.comp
@@ -5,6 +5,8 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 
 #include "bindings.glsl"
+#include "instancing_common.glsl"
+#include "cull_compute_common.glsl"
 
 layout(local_size_x = 256) in;
 
@@ -28,14 +30,7 @@ layout(std430, binding = BINDING_TREE_BRANCH_SHADOW_OUTPUT) writeonly buffer Out
 };
 
 // Indirect draw commands (one per mesh group)
-struct DrawIndexedIndirectCommand {
-    uint indexCount;
-    uint instanceCount;
-    uint firstIndex;
-    int vertexOffset;
-    uint firstInstance;
-};
-
+// Uses DrawIndexedIndirectCommand from instancing_common.glsl
 layout(std430, binding = BINDING_TREE_BRANCH_SHADOW_INDIRECT) buffer IndirectBuffer {
     DrawIndexedIndirectCommand drawCmds[];
 };
@@ -69,17 +64,7 @@ layout(binding = BINDING_TREE_BRANCH_SHADOW_UNIFORMS) uniform CullUniforms {
     uint _pad2;
 } uniforms;
 
-// Frustum culling test
-bool isInFrustum(vec3 center, float radius) {
-    for (int i = 0; i < 6; i++) {
-        vec4 plane = uniforms.cascadeFrustumPlanes[i];
-        float dist = dot(plane.xyz, center) + plane.w;
-        if (dist < -radius) {
-            return false;
-        }
-    }
-    return true;
-}
+// Frustum culling uses isSphereInFrustum from cull_compute_common.glsl
 
 // Maximum mesh groups to prevent GPU hang from garbage uniform data
 const uint MAX_MESH_GROUPS = 16u;
@@ -128,7 +113,7 @@ void main() {
     // Frustum culling against cascade light frustum with margin for shadow projection
     // Shadows can extend beyond the tree depending on light angle
     float shadowMargin = boundingRadius * 0.5;
-    if (!isInFrustum(boundingCenter, boundingRadius + shadowMargin)) {
+    if (!isSphereInFrustum(boundingCenter, boundingRadius + shadowMargin, uniforms.cascadeFrustumPlanes)) {
         return;
     }
 

--- a/shaders/tree_cell_cull.comp
+++ b/shaders/tree_cell_cull.comp
@@ -6,13 +6,12 @@
 
 #include "bindings.glsl"
 #include "instancing_common.glsl"
+#include "cull_compute_common.glsl"
 
 // Workgroup size: 256 threads per workgroup
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
-// Distance bucketing for prioritized cell processing
-// Cells are sorted into buckets by distance so nearby trees get processed first
-const uint NUM_DISTANCE_BUCKETS = 8;
+// Distance bucketing uses NUM_DISTANCE_BUCKETS from cull_compute_common.glsl
 
 // Cell data (packed for GPU - 32 bytes per cell)
 // boundsMinAndFirst: xyz = boundsMin, w = firstTreeIndex as float bits
@@ -57,56 +56,8 @@ layout(binding = BINDING_TREE_CELL_CULL_UNIFORMS) uniform CellCullUniforms {
     uint _pad0;
 };
 
-// AABB vs frustum test
-// Returns true if the AABB is at least partially inside the frustum
-bool isAABBInFrustum(vec3 boundsMin, vec3 boundsMax, vec4 planes[6]) {
-    // For each frustum plane, find the vertex of the AABB that is most
-    // in the direction of the plane normal. If this vertex is behind the plane,
-    // the AABB is completely outside the frustum.
-    for (int i = 0; i < 6; i++) {
-        vec3 normal = planes[i].xyz;
-
-        // Find the positive vertex (vertex most in direction of normal)
-        vec3 positiveVertex;
-        positiveVertex.x = (normal.x >= 0.0) ? boundsMax.x : boundsMin.x;
-        positiveVertex.y = (normal.y >= 0.0) ? boundsMax.y : boundsMin.y;
-        positiveVertex.z = (normal.z >= 0.0) ? boundsMax.z : boundsMin.z;
-
-        // Test if positive vertex is behind the plane
-        if (dot(vec4(positiveVertex, 1.0), planes[i]) < 0.0) {
-            return false;  // Completely outside this plane
-        }
-    }
-    return true;  // At least partially inside all planes
-}
-
-// Distance culling for AABB
-// Returns true if the AABB's closest point is within max distance
-bool isAABBInRange(vec3 boundsMin, vec3 boundsMax, vec3 cameraPos, float maxDistance) {
-    // Find closest point on AABB to camera
-    vec3 closestPoint;
-    closestPoint.x = clamp(cameraPos.x, boundsMin.x, boundsMax.x);
-    closestPoint.y = clamp(cameraPos.y, boundsMin.y, boundsMax.y);
-    closestPoint.z = clamp(cameraPos.z, boundsMin.z, boundsMax.z);
-
-    // Check if closest point is within range
-    float dist = length(closestPoint - cameraPos);
-    return dist <= maxDistance;
-}
-
-// Calculate which distance bucket a cell belongs to
-uint getDistanceBucket(float dist) {
-    // Bucket boundaries aligned with 64m cell size:
-    // 0-64m (1 cell), 64-128m (2 cells), 128-192m, 192-256m, 256-320m, 320-400m, 400-500m, 500m+
-    if (dist < 64.0) return 0;
-    if (dist < 128.0) return 1;
-    if (dist < 192.0) return 2;
-    if (dist < 256.0) return 3;
-    if (dist < 320.0) return 4;
-    if (dist < 400.0) return 5;
-    if (dist < 500.0) return 6;
-    return 7;
-}
+// Culling functions (isAABBInFrustum, isAABBInRange, getDistanceBucket)
+// are provided by cull_compute_common.glsl
 
 // Shared memory for bucket prefix sum calculation
 shared uint sharedBucketCounts[NUM_DISTANCE_BUCKETS];

--- a/shaders/tree_filter.comp
+++ b/shaders/tree_filter.comp
@@ -6,13 +6,13 @@
 
 #include "bindings.glsl"
 #include "instancing_common.glsl"
+#include "cull_compute_common.glsl"
 
 // Workgroup size: One workgroup per visible cell
 // Each thread in the workgroup processes one tree from the cell
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-// Distance bucketing constants (must match tree_cell_cull.comp)
-const uint NUM_DISTANCE_BUCKETS = 8;
+// Distance bucketing uses NUM_DISTANCE_BUCKETS from cull_compute_common.glsl
 
 // Per-tree culling data (from TreeRenderer - all trees)
 struct TreeCullData {
@@ -58,19 +58,11 @@ layout(std430, binding = BINDING_TREE_FILTER_ALL_TREES) readonly buffer AllTrees
 
 // Input: Visible cell indices (from cell culling)
 // Cell indices are encoded: high 3 bits = distance bucket, low 29 bits = actual cell index
+// Use decodeCellIndex() and decodeBucket() from cull_compute_common.glsl
 layout(std430, binding = BINDING_TREE_FILTER_VISIBLE_CELLS) readonly buffer VisibleCellsBuffer {
     uint visibleCellCount;
     uint visibleCellIndices[];
 };
-
-// Helper to decode bucket-encoded cell index
-uint decodeCellIndex(uint encoded) {
-    return encoded & 0x1FFFFFFF;
-}
-
-uint decodeBucket(uint encoded) {
-    return encoded >> 29;
-}
 
 // Input: Cell data for tree ranges
 layout(std430, binding = BINDING_TREE_FILTER_CELL_DATA) readonly buffer CellDataBuffer {


### PR DESCRIPTION
Consolidate duplicated culling patterns from tree compute shaders:
- AABB frustum culling (isAABBInFrustum)
- Sphere frustum culling (isSphereInFrustum)
- AABB distance culling (isAABBInRange)
- Distance bucket calculations (getDistanceBucket, encode/decode helpers)
- NUM_DISTANCE_BUCKETS constant

Removes ~90 lines of duplicated code across tree_branch_shadow_cull.comp, tree_cell_cull.comp, and tree_filter.comp.