### PR TITLE
Optimize game engine initialization order for Vulkan

### DIFF
--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -46,6 +46,11 @@ public:
         SDL_Window* window;
         std::string resourcePath;
         Config config{};  // Optional renderer configuration
+
+        // Optional: pre-initialized VulkanContext (instance already created)
+        // If provided, Renderer takes ownership and completes device init.
+        // If nullptr, Renderer creates and fully initializes a new VulkanContext.
+        std::unique_ptr<VulkanContext> vulkanContext;
     };
 
     /**
@@ -72,8 +77,8 @@ public:
     void waitForPreviousFrame();
 
     // Viewport dimensions
-    uint32_t getWidth() const { return vulkanContext.getWidth(); }
-    uint32_t getHeight() const { return vulkanContext.getHeight(); }
+    uint32_t getWidth() const { return vulkanContext_->getWidth(); }
+    uint32_t getHeight() const { return vulkanContext_->getHeight(); }
 
     // Handle window resize (recreate swapchain and dependent resources)
     bool handleResize();
@@ -93,17 +98,17 @@ public:
     bool isWindowSuspended() const { return windowSuspended; }
 
     // Vulkan handle getters for GUI integration
-    VkInstance getInstance() const { return vulkanContext.getInstance(); }
-    VkPhysicalDevice getPhysicalDevice() const { return vulkanContext.getPhysicalDevice(); }
-    VkDevice getDevice() const { return vulkanContext.getDevice(); }
-    VkQueue getGraphicsQueue() const { return vulkanContext.getGraphicsQueue(); }
-    uint32_t getGraphicsQueueFamily() const { return vulkanContext.getGraphicsQueueFamily(); }
+    VkInstance getInstance() const { return vulkanContext_->getInstance(); }
+    VkPhysicalDevice getPhysicalDevice() const { return vulkanContext_->getPhysicalDevice(); }
+    VkDevice getDevice() const { return vulkanContext_->getDevice(); }
+    VkQueue getGraphicsQueue() const { return vulkanContext_->getGraphicsQueue(); }
+    uint32_t getGraphicsQueueFamily() const { return vulkanContext_->getGraphicsQueueFamily(); }
     VkRenderPass getSwapchainRenderPass() const { return renderPass.get(); }
-    uint32_t getSwapchainImageCount() const { return vulkanContext.getSwapchainImageCount(); }
+    uint32_t getSwapchainImageCount() const { return vulkanContext_->getSwapchainImageCount(); }
 
     // Access to VulkanContext
-    VulkanContext& getVulkanContext() { return vulkanContext; }
-    const VulkanContext& getVulkanContext() const { return vulkanContext; }
+    VulkanContext& getVulkanContext() { return *vulkanContext_; }
+    const VulkanContext& getVulkanContext() const { return *vulkanContext_; }
 
     // Interface accessors - provide access to GUI-facing control interfaces via RendererSystems
     ILocationControl& getLocationControl() { return systems_->locationControl(); }
@@ -241,7 +246,7 @@ private:
     std::string resourcePath;
     Config config_;  // Renderer configuration
 
-    VulkanContext vulkanContext;
+    std::unique_ptr<VulkanContext> vulkanContext_;
 
     // All rendering subsystems - managed with automatic lifecycle
     std::unique_ptr<RendererSystems> systems_;

--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -64,11 +64,11 @@ bool Renderer::initDescriptorInfrastructure() {
 }
 
 bool Renderer::initSubsystems(const InitContext& initCtx) {
-    VkDevice device = vulkanContext.getDevice();
-    VmaAllocator allocator = vulkanContext.getAllocator();
-    VkPhysicalDevice physicalDevice = vulkanContext.getPhysicalDevice();
-    VkQueue graphicsQueue = vulkanContext.getGraphicsQueue();
-    VkFormat swapchainImageFormat = vulkanContext.getSwapchainImageFormat();
+    VkDevice device = vulkanContext_->getDevice();
+    VmaAllocator allocator = vulkanContext_->getAllocator();
+    VkPhysicalDevice physicalDevice = vulkanContext_->getPhysicalDevice();
+    VkQueue graphicsQueue = vulkanContext_->getGraphicsQueue();
+    VkFormat swapchainImageFormat = vulkanContext_->getSwapchainImageFormat();
 
     // Initialize post-processing systems (PostProcessSystem, BloomSystem)
     if (!RendererInit::initPostProcessing(*systems_, initCtx, renderPass.get(), swapchainImageFormat)) {
@@ -1026,12 +1026,12 @@ void Renderer::initResizeCoordinator() {
     // Register core resize handler for swapchain, depth buffer, and framebuffers
     systems_->resizeCoordinator().setCoreResizeHandler([this](VkDevice, VmaAllocator) -> VkExtent2D {
         // Recreate swapchain
-        if (!vulkanContext.recreateSwapchain()) {
+        if (!vulkanContext_->recreateSwapchain()) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to recreate swapchain");
             return {0, 0};
         }
 
-        VkExtent2D newExtent = vulkanContext.getSwapchainExtent();
+        VkExtent2D newExtent = vulkanContext_->getSwapchainExtent();
 
         // Handle minimized window (extent = 0)
         if (newExtent.width == 0 || newExtent.height == 0) {
@@ -1061,7 +1061,7 @@ void Renderer::initResizeCoordinator() {
 void Renderer::initControlSubsystems() {
     // Initialize control subsystems in RendererSystems
     // These subsystems implement GUI-facing interfaces directly
-    systems_->initControlSubsystems(vulkanContext, perfToggles);
+    systems_->initControlSubsystems(*vulkanContext_, perfToggles);
 
     // Set up the performance sync callback
     systems_->setPerformanceSyncCallback([this]() { syncPerformanceToggles(); });

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -6,10 +6,27 @@
 // Required for dynamic dispatch loader - only define in one .cpp file
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
-bool VulkanContext::init(SDL_Window* win) {
-    window = win;
+bool VulkanContext::initInstance() {
+    if (instanceReady) {
+        return true;  // Already initialized
+    }
 
     if (!createInstance()) return false;
+
+    instanceReady = true;
+    SDL_Log("Vulkan instance ready (early init phase complete)");
+    return true;
+}
+
+bool VulkanContext::initDevice(SDL_Window* win) {
+    if (!instanceReady) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "initDevice called before initInstance");
+        return false;
+    }
+
+    window = win;
+
     if (!createSurface()) return false;
     if (!selectPhysicalDevice()) return false;
     if (!createLogicalDevice()) return false;
@@ -17,6 +34,13 @@ bool VulkanContext::init(SDL_Window* win) {
     if (!createPipelineCache()) return false;
     if (!createSwapchain()) return false;
 
+    return true;
+}
+
+bool VulkanContext::init(SDL_Window* win) {
+    // Combined init for backwards compatibility
+    if (!initInstance()) return false;
+    if (!initDevice(win)) return false;
     return true;
 }
 

--- a/src/core/vulkan/VulkanContext.h
+++ b/src/core/vulkan/VulkanContext.h
@@ -26,6 +26,21 @@ public:
     VulkanContext(const VulkanContext&) = delete;
     VulkanContext& operator=(const VulkanContext&) = delete;
 
+    /**
+     * Two-phase initialization for early Vulkan startup.
+     *
+     * initInstance() can be called before window creation to start
+     * Vulkan instance, validation layers, and dispatcher earlier.
+     *
+     * initDevice() completes initialization once a window is available.
+     */
+    bool initInstance();
+    bool initDevice(SDL_Window* window);
+
+    /**
+     * Combined init for backwards compatibility.
+     * Equivalent to initInstance() + initDevice(window).
+     */
     bool init(SDL_Window* window);
     void shutdown();
 
@@ -56,6 +71,9 @@ public:
 
     const vkb::Device& getVkbDevice() const { return vkbDevice; }
 
+    // Check if instance phase is complete (for two-phase init)
+    bool isInstanceReady() const { return instanceReady; }
+
 private:
     bool createInstance();
     bool createSurface();
@@ -65,6 +83,7 @@ private:
     bool createPipelineCache();
 
     SDL_Window* window = nullptr;
+    bool instanceReady = false;
 
     vkb::Instance vkbInstance;
     vkb::PhysicalDevice vkbPhysicalDevice;


### PR DESCRIPTION
Extract Vulkan instance creation into separate initInstance() method that can be called before window creation. This allows validation layers and the vulkan-hpp dispatcher to start earlier, reducing overall initialization time.

Changes:
- Add initInstance() and initDevice() two-phase init to VulkanContext
- Update Renderer to accept pre-initialized VulkanContext via InitInfo
- Change Renderer's vulkanContext member to unique_ptr for ownership
- Update Application to create VulkanContext and init instance before creating SDL window