### PR TITLE
Extract triple buffering pattern into class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SOURCES
     src/core/LoadingRenderer.cpp
     src/core/Mesh.cpp
     src/core/BufferUtils.cpp
+    src/core/TripleBuffering.cpp
     src/core/Texture.cpp
     src/core/ShaderLoader.cpp
     src/core/pipeline/PipelineBuilder.cpp

--- a/src/core/FrameBuffered.h
+++ b/src/core/FrameBuffered.h
@@ -1,0 +1,258 @@
+#pragma once
+
+// ============================================================================
+// FrameBuffered.h - Generic template for triple-buffered (or N-buffered) resources
+// ============================================================================
+//
+// This template provides a generic way to manage per-frame resources with
+// automatic frame cycling. It encapsulates the common pattern of having
+// N copies of a resource (one per frame-in-flight) and cycling through them.
+//
+// Key design principles:
+// - Generic: Works with any type T (buffers, descriptors, sync primitives, etc.)
+// - Frame index as source of truth: All access is based on frame index
+// - Safe modulo arithmetic: Handles wraparound correctly
+// - Non-owning by default: Doesn't manage lifecycle of T (use RAII types for T)
+//
+// Usage examples:
+//
+// 1. Simple per-frame buffers:
+//    FrameBuffered<VkBuffer> uniformBuffers(3);
+//    uniformBuffers[frameIndex] = createBuffer(...);
+//    vkCmdBindBuffer(cmd, uniformBuffers.current());
+//    uniformBuffers.advance();
+//
+// 2. Per-frame descriptor sets:
+//    FrameBuffered<VkDescriptorSet> descriptorSets;
+//    descriptorSets.resize(3, allocateDescriptorSet());
+//    vkCmdBindDescriptorSets(..., descriptorSets.current(), ...);
+//
+// 3. Aggregate per-frame data:
+//    struct FrameData { VkBuffer ubo; VkDescriptorSet desc; };
+//    FrameBuffered<FrameData> frames(3);
+//    frames.current().ubo = ...;
+//
+// 4. With initialization factory:
+//    auto frames = FrameBuffered<MyResource>::create(3, []() {
+//        return MyResource::create();
+//    });
+//
+
+#include <cstdint>
+#include <vector>
+#include <functional>
+#include <cassert>
+
+template<typename T>
+class FrameBuffered {
+public:
+    // Default frame count for triple buffering
+    static constexpr uint32_t DEFAULT_FRAME_COUNT = 3;
+
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    // Default constructor - must call resize() before use
+    FrameBuffered() = default;
+
+    // Construct with frame count (default-constructs T for each frame)
+    explicit FrameBuffered(uint32_t frameCount)
+        : resources_(frameCount)
+        , frameCount_(frameCount)
+        , currentFrame_(0) {}
+
+    // Construct with frame count and initial value (copies value to each frame)
+    FrameBuffered(uint32_t frameCount, const T& initialValue)
+        : resources_(frameCount, initialValue)
+        , frameCount_(frameCount)
+        , currentFrame_(0) {}
+
+    // Factory function: create with a generator for each frame
+    static FrameBuffered create(uint32_t frameCount, std::function<T(uint32_t)> generator) {
+        FrameBuffered fb;
+        fb.resources_.reserve(frameCount);
+        for (uint32_t i = 0; i < frameCount; ++i) {
+            fb.resources_.push_back(generator(i));
+        }
+        fb.frameCount_ = frameCount;
+        fb.currentFrame_ = 0;
+        return fb;
+    }
+
+    // =========================================================================
+    // Initialization / Resize
+    // =========================================================================
+
+    // Resize with default-constructed T
+    void resize(uint32_t frameCount) {
+        resources_.resize(frameCount);
+        frameCount_ = frameCount;
+        currentFrame_ = 0;
+    }
+
+    // Resize with initial value
+    void resize(uint32_t frameCount, const T& initialValue) {
+        resources_.resize(frameCount, initialValue);
+        frameCount_ = frameCount;
+        currentFrame_ = 0;
+    }
+
+    // Resize with factory function
+    void resize(uint32_t frameCount, std::function<T(uint32_t)> generator) {
+        resources_.clear();
+        resources_.reserve(frameCount);
+        for (uint32_t i = 0; i < frameCount; ++i) {
+            resources_.push_back(generator(i));
+        }
+        frameCount_ = frameCount;
+        currentFrame_ = 0;
+    }
+
+    // Clear all resources
+    void clear() {
+        resources_.clear();
+        frameCount_ = 0;
+        currentFrame_ = 0;
+    }
+
+    // =========================================================================
+    // Frame Index Management
+    // =========================================================================
+
+    // Get frame count
+    uint32_t frameCount() const { return frameCount_; }
+
+    // Get current frame index
+    uint32_t currentIndex() const { return currentFrame_; }
+
+    // Get previous frame index (wraps around)
+    uint32_t previousIndex() const {
+        return (currentFrame_ + frameCount_ - 1) % frameCount_;
+    }
+
+    // Get next frame index (wraps around)
+    uint32_t nextIndex() const {
+        return (currentFrame_ + 1) % frameCount_;
+    }
+
+    // Advance to next frame (call at end of render loop)
+    void advance() {
+        currentFrame_ = (currentFrame_ + 1) % frameCount_;
+    }
+
+    // Reset to first frame
+    void reset() {
+        currentFrame_ = 0;
+    }
+
+    // Apply modulo to wrap any index
+    uint32_t wrapIndex(uint32_t index) const {
+        return index % frameCount_;
+    }
+
+    // Get pointer to current frame index (for legacy code needing pointer access)
+    const uint32_t* currentIndexPtr() const { return &currentFrame_; }
+
+    // =========================================================================
+    // Resource Access
+    // =========================================================================
+
+    // Get current frame's resource
+    T& current() {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[currentFrame_];
+    }
+
+    const T& current() const {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[currentFrame_];
+    }
+
+    // Get previous frame's resource
+    T& previous() {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[previousIndex()];
+    }
+
+    const T& previous() const {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[previousIndex()];
+    }
+
+    // Get next frame's resource
+    T& next() {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[nextIndex()];
+    }
+
+    const T& next() const {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[nextIndex()];
+    }
+
+    // Get resource at specific frame index (with automatic wraparound)
+    T& at(uint32_t frameIndex) {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[frameIndex % frameCount_];
+    }
+
+    const T& at(uint32_t frameIndex) const {
+        assert(frameCount_ > 0 && "FrameBuffered not initialized");
+        return resources_[frameIndex % frameCount_];
+    }
+
+    // Array-style access (no modulo - caller must ensure valid index)
+    T& operator[](uint32_t index) {
+        assert(index < frameCount_ && "Index out of bounds");
+        return resources_[index];
+    }
+
+    const T& operator[](uint32_t index) const {
+        assert(index < frameCount_ && "Index out of bounds");
+        return resources_[index];
+    }
+
+    // =========================================================================
+    // Iteration
+    // =========================================================================
+
+    auto begin() { return resources_.begin(); }
+    auto end() { return resources_.end(); }
+    auto begin() const { return resources_.begin(); }
+    auto end() const { return resources_.end(); }
+
+    // Check if initialized
+    bool empty() const { return resources_.empty(); }
+    uint32_t size() const { return frameCount_; }
+
+    // =========================================================================
+    // Bulk Operations
+    // =========================================================================
+
+    // Apply a function to all frames
+    template<typename Func>
+    void forEach(Func&& func) {
+        for (uint32_t i = 0; i < frameCount_; ++i) {
+            func(i, resources_[i]);
+        }
+    }
+
+    template<typename Func>
+    void forEach(Func&& func) const {
+        for (uint32_t i = 0; i < frameCount_; ++i) {
+            func(i, resources_[i]);
+        }
+    }
+
+private:
+    std::vector<T> resources_;
+    uint32_t frameCount_ = 0;
+    uint32_t currentFrame_ = 0;
+};
+
+// ============================================================================
+// Type alias for triple buffering specifically
+// ============================================================================
+template<typename T>
+using TripleBuffered = FrameBuffered<T>;

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -22,6 +22,7 @@
 #include "VulkanRAII.h"
 #include "RendererSystems.h"
 #include "PerformanceToggles.h"
+#include "TripleBuffering.h"
 
 // Forward declarations
 class PhysicsWorld;
@@ -277,9 +278,8 @@ private:
 
     std::optional<DescriptorManager::Pool> descriptorManagerPool;
 
-    std::vector<ManagedSemaphore> imageAvailableSemaphores;
-    std::vector<ManagedSemaphore> renderFinishedSemaphores;
-    std::vector<ManagedFence> inFlightFences;
+    // Triple buffering: frame synchronization and indexing
+    TripleBuffering frameSync_;
 
     // Rock descriptor sets (RockSystem has its own textures, not in MaterialRegistry)
     std::vector<VkDescriptorSet> rockDescriptorSets;
@@ -292,8 +292,8 @@ private:
     std::unordered_map<std::string, std::vector<VkDescriptorSet>> treeBarkDescriptorSets;
     std::unordered_map<std::string, std::vector<VkDescriptorSet>> treeLeafDescriptorSets;
 
-    uint32_t currentFrame = 0;
-    static constexpr int MAX_FRAMES_IN_FLIGHT = 3;
+    // Convenience accessor for frame count (matches TripleBuffering::DEFAULT_FRAME_COUNT)
+    static constexpr int MAX_FRAMES_IN_FLIGHT = TripleBuffering::DEFAULT_FRAME_COUNT;
 
     float lastSunIntensity = 1.0f;
 

--- a/src/core/TripleBuffering.cpp
+++ b/src/core/TripleBuffering.cpp
@@ -1,0 +1,57 @@
+#include "TripleBuffering.h"
+#include <SDL3/SDL_log.h>
+
+bool TripleBuffering::init(VkDevice device, uint32_t frameCount) {
+    if (frameCount == 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "TripleBuffering::init: frameCount must be > 0");
+        return false;
+    }
+
+    destroy();
+
+    // Use FrameBuffered's resize with a factory function
+    frames_.resize(frameCount, [device](uint32_t i) -> FrameSyncPrimitives {
+        FrameSyncPrimitives primitives;
+
+        if (!ManagedSemaphore::create(device, primitives.imageAvailable)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                "TripleBuffering::init: failed to create imageAvailable[%u]", i);
+            return primitives;
+        }
+
+        if (!ManagedSemaphore::create(device, primitives.renderFinished)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                "TripleBuffering::init: failed to create renderFinished[%u]", i);
+            return primitives;
+        }
+
+        // Create fences in signaled state so first frame doesn't wait forever
+        if (!ManagedFence::createSignaled(device, primitives.inFlightFence)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                "TripleBuffering::init: failed to create inFlightFence[%u]", i);
+            return primitives;
+        }
+
+        return primitives;
+    });
+
+    // Verify all primitives were created successfully
+    for (uint32_t i = 0; i < frameCount; ++i) {
+        const auto& p = frames_[i];
+        if (!p.imageAvailable.get() || !p.renderFinished.get() || !p.inFlightFence.get()) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                "TripleBuffering::init: incomplete primitives for frame %u", i);
+            destroy();
+            return false;
+        }
+    }
+
+    SDL_Log("TripleBuffering: initialized with %u frames in flight", frameCount);
+    return true;
+}
+
+void TripleBuffering::destroy() {
+    // RAII handles cleanup - just clear the FrameBuffered container
+    frames_.clear();
+}

--- a/src/core/TripleBuffering.h
+++ b/src/core/TripleBuffering.h
@@ -1,0 +1,179 @@
+#pragma once
+
+// ============================================================================
+// TripleBuffering.h - Frame synchronization using FrameBuffered template
+// ============================================================================
+//
+// This header provides a specialized TripleBuffering class that uses the
+// generic FrameBuffered<T> template for managing Vulkan synchronization
+// primitives (fences and semaphores) per frame.
+//
+// The class encapsulates:
+// - Per-frame synchronization primitives (fences, semaphores)
+// - Frame index management and cycling
+// - Convenient methods for common synchronization patterns
+//
+// Usage:
+//   TripleBuffering frames;
+//   if (!frames.init(device)) return false;
+//
+//   // In render loop:
+//   frames.waitForCurrentFrameIfNeeded();
+//   uint32_t idx = frames.currentIndex();
+//   // ... record commands using idx for buffer selection ...
+//   frames.resetCurrentFence();
+//   // ... submit commands with frames.currentImageAvailableSemaphore() ...
+//   frames.advance();
+//
+
+#include "FrameBuffered.h"
+#include "vulkan/VulkanRAII.h"
+#include <vulkan/vulkan.h>
+
+// ============================================================================
+// FrameSyncPrimitives - Per-frame synchronization resources
+// ============================================================================
+
+struct FrameSyncPrimitives {
+    ManagedSemaphore imageAvailable;
+    ManagedSemaphore renderFinished;
+    ManagedFence inFlightFence;
+
+    // Non-copyable (Vulkan resources)
+    FrameSyncPrimitives() = default;
+    FrameSyncPrimitives(const FrameSyncPrimitives&) = delete;
+    FrameSyncPrimitives& operator=(const FrameSyncPrimitives&) = delete;
+
+    // Movable
+    FrameSyncPrimitives(FrameSyncPrimitives&&) noexcept = default;
+    FrameSyncPrimitives& operator=(FrameSyncPrimitives&&) noexcept = default;
+};
+
+// ============================================================================
+// TripleBuffering - Manages frame-in-flight synchronization using FrameBuffered
+// ============================================================================
+
+class TripleBuffering {
+public:
+    // Default to 3 frames in flight (triple buffering)
+    static constexpr uint32_t DEFAULT_FRAME_COUNT = 3;
+
+    TripleBuffering() = default;
+    ~TripleBuffering() = default;
+
+    // Non-copyable (contains Vulkan resources)
+    TripleBuffering(const TripleBuffering&) = delete;
+    TripleBuffering& operator=(const TripleBuffering&) = delete;
+
+    // Movable
+    TripleBuffering(TripleBuffering&&) noexcept = default;
+    TripleBuffering& operator=(TripleBuffering&&) noexcept = default;
+
+    // =========================================================================
+    // Initialization
+    // =========================================================================
+
+    // Initialize synchronization primitives for the specified frame count
+    // Returns false on failure
+    bool init(VkDevice device, uint32_t frameCount = DEFAULT_FRAME_COUNT);
+
+    // Clean up synchronization primitives
+    void destroy();
+
+    // Check if initialized
+    bool isInitialized() const { return !frames_.empty(); }
+
+    // =========================================================================
+    // Frame Index Management (delegated to FrameBuffered)
+    // =========================================================================
+
+    uint32_t frameCount() const { return frames_.frameCount(); }
+    uint32_t currentIndex() const { return frames_.currentIndex(); }
+    uint32_t previousIndex() const { return frames_.previousIndex(); }
+    uint32_t nextIndex() const { return frames_.nextIndex(); }
+    uint32_t wrapIndex(uint32_t index) const { return frames_.wrapIndex(index); }
+
+    void advance() { frames_.advance(); }
+    void reset() { frames_.reset(); }
+
+    // Get pointer to current frame index (for legacy code needing pointer access)
+    const uint32_t* currentIndexPtr() const { return frames_.currentIndexPtr(); }
+
+    // =========================================================================
+    // Synchronization - Fences
+    // =========================================================================
+
+    // Get fence for current frame
+    VkFence currentFence() const {
+        return frames_.current().inFlightFence.get();
+    }
+
+    // Get fence for any frame index
+    VkFence fence(uint32_t frameIndex) const {
+        return frames_.at(frameIndex).inFlightFence.get();
+    }
+
+    // Check if current frame's fence is already signaled (non-blocking)
+    bool isCurrentFenceSignaled() const {
+        return frames_.current().inFlightFence.isSignaled();
+    }
+
+    // Wait for current frame's fence (blocks until signaled)
+    void waitForCurrentFrame() const {
+        frames_.current().inFlightFence.wait();
+    }
+
+    // Wait for current frame only if not already signaled (optimization)
+    void waitForCurrentFrameIfNeeded() const {
+        if (!frames_.current().inFlightFence.isSignaled()) {
+            frames_.current().inFlightFence.wait();
+        }
+    }
+
+    // Wait for previous frame's fence (useful before destroying resources)
+    void waitForPreviousFrame() const {
+        const auto& prev = frames_.previous();
+        if (!prev.inFlightFence.isSignaled()) {
+            prev.inFlightFence.wait();
+        }
+    }
+
+    // Reset current frame's fence (call before queue submit)
+    void resetCurrentFence() const {
+        frames_.current().inFlightFence.resetFence();
+    }
+
+    // =========================================================================
+    // Synchronization - Semaphores
+    // =========================================================================
+
+    // Get image available semaphore for current frame
+    VkSemaphore currentImageAvailableSemaphore() const {
+        return frames_.current().imageAvailable.get();
+    }
+
+    // Get render finished semaphore for current frame
+    VkSemaphore currentRenderFinishedSemaphore() const {
+        return frames_.current().renderFinished.get();
+    }
+
+    // Get semaphores for any frame index
+    VkSemaphore imageAvailableSemaphore(uint32_t frameIndex) const {
+        return frames_.at(frameIndex).imageAvailable.get();
+    }
+
+    VkSemaphore renderFinishedSemaphore(uint32_t frameIndex) const {
+        return frames_.at(frameIndex).renderFinished.get();
+    }
+
+    // =========================================================================
+    // Direct Access (for compatibility with existing code)
+    // =========================================================================
+
+    // Access the underlying FrameBuffered container
+    const FrameBuffered<FrameSyncPrimitives>& frames() const { return frames_; }
+    FrameBuffered<FrameSyncPrimitives>& frames() { return frames_; }
+
+private:
+    FrameBuffered<FrameSyncPrimitives> frames_;
+};

--- a/src/core/pipeline/RenderPipelineFactory.cpp
+++ b/src/core/pipeline/RenderPipelineFactory.cpp
@@ -51,7 +51,7 @@ void RenderPipelineFactory::setupPipeline(
     // Capture state pointers for use in lambdas
     bool* terrainEnabled = state.terrainEnabled;
     bool* physicsDebugEnabled = state.physicsDebugEnabled;
-    uint32_t* currentFrame = state.currentFrame;
+    const uint32_t* currentFrame = state.currentFrame;
     glm::mat4* lastViewProj = state.lastViewProj;
     VkPipeline graphicsPipeline = state.graphicsPipeline;
 

--- a/src/core/pipeline/RenderPipelineFactory.h
+++ b/src/core/pipeline/RenderPipelineFactory.h
@@ -34,8 +34,8 @@ public:
         bool* terrainEnabled = nullptr;
         bool* physicsDebugEnabled = nullptr;
 
-        // Frame state
-        uint32_t* currentFrame = nullptr;
+        // Frame state (const pointer - read-only access)
+        const uint32_t* currentFrame = nullptr;
 
         // Cached state for debug rendering
         glm::mat4* lastViewProj = nullptr;


### PR DESCRIPTION
Introduces a generic FrameBuffered<T> template for per-frame resource management with automatic frame cycling. The template provides:
- Frame count configuration (default 3 for triple buffering)
- Current/previous/next frame access with automatic modulo wraparound
- Factory-based initialization for complex resource types
- Iteration and bulk operations on all frames

The TripleBuffering class uses FrameBuffered<FrameSyncPrimitives> to manage Vulkan synchronization primitives (fences and semaphores) with convenient methods for common patterns:
- waitForCurrentFrameIfNeeded() - non-blocking check then wait
- waitForPreviousFrame() - for resource destruction safety
- currentFence/Semaphore accessors

This replaces the scattered sync primitive management in Renderer with a single, well-encapsulated abstraction that can be reused by other systems needing per-frame resource isolation.