### PR TITLE
Refactor triple buffering to use class

### DIFF
--- a/src/vegetation/GrassSystem.h
+++ b/src/vegetation/GrassSystem.h
@@ -15,6 +15,7 @@
 #include "UBOs.h"
 #include "RAIIAdapter.h"
 #include "VulkanRAII.h"
+#include "core/FrameBuffered.h"
 
 // Forward declarations
 class WindSystem;
@@ -219,7 +220,7 @@ private:
     // Tile cache resources for high-res terrain sampling
     VkImageView tileArrayView = VK_NULL_HANDLE;
     VkSampler tileSampler = VK_NULL_HANDLE;
-    std::array<VkBuffer, 3> tileInfoBuffers = {};  // Triple-buffered for frames-in-flight sync
+    TripleBuffered<VkBuffer> tileInfoBuffers_;  // Triple-buffered for frames-in-flight sync
 
     // Renderer uniform buffers for per-frame descriptor updates (stores reference from updateDescriptorSets)
     std::vector<VkBuffer> rendererUniformBuffers_;

--- a/src/vegetation/ImpostorCullSystem.h
+++ b/src/vegetation/ImpostorCullSystem.h
@@ -226,9 +226,8 @@ private:
 
     // Visibility cache buffers for temporal coherence (per-frame to avoid races)
     // Stores 1 bit per tree: 1 = visible as impostor, 0 = not visible
-    static constexpr uint32_t MAX_FRAMES_IN_FLIGHT = 3;
-    std::array<VkBuffer, MAX_FRAMES_IN_FLIGHT> visibilityCacheBuffers_{};
-    std::array<VmaAllocation, MAX_FRAMES_IN_FLIGHT> visibilityCacheAllocations_{};
+    // Using FrameIndexedBuffers for automatic RAII management
+    BufferUtils::FrameIndexedBuffers visibilityCacheBuffers_;
     VkDeviceSize visibilityCacheBufferSize_ = 0;
 
     // State

--- a/src/vegetation/LeafSystem.cpp
+++ b/src/vegetation/LeafSystem.cpp
@@ -422,7 +422,10 @@ void LeafSystem::updateDescriptorSets(VkDevice dev, const std::vector<VkBuffer>&
     this->displacementMapSampler = displacementMapSamplerParam;
 
     // Store tile info buffers (triple-buffered for frames-in-flight sync)
-    this->tileInfoBuffers = tileInfoBuffersParam;
+    tileInfoBuffers_.resize(tileInfoBuffersParam.size());
+    for (size_t i = 0; i < tileInfoBuffersParam.size(); ++i) {
+        tileInfoBuffers_[i] = tileInfoBuffersParam[i];
+    }
 
     // Store renderer uniform buffers (kept for backward compatibility)
     this->rendererUniformBuffers_ = rendererUniformBuffers;
@@ -455,8 +458,8 @@ void LeafSystem::updateDescriptorSets(VkDevice dev, const std::vector<VkBuffer>&
             computeWriter.writeImage(8, tileArrayView, tileSampler);
         }
         // Write initial tile info buffer (frame 0) - will be updated per-frame
-        if (tileInfoBuffers[0] != VK_NULL_HANDLE) {
-            computeWriter.writeBuffer(9, tileInfoBuffers[0], 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        if (!tileInfoBuffers_.empty() && tileInfoBuffers_[0] != VK_NULL_HANDLE) {
+            computeWriter.writeBuffer(9, tileInfoBuffers_[0], 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         }
 
         computeWriter.update();
@@ -553,8 +556,8 @@ void LeafSystem::recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex,
           .writeBuffer(10, paramsBuffers.buffers[frameIndex], 0, sizeof(LeafPhysicsParams));
 
     // Update tile info buffer to the correct frame's buffer (triple-buffered to avoid CPU-GPU sync)
-    if (tileInfoBuffers[frameIndex % 3] != VK_NULL_HANDLE) {
-        writer.writeBuffer(9, tileInfoBuffers[frameIndex % 3], 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    if (!tileInfoBuffers_.empty() && tileInfoBuffers_.at(frameIndex) != VK_NULL_HANDLE) {
+        writer.writeBuffer(9, tileInfoBuffers_.at(frameIndex), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     }
     writer.update();
 

--- a/src/vegetation/LeafSystem.h
+++ b/src/vegetation/LeafSystem.h
@@ -14,6 +14,7 @@
 #include "UBOs.h"
 #include "RAIIAdapter.h"
 #include "interfaces/ILeafControl.h"
+#include "core/FrameBuffered.h"
 #include <optional>
 
 // Leaf particle states
@@ -175,7 +176,7 @@ private:
     VkSampler displacementMapSampler = VK_NULL_HANDLE;
 
     // Tile cache resources for high-res terrain sampling
-    std::array<VkBuffer, 3> tileInfoBuffers = {};  // Triple-buffered for frames-in-flight sync
+    TripleBuffered<VkBuffer> tileInfoBuffers_;  // Triple-buffered for frames-in-flight sync
 
     // Renderer uniform buffers for per-frame descriptor updates
     std::vector<VkBuffer> rendererUniformBuffers_;

--- a/src/water/WaterSystem.h
+++ b/src/water/WaterSystem.h
@@ -14,6 +14,7 @@
 #include "DescriptorManager.h"
 #include "RAIIAdapter.h"
 #include "VulkanRAII.h"
+#include "core/FrameBuffered.h"
 
 class ShadowSystem;
 
@@ -398,7 +399,7 @@ private:
     float tidalRange = 2.0f;      // Max tide height variation in meters
 
     // Tile cache resources for high-res terrain sampling
-    std::array<VkBuffer, 3> tileInfoBuffers_ = {};  // Triple-buffered for frames-in-flight sync
+    TripleBuffered<VkBuffer> tileInfoBuffers_;  // Triple-buffered for frames-in-flight sync
 
     // Push constants - must match shader layout exactly
     struct PushConstants {


### PR DESCRIPTION
…exedBuffers

- TerrainTileCache: Use TripleBuffered<ManagedBuffer> for tile info buffers
- ImpostorCullSystem: Use FrameIndexedBuffers for visibility cache buffers
- WaterSystem, LeafSystem, GrassSystem: Use TripleBuffered<VkBuffer> for tile info buffers

This consolidates the frame-in-flight buffer patterns to use the new TripleBuffered template and BufferUtils utilities, improving code consistency and reducing manual array management.