### PR TITLE
Rename sunDirection to clarify light direction

### DIFF
--- a/docs/TREE_RENDERING_ROADMAP.md
+++ b/docs/TREE_RENDERING_ROADMAP.md
@@ -119,7 +119,7 @@ Trees must integrate with the engine's lighting and atmospheric systems to avoid
 | Volumetric Fog (Froxels) | Local fog volumes | Sample froxel grid for inscatter/transmittance |
 | Cloud Shadows | Soft cloud shadow projection | Sample cloud shadow map if enabled |
 | Atmosphere LUTs | Sky color, transmittance | Use precomputed LUTs for consistent sky lighting |
-| Time of Day | Sun position, color, intensity | Read from `ubo.sunDirection`, `ubo.sunColor` |
+| Time of Day | Sun position, color, intensity | Read from `ubo.toSunDirection`, `ubo.sunColor` |
 
 ### Current Implementation Status
 
@@ -145,7 +145,7 @@ void main() {
     vec3 cameraToFrag = fragWorldPos - ubo.cameraPosition.xyz;
     float viewDist = length(cameraToFrag);
     vec3 viewDir = normalize(cameraToFrag);
-    vec3 sunDir = normalize(-ubo.sunDirection.xyz);
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);  // Already points toward sun
 
     color = applyAerialPerspective(
         color,
@@ -164,7 +164,7 @@ void main() {
 
 When cross-fading between geometry and impostors, lighting must match closely to avoid visible seams:
 
-1. **Same sun direction/color**: Both LODs read from `ubo.sunDirection`, `ubo.sunColor`
+1. **Same sun direction/color**: Both LODs read from `ubo.toSunDirection`, `ubo.sunColor`
 2. **Same shadow sampling**: Both use `calculateCascadedShadow()` with same parameters
 3. **Same aerial perspective**: Both apply `applyAerialPerspective()` at same world position
 4. **Matched ambient**: Both use `ubo.ambientColor` for sky contribution

--- a/shaders/atmosphere_common.glsl
+++ b/shaders/atmosphere_common.glsl
@@ -413,8 +413,8 @@ vec3 applyAerialPerspectiveSimple(vec3 color, vec3 fragWorldPos) {
     vec3 cameraToFrag = fragWorldPos - ubo.cameraPosition.xyz;
     float viewDist = length(cameraToFrag);
     vec3 viewDir = normalize(cameraToFrag);
-    vec3 sunDir = normalize(ubo.sunDirection.xyz);
-    vec3 sunColor = ubo.sunColor.rgb * ubo.sunDirection.w;
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);
+    vec3 sunColor = ubo.sunColor.rgb * ubo.toSunDirection.w;
     return applyAerialPerspective(color, ubo.cameraPosition.xyz, viewDir, viewDist, sunDir, sunColor);
 }
 

--- a/shaders/cloud_shadow.comp
+++ b/shaders/cloud_shadow.comp
@@ -21,7 +21,7 @@ layout(binding = BINDING_CLOUD_SHADOW_CLOUDMAP) uniform sampler2D cloudMapLUT;
 // Uniform buffer
 layout(binding = BINDING_CLOUD_SHADOW_UNIFORMS) uniform CloudShadowUniforms {
     mat4 worldToShadowUV;      // Transform world XZ to shadow map UV
-    vec4 sunDirection;          // xyz = sun direction (toward sun), w = intensity
+    vec4 toSunDirection;          // xyz = direction toward sun, w = intensity
     vec4 windOffset;            // xyz = wind offset for cloud animation, w = time
     vec4 shadowParams;          // x = intensity, y = softness, z = cloud height, w = cloud thickness
     vec4 worldBounds;           // xy = world min XZ, zw = world size XZ
@@ -242,7 +242,7 @@ void main() {
     vec3 worldPos = vec3(worldXZ.x, 0.0, worldXZ.y);  // Ground level
 
     // Get sun direction (toward sun)
-    vec3 sunDir = normalize(sunDirection.xyz);
+    vec3 sunDir = normalize(toSunDirection.xyz);
 
     // Compute cloud shadow at this position
     float shadow = computeCloudShadow(worldPos, sunDir);

--- a/shaders/froxel_integrate.comp
+++ b/shaders/froxel_integrate.comp
@@ -20,7 +20,7 @@ layout(binding = BINDING_FROXEL_UNIFORMS) uniform FroxelUniforms {
     mat4 cascadeViewProj[NUM_CASCADES];  // Light-space matrices for shadow cascades
     vec4 cascadeSplits;                   // View-space split depths
     vec4 cameraPosition;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 sunColor;
     vec4 fogParams;
     vec4 layerParams;

--- a/shaders/froxel_update.comp
+++ b/shaders/froxel_update.comp
@@ -28,7 +28,7 @@ layout(binding = BINDING_FROXEL_UNIFORMS) uniform FroxelUniforms {
     mat4 cascadeViewProj[NUM_CASCADES];  // Light-space matrices for shadow cascades
     vec4 cascadeSplits;                   // View-space split depths
     vec4 cameraPosition;
-    vec4 sunDirection;      // xyz = direction, w = intensity
+    vec4 toSunDirection;      // xyz = direction toward sun, w = intensity
     vec4 sunColor;
     vec4 fogParams;         // x = base height, y = scale height, z = density, w = absorption
     vec4 layerParams;       // x = layer height, y = layer thickness, z = layer density
@@ -303,8 +303,8 @@ void main() {
     vec2 jitter = blueNoise2D(texel.xy, ubo.gridParams.z) * 0.5 - 0.25;
 
     // Sun direction and lighting
-    vec3 sunDir = normalize(ubo.sunDirection.xyz);
-    float sunIntensity = ubo.sunDirection.w;
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);
+    float sunIntensity = ubo.toSunDirection.w;
     vec3 sunLight = ubo.sunColor.rgb * sunIntensity;
 
     // View direction (from camera to froxel)

--- a/shaders/grass.frag
+++ b/shaders/grass.frag
@@ -96,7 +96,7 @@ void main() {
     }
 
     // === SUN LIGHTING ===
-    vec3 sunL = normalize(ubo.sunDirection.xyz);
+    vec3 sunL = normalize(ubo.toSunDirection.xyz);
     float terrainShadow = calculateCascadedShadow(
         fragWorldPos, N, sunL,
         ubo.view, ubo.cascadeSplits, ubo.cascadeViewProj,
@@ -128,7 +128,7 @@ void main() {
     // Subsurface scattering - light through grass blades when backlit
     vec3 sss = calculateSSS(sunL, V, N, ubo.sunColor.rgb, albedo, GRASS_SSS_STRENGTH);
 
-    vec3 sunLight = (albedo * sunDiffuse + specular + sss) * ubo.sunColor.rgb * ubo.sunDirection.w * shadow;
+    vec3 sunLight = (albedo * sunDiffuse + specular + sss) * ubo.sunColor.rgb * ubo.toSunDirection.w * shadow;
 
     // === MOON LIGHTING ===
     vec3 moonL = normalize(ubo.moonDirection.xyz);
@@ -137,7 +137,7 @@ void main() {
 
     // Add subsurface scattering for moonlight - fades in smoothly during twilight
     // Smooth transition: starts at sun altitude 10°, full effect at -6°
-    float twilightFactor = smoothstep(0.17, -0.1, ubo.sunDirection.y);
+    float twilightFactor = smoothstep(0.17, -0.1, ubo.toSunDirection.y);
     float moonVisibility = smoothstep(-0.09, 0.1, ubo.moonDirection.y);
     float moonSssFactor = twilightFactor * moonVisibility;
     vec3 moonSss = calculateSSS(moonL, V, N, ubo.moonColor.rgb, albedo, GRASS_SSS_STRENGTH) * 0.5 * moonSssFactor;
@@ -154,7 +154,7 @@ void main() {
     float NoV = max(dot(N, V), 0.0);
     float rimFresnel = pow(1.0 - NoV, 4.0);
     // Rim color based on sky/ambient
-    vec3 rimColor = ubo.ambientColor.rgb * 0.5 + ubo.sunColor.rgb * ubo.sunDirection.w * 0.2;
+    vec3 rimColor = ubo.ambientColor.rgb * 0.5 + ubo.sunColor.rgb * ubo.toSunDirection.w * 0.2;
     vec3 rimLight = rimColor * rimFresnel * 0.15;
 
     // === AMBIENT LIGHTING ===

--- a/shaders/irradiance_lut.comp
+++ b/shaders/irradiance_lut.comp
@@ -29,7 +29,7 @@ layout(binding = BINDING_IRRADIANCE_TRANSMITTANCE) uniform sampler2D transmittan
 
 layout(binding = BINDING_IRRADIANCE_UNIFORMS) uniform AtmosphereUniforms {
     AtmosphereParams params;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 cameraPosition;
     float padding[2];
 } uAtmosphere;

--- a/shaders/leaf.frag
+++ b/shaders/leaf.frag
@@ -108,8 +108,8 @@ void main() {
     vec3 viewDir = normalize(ubo.cameraPosition.xyz - fragWorldPos);
 
     // Sun lighting
-    vec3 sunDir = normalize(ubo.sunDirection.xyz);
-    float sunIntensity = ubo.sunDirection.w;
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);
+    float sunIntensity = ubo.toSunDirection.w;
 
     // Diffuse (Lambert)
     float NdotL = dot(normal, sunDir);

--- a/shaders/multiscatter_lut.comp
+++ b/shaders/multiscatter_lut.comp
@@ -13,7 +13,7 @@ layout(binding = BINDING_ATMO_TRANSMITTANCE) uniform sampler2D transmittanceLUT;
 
 layout(binding = BINDING_ATMO_MULTISCATTER) uniform AtmosphereUniforms {
     AtmosphereParams params;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 cameraPosition;
     float padding[2];
 } uAtmosphere;

--- a/shaders/shader.frag
+++ b/shaders/shader.frag
@@ -161,7 +161,7 @@ void main() {
     }
 
     // Calculate shadow for sun (terrain + cloud shadows combined)
-    vec3 sunL = normalize(ubo.sunDirection.xyz);
+    vec3 sunL = normalize(ubo.toSunDirection.xyz);
     float terrainShadow = calculateCascadedShadow(
         fragWorldPos, N, sunL,
         ubo.view, ubo.cascadeSplits, ubo.cascadeViewProj,
@@ -179,7 +179,7 @@ void main() {
 
     // Sun lighting with shadow
     // Apply eclipse darkening - moon blocks sunlight during solar eclipse
-    float sunIntensity = ubo.sunDirection.w * (1.0 - ubo.eclipseAmount);
+    float sunIntensity = ubo.toSunDirection.w * (1.0 - ubo.eclipseAmount);
     vec3 sunLight = calculatePBR(N, V, sunL, ubo.sunColor.rgb, sunIntensity, albedo, shadow,
                                   roughness, metallic);
 

--- a/shaders/skyview_lut.comp
+++ b/shaders/skyview_lut.comp
@@ -14,7 +14,7 @@ layout(binding = BINDING_ATMO_MULTISCATTER) uniform sampler2D multiScatterLUT;
 
 layout(binding = BINDING_ATMO_UNIFORMS) uniform AtmosphereUniforms {
     AtmosphereParams params;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 cameraPosition;  // w = camera altitude
     float padding[2];
 } uAtmosphere;
@@ -74,7 +74,7 @@ void main() {
     viewDir = normalize(viewDir);
 
     // Camera position
-    vec3 sunDir = normalize(uAtmosphere.sunDirection.xyz);
+    vec3 sunDir = normalize(uAtmosphere.toSunDirection.xyz);
     float cameraAltitude = uAtmosphere.cameraPosition.w;
     float r = uAtmosphere.params.planetRadius + cameraAltitude;
     vec3 cameraPos = vec3(0.0, r, 0.0);

--- a/shaders/terrain/terrain.frag
+++ b/shaders/terrain/terrain.frag
@@ -127,7 +127,7 @@ layout(location = 0) out vec4 outColor;
 
 // Shadow sampling - use common shadow functions
 float getShadowFactor(vec3 worldPos) {
-    vec3 sunL = normalize(ubo.sunDirection.xyz);
+    vec3 sunL = normalize(ubo.toSunDirection.xyz);
     return calculateCascadedShadow(
         worldPos,
         normalize(fragNormal),
@@ -326,7 +326,7 @@ void main() {
     vec3 V = normalize(ubo.cameraPosition.xyz - fragWorldPos);
 
     // Calculate sun contribution
-    vec3 L = normalize(ubo.sunDirection.xyz);
+    vec3 L = normalize(ubo.toSunDirection.xyz);
     vec3 H = normalize(V + L);
 
     // PBR calculations using common functions
@@ -346,7 +346,7 @@ void main() {
     float denominator = 4.0 * max(dot(normal, V), 0.0) * NdotL + 0.0001;
     vec3 specular = numerator / denominator;
 
-    vec3 radiance = ubo.sunColor.rgb * ubo.sunDirection.w;
+    vec3 radiance = ubo.sunColor.rgb * ubo.toSunDirection.w;
     vec3 sunLight = (kD * albedo / PI + specular) * radiance * NdotL;
 
     // Shadow (terrain + cloud shadows combined)

--- a/shaders/transmittance_lut.comp
+++ b/shaders/transmittance_lut.comp
@@ -12,7 +12,7 @@ layout(binding = BINDING_ATMO_OUTPUT_LUT, rgba16f) writeonly uniform image2D tra
 
 layout(binding = BINDING_ATMO_TRANSMITTANCE) uniform AtmosphereUniforms {
     AtmosphereParams params;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 cameraPosition;
     float padding[2];
 } uAtmosphere;

--- a/shaders/tree.frag
+++ b/shaders/tree.frag
@@ -60,7 +60,7 @@ void main() {
 
     // View and light directions
     vec3 V = normalize(ubo.cameraPosition.xyz - fragWorldPos);
-    vec3 L = normalize(ubo.sunDirection.xyz);  // sunDirection points toward sun
+    vec3 L = normalize(ubo.toSunDirection.xyz);  // sunDirection points toward sun
 
     // Calculate shadow
     float shadow = calculateCascadedShadow(
@@ -77,7 +77,7 @@ void main() {
         softAO,
         shadow,
         ubo.sunColor.rgb,
-        ubo.sunDirection.w,
+        ubo.toSunDirection.w,
         ubo.ambientColor.rgb
     );
 

--- a/shaders/tree_impostor.frag
+++ b/shaders/tree_impostor.frag
@@ -192,7 +192,7 @@ void main() {
 
     // Calculate lighting directions
     vec3 V = normalize(ubo.cameraPosition.xyz - fragWorldPos);
-    vec3 L = normalize(ubo.sunDirection.xyz);  // sunDirection points toward sun
+    vec3 L = normalize(ubo.toSunDirection.xyz);  // sunDirection points toward sun
 
     // Shadow sampling
     float shadow = calculateCascadedShadow(
@@ -208,7 +208,7 @@ void main() {
         ao,
         shadow,
         ubo.sunColor.rgb,
-        ubo.sunDirection.w,
+        ubo.toSunDirection.w,
         ubo.ambientColor.rgb
     );
 

--- a/shaders/tree_impostor_shadow.vert
+++ b/shaders/tree_impostor_shadow.vert
@@ -40,7 +40,7 @@ void main() {
 
     // For shadows, orient billboard to face the sun (not the camera)
     // This gives a full shadow profile instead of a thin edge shadow
-    vec3 sunDir = normalize(ubo.sunDirection.xyz);  // Points toward sun
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);  // Points toward sun
 
     // Apply tree rotation to view direction (rotate view around Y axis)
     float cosRot = cos(-rotation);

--- a/shaders/tree_leaf.frag
+++ b/shaders/tree_leaf.frag
@@ -61,7 +61,7 @@ void main() {
 
     // View and light directions
     vec3 V = normalize(ubo.cameraPosition.xyz - fragWorldPos);
-    vec3 L = normalize(ubo.sunDirection.xyz);  // sunDirection points toward sun
+    vec3 L = normalize(ubo.toSunDirection.xyz);  // sunDirection points toward sun
 
     // Calculate shadow
     float shadow = calculateCascadedShadow(
@@ -76,7 +76,7 @@ void main() {
         baseColor,
         shadow,
         ubo.sunColor.rgb,
-        ubo.sunDirection.w,
+        ubo.toSunDirection.w,
         ubo.ambientColor.rgb
     );
 

--- a/shaders/ubo_common.glsl
+++ b/shaders/ubo_common.glsl
@@ -20,10 +20,8 @@ layout(set = 0, binding = UBO_BINDING) uniform UniformBufferObject {
     mat4 proj;
     mat4 cascadeViewProj[NUM_CASCADES];  // Per-cascade light matrices
     vec4 cascadeSplits;                   // View-space split depths
-    // Light direction convention: xyz points TOWARD the light source
-    // For lighting calculations, use L = normalize(sunDirection.xyz) directly
-    // The w component stores intensity (0-1)
-    vec4 sunDirection;
+    // Light direction: xyz points TOWARD the sun, w = intensity (0-1)
+    vec4 toSunDirection;
     vec4 moonDirection;
     vec4 sunColor;
     vec4 moonColor;                       // rgb = moon color, a = moon phase (0-1)

--- a/shaders/water.frag
+++ b/shaders/water.frag
@@ -354,7 +354,7 @@ BlendedMaterial getBlendedMaterial(vec3 worldPos) {
 void main() {
     vec3 N = normalize(fragNormal);
     vec3 V = normalize(ubo.cameraPosition.xyz - fragWorldPos);
-    vec3 sunDir = normalize(ubo.sunDirection.xyz);
+    vec3 sunDir = normalize(ubo.toSunDirection.xyz);
     vec3 moonDir = normalize(ubo.moonDirection.xyz);
     float time = ubo.windDirectionAndSpeed.w;
 
@@ -498,7 +498,7 @@ void main() {
     baseColor = mix(baseColor, depthTint * waterTransmission, 0.5);
 
     // Sun color used for SSS and specular - calculate once
-    vec3 sunColor = ubo.sunColor.rgb * ubo.sunDirection.w;
+    vec3 sunColor = ubo.sunColor.rgb * ubo.toSunDirection.w;
 
     // =========================================================================
     // PHASE 17: Enhanced Subsurface Scattering (Sea of Thieves inspired)

--- a/shaders/water_position.frag
+++ b/shaders/water_position.frag
@@ -22,7 +22,7 @@ layout(binding = BINDING_UBO) uniform UniformBufferObject {
     mat4 proj;
     mat4 cascadeViewProj[NUM_CASCADES];
     vec4 cascadeSplits;
-    vec4 sunDirection;
+    vec4 toSunDirection;
     vec4 moonDirection;
     vec4 sunColor;
     vec4 moonColor;

--- a/shaders/weather.frag
+++ b/shaders/weather.frag
@@ -92,8 +92,8 @@ void main() {
         vec3 baseColor = vec3(0.7, 0.8, 1.0);
 
         // Add highlight from sun/moon
-        vec3 sunDir = normalize(ubo.sunDirection.xyz);
-        float sunIntensity = ubo.sunDirection.w;
+        vec3 sunDir = normalize(ubo.toSunDirection.xyz);
+        float sunIntensity = ubo.toSunDirection.w;
 
         // Backlit effect when rain is between camera and light
         vec3 viewDir = normalize(ubo.cameraPosition.xyz - fragWorldPos);
@@ -134,7 +134,7 @@ void main() {
         color = baseColor * (ubo.ambientColor.rgb * 0.8 + vec3(0.2));
 
         // Sun contribution
-        float sunIntensity = ubo.sunDirection.w;
+        float sunIntensity = ubo.toSunDirection.w;
         color += baseColor * ubo.sunColor.rgb * sunIntensity * 0.3;
 
         // Moon contribution at night

--- a/src/atmosphere/AtmosphereLUTCompute.cpp
+++ b/src/atmosphere/AtmosphereLUTCompute.cpp
@@ -78,7 +78,7 @@ void AtmosphereLUTSystem::computeSkyViewLUT(VkCommandBuffer cmd, const glm::vec3
     // Update uniform buffer (use frame 0's per-frame buffer for startup computation)
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    uniforms.sunDirection = glm::vec4(sunDir, 0.0f);
+    uniforms.toSunDirection = glm::vec4(sunDir, 0.0f);
     uniforms.cameraPosition = glm::vec4(cameraPos, cameraAltitude);
     memcpy(skyViewUniformBuffers.mappedPointers[0], &uniforms, sizeof(AtmosphereUniforms));
 
@@ -122,7 +122,7 @@ void AtmosphereLUTSystem::updateSkyViewLUT(VkCommandBuffer cmd, uint32_t frameIn
     // Update per-frame uniform buffer with new sun direction (double-buffered)
     AtmosphereUniforms uniforms{};
     uniforms.params = atmosphereParams;
-    uniforms.sunDirection = glm::vec4(sunDir, 0.0f);
+    uniforms.toSunDirection = glm::vec4(sunDir, 0.0f);
     uniforms.cameraPosition = glm::vec4(cameraPos, cameraAltitude);
     memcpy(skyViewUniformBuffers.mappedPointers[frameIndex], &uniforms, sizeof(AtmosphereUniforms));
 

--- a/src/atmosphere/AtmosphereLUTSystem.h
+++ b/src/atmosphere/AtmosphereLUTSystem.h
@@ -48,7 +48,7 @@ struct AtmosphereParams {
 // AtmosphereUniforms struct (manually defined since it contains nested AtmosphereParams)
 struct AtmosphereUniforms {
     AtmosphereParams params;
-    glm::vec4 sunDirection;  // xyz = sun dir, w = unused
+    glm::vec4 toSunDirection;  // xyz = direction toward sun, w = unused
     glm::vec4 cameraPosition; // xyz = camera pos, w = camera altitude
     float padding[2];
 };

--- a/src/atmosphere/CloudShadowSystem.cpp
+++ b/src/atmosphere/CloudShadowSystem.cpp
@@ -274,7 +274,7 @@ void CloudShadowSystem::recordUpdate(VkCommandBuffer cmd, uint32_t frameIndex,
     // Update uniform buffer
     CloudShadowUniforms uniforms{};
     uniforms.worldToShadowUV = worldToShadowUV;
-    uniforms.sunDirection = glm::vec4(sunDir, sunIntensity);
+    uniforms.toSunDirection = glm::vec4(sunDir, sunIntensity);
     uniforms.windOffset = glm::vec4(windOffset, windTime);
     uniforms.shadowParams = glm::vec4(shadowIntensity, shadowSoftness,
                                        CLOUD_LAYER_BOTTOM, CLOUD_LAYER_TOP - CLOUD_LAYER_BOTTOM);

--- a/src/atmosphere/CloudShadowSystem.h
+++ b/src/atmosphere/CloudShadowSystem.h
@@ -20,7 +20,7 @@
 // Uniforms for cloud shadow compute shader (must match GLSL layout)
 struct CloudShadowUniforms {
     glm::mat4 worldToShadowUV;   // Transform world XZ to shadow map UV
-    glm::vec4 sunDirection;      // xyz = sun direction, w = intensity
+    glm::vec4 toSunDirection;      // xyz = direction toward sun, w = intensity
     glm::vec4 windOffset;        // xyz = wind offset for cloud animation, w = time
     glm::vec4 shadowParams;      // x = shadow intensity, y = softness, z = cloud height, w = cloud thickness
     glm::vec4 worldBounds;       // xy = world min XZ, zw = world size XZ

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -1176,8 +1176,8 @@ FrameData Renderer::buildFrameData(const Camera& camera, float deltaTime, float 
 
     // Get sun direction from last computed UBO (already computed in updateUniformBuffer)
     UniformBufferObject* ubo = static_cast<UniformBufferObject*>(systems_->globalBuffers().uniformBuffers.mappedPointers[frameSync_.currentIndex()]);
-    frame.sunDirection = glm::normalize(glm::vec3(ubo->sunDirection));
-    frame.sunIntensity = ubo->sunDirection.w;
+    frame.sunDirection = glm::normalize(glm::vec3(ubo->toSunDirection));
+    frame.sunIntensity = ubo->toSunDirection.w;
 
     frame.playerPosition = playerPosition;
     frame.playerVelocity = playerVelocity;

--- a/src/core/UBOBuilder.cpp
+++ b/src/core/UBOBuilder.cpp
@@ -100,7 +100,7 @@ UniformBufferObject UBOBuilder::buildUniformBufferData(
         cascadeSplitDepths[4]
     );
 
-    ubo.sunDirection = glm::vec4(lighting.sunDir, lighting.sunIntensity);
+    ubo.toSunDirection = glm::vec4(lighting.sunDir, lighting.sunIntensity);
     ubo.moonDirection = glm::vec4(lighting.moonDir, lighting.moonIntensity);
     ubo.sunColor = glm::vec4(lighting.sunColor, 1.0f);
     ubo.moonColor = glm::vec4(lighting.moonColor, lighting.moonPhase);  // Pass moon phase in alpha channel

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -360,7 +360,7 @@ void FroxelSystem::recordFroxelUpdate(VkCommandBuffer cmd, uint32_t frameIndex,
     ubo->cascadeSplits = cascadeSplits;
 
     ubo->cameraPosition = glm::vec4(cameraPos, 1.0f);
-    ubo->sunDirection = glm::vec4(sunDir, sunIntensity);
+    ubo->toSunDirection = glm::vec4(sunDir, sunIntensity);
     ubo->sunColor = glm::vec4(sunColor, 1.0f);
     ubo->fogParams = glm::vec4(fogBaseHeight, fogScaleHeight, fogDensity, fogAbsorption);
     ubo->layerParams = glm::vec4(layerHeight, layerThickness, layerDensity, 0.0f);


### PR DESCRIPTION
The previous name sunDirection was ambiguous - it wasn't clear whether it pointed FROM the sun (light direction) or TO the sun. The new name toSunDirection makes it explicit that this vector points toward the sun, which is the correct convention for PBR lighting calculations.

Changes:
- Renamed in shared UBO (ubo_common.glsl) and all shaders using it
- Renamed in local UBOs for atmosphere, cloud shadow, and froxel systems
- Updated C++ structs and usages to match
- Fixed documentation example that incorrectly negated the direction