### PR TITLE
Add tile loader debug window with LOD colors

### DIFF
--- a/src/gui/GuiSystem.h
+++ b/src/gui/GuiSystem.h
@@ -75,6 +75,7 @@ private:
     void renderDebugWindow(GuiInterfaces& ui);
     void renderPerformanceWindow(GuiInterfaces& ui);
     void renderProfilerWindow(GuiInterfaces& ui);
+    void renderTileLoaderWindow(GuiInterfaces& ui, const Camera& camera);
 
     VkDevice device_ = VK_NULL_HANDLE;  // Stored for cleanup
     VkDescriptorPool imguiPool = VK_NULL_HANDLE;
@@ -110,5 +111,6 @@ private:
         bool showDebug = false;
         bool showPerformance = false;
         bool showProfiler = false;
+        bool showTileLoader = false;
     } windowStates;
 };


### PR DESCRIPTION
Adds a new debug window accessible via Debug menu that visualizes the TerrainTileCache tile loading state on a 32x32 grid with 16x16px cells. Features include:
- Color-coded LOD levels (green=LOD0, blue=LOD1, yellow=LOD2, purple=LOD3)
- Camera/player position marker (red circle)
- Active tile count and statistics display
- Legend showing LOD distance thresholds