### PR TITLE
Check terrain placeholder image mip-mapping

### DIFF
--- a/src/terrain/TerrainTextures.cpp
+++ b/src/terrain/TerrainTextures.cpp
@@ -5,6 +5,8 @@
 #include <vulkan/vulkan.hpp>
 #include <stb_image.h>
 #include <cstring>
+#include <cmath>
+#include <algorithm>
 
 bool TerrainTextures::init(const InitInfo& info) {
     device = info.device;
@@ -50,16 +52,19 @@ bool TerrainTextures::createAlbedoTexture() {
     uint32_t width = static_cast<uint32_t>(texWidth);
     uint32_t height = static_cast<uint32_t>(texHeight);
 
-    // Create Vulkan image
+    // Calculate mip levels
+    albedoMipLevels = static_cast<uint32_t>(std::floor(std::log2(std::max(width, height)))) + 1;
+
+    // Create Vulkan image with mip levels
     auto imageInfo = vk::ImageCreateInfo{}
         .setImageType(vk::ImageType::e2D)
         .setFormat(vk::Format::eR8G8B8A8Srgb)
         .setExtent(vk::Extent3D{width, height, 1})
-        .setMipLevels(1)
+        .setMipLevels(albedoMipLevels)
         .setArrayLayers(1)
         .setSamples(vk::SampleCountFlagBits::e1)
         .setTiling(vk::ImageTiling::eOptimal)
-        .setUsage(vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eTransferDst)
+        .setUsage(vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc)
         .setSharingMode(vk::SharingMode::eExclusive)
         .setInitialLayout(vk::ImageLayout::eUndefined);
 
@@ -72,7 +77,7 @@ bool TerrainTextures::createAlbedoTexture() {
         return false;
     }
 
-    // Create image view
+    // Create image view with all mip levels
     auto viewInfo = vk::ImageViewCreateInfo{}
         .setImage(albedoImage)
         .setViewType(vk::ImageViewType::e2D)
@@ -80,7 +85,7 @@ bool TerrainTextures::createAlbedoTexture() {
         .setSubresourceRange(vk::ImageSubresourceRange{}
             .setAspectMask(vk::ImageAspectFlagBits::eColor)
             .setBaseMipLevel(0)
-            .setLevelCount(1)
+            .setLevelCount(albedoMipLevels)
             .setBaseArrayLayer(0)
             .setLayerCount(1));
 
@@ -97,15 +102,22 @@ bool TerrainTextures::createAlbedoTexture() {
         return false;
     }
 
-    // Upload texture to GPU
-    if (!uploadImageData(albedoImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4)) {
+    // Upload base level texture to GPU
+    if (!uploadImageDataMipLevel(albedoImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4, 0)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to upload terrain albedo texture to GPU");
         stbi_image_free(pixels);
         return false;
     }
 
     stbi_image_free(pixels);
-    SDL_Log("Terrain albedo texture loaded: %s (%ux%u)", texturePath.c_str(), width, height);
+
+    // Generate mipmaps on GPU
+    if (!generateMipmaps(albedoImage, width, height, albedoMipLevels)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to generate mipmaps for terrain albedo texture");
+        return false;
+    }
+
+    SDL_Log("Terrain albedo texture loaded: %s (%ux%u, %u mip levels)", texturePath.c_str(), width, height, albedoMipLevels);
     return true;
 }
 
@@ -124,16 +136,19 @@ bool TerrainTextures::createGrassFarLODTexture() {
     uint32_t width = static_cast<uint32_t>(texWidth);
     uint32_t height = static_cast<uint32_t>(texHeight);
 
-    // Create Vulkan image
+    // Calculate mip levels
+    grassFarLODMipLevels = static_cast<uint32_t>(std::floor(std::log2(std::max(width, height)))) + 1;
+
+    // Create Vulkan image with mip levels
     auto imageInfo = vk::ImageCreateInfo{}
         .setImageType(vk::ImageType::e2D)
         .setFormat(vk::Format::eR8G8B8A8Srgb)
         .setExtent(vk::Extent3D{width, height, 1})
-        .setMipLevels(1)
+        .setMipLevels(grassFarLODMipLevels)
         .setArrayLayers(1)
         .setSamples(vk::SampleCountFlagBits::e1)
         .setTiling(vk::ImageTiling::eOptimal)
-        .setUsage(vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eTransferDst)
+        .setUsage(vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc)
         .setSharingMode(vk::SharingMode::eExclusive)
         .setInitialLayout(vk::ImageLayout::eUndefined);
 
@@ -146,7 +161,7 @@ bool TerrainTextures::createGrassFarLODTexture() {
         return false;
     }
 
-    // Create image view
+    // Create image view with all mip levels
     auto viewInfo = vk::ImageViewCreateInfo{}
         .setImage(grassFarLODImage)
         .setViewType(vk::ImageViewType::e2D)
@@ -154,7 +169,7 @@ bool TerrainTextures::createGrassFarLODTexture() {
         .setSubresourceRange(vk::ImageSubresourceRange{}
             .setAspectMask(vk::ImageAspectFlagBits::eColor)
             .setBaseMipLevel(0)
-            .setLevelCount(1)
+            .setLevelCount(grassFarLODMipLevels)
             .setBaseArrayLayer(0)
             .setLayerCount(1));
 
@@ -171,20 +186,27 @@ bool TerrainTextures::createGrassFarLODTexture() {
         return false;
     }
 
-    // Upload texture to GPU
-    if (!uploadImageData(grassFarLODImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4)) {
+    // Upload base level texture to GPU
+    if (!uploadImageDataMipLevel(grassFarLODImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4, 0)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to upload grass far LOD texture to GPU");
         stbi_image_free(pixels);
         return false;
     }
 
     stbi_image_free(pixels);
-    SDL_Log("Grass far LOD texture loaded: %s (%ux%u)", texturePath.c_str(), width, height);
+
+    // Generate mipmaps on GPU
+    if (!generateMipmaps(grassFarLODImage, width, height, grassFarLODMipLevels)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to generate mipmaps for grass far LOD texture");
+        return false;
+    }
+
+    SDL_Log("Grass far LOD texture loaded: %s (%ux%u, %u mip levels)", texturePath.c_str(), width, height, grassFarLODMipLevels);
     return true;
 }
 
-bool TerrainTextures::uploadImageData(VkImage image, const void* data, uint32_t width, uint32_t height,
-                                       VkFormat format, uint32_t bytesPerPixel) {
+bool TerrainTextures::uploadImageDataMipLevel(VkImage image, const void* data, uint32_t width, uint32_t height,
+                                               VkFormat format, uint32_t bytesPerPixel, uint32_t mipLevel) {
     VkDeviceSize imageSize = width * height * bytesPerPixel;
 
     // Create staging buffer using RAII wrapper
@@ -203,11 +225,167 @@ bool TerrainTextures::uploadImageData(VkImage image, const void* data, uint32_t 
     CommandScope cmd(device, commandPool, graphicsQueue);
     if (!cmd.begin()) return false;
 
-    // Copy staging buffer to image with automatic barrier transitions
-    Barriers::copyBufferToImage(cmd.get(), stagingBuffer.get(), image, width, height);
+    vk::CommandBuffer vkCmd(cmd.get());
+
+    // Transition base mip level to transfer dst
+    auto barrier = vk::ImageMemoryBarrier{}
+        .setImage(image)
+        .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+        .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+        .setSubresourceRange(vk::ImageSubresourceRange{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setBaseMipLevel(mipLevel)
+            .setLevelCount(1)
+            .setBaseArrayLayer(0)
+            .setLayerCount(1))
+        .setOldLayout(vk::ImageLayout::eUndefined)
+        .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setSrcAccessMask(vk::AccessFlags{})
+        .setDstAccessMask(vk::AccessFlagBits::eTransferWrite);
+
+    vkCmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eTopOfPipe,
+        vk::PipelineStageFlagBits::eTransfer,
+        vk::DependencyFlags{},
+        nullptr, nullptr, barrier);
+
+    // Copy buffer to image
+    auto region = vk::BufferImageCopy{}
+        .setBufferOffset(0)
+        .setBufferRowLength(0)
+        .setBufferImageHeight(0)
+        .setImageSubresource(vk::ImageSubresourceLayers{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setMipLevel(mipLevel)
+            .setBaseArrayLayer(0)
+            .setLayerCount(1))
+        .setImageOffset({0, 0, 0})
+        .setImageExtent({width, height, 1});
+
+    vkCmd.copyBufferToImage(stagingBuffer.get(), image, vk::ImageLayout::eTransferDstOptimal, region);
 
     if (!cmd.end()) return false;
 
     // ManagedBuffer automatically destroyed on scope exit
     return true;
+}
+
+bool TerrainTextures::generateMipmaps(VkImage image, uint32_t width, uint32_t height, uint32_t mipLevels) {
+    CommandScope cmd(device, commandPool, graphicsQueue);
+    if (!cmd.begin()) return false;
+
+    vk::CommandBuffer vkCmd(cmd.get());
+
+    int32_t mipWidth = static_cast<int32_t>(width);
+    int32_t mipHeight = static_cast<int32_t>(height);
+
+    for (uint32_t i = 1; i < mipLevels; ++i) {
+        // Transition previous mip level from transfer dst to transfer src
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setImage(image)
+            .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setSubresourceRange(vk::ImageSubresourceRange{}
+                .setAspectMask(vk::ImageAspectFlagBits::eColor)
+                .setBaseMipLevel(i - 1)
+                .setLevelCount(1)
+                .setBaseArrayLayer(0)
+                .setLayerCount(1))
+            .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
+            .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+            .setDstAccessMask(vk::AccessFlagBits::eTransferRead);
+
+        vkCmd.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::DependencyFlags{},
+            nullptr, nullptr, barrier);
+
+        // Transition current mip level to transfer dst
+        barrier.setSubresourceRange(vk::ImageSubresourceRange{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setBaseMipLevel(i)
+            .setLevelCount(1)
+            .setBaseArrayLayer(0)
+            .setLayerCount(1))
+            .setOldLayout(vk::ImageLayout::eUndefined)
+            .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setSrcAccessMask(vk::AccessFlags{})
+            .setDstAccessMask(vk::AccessFlagBits::eTransferWrite);
+
+        vkCmd.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::DependencyFlags{},
+            nullptr, nullptr, barrier);
+
+        // Blit from previous mip level to current
+        int32_t nextMipWidth = mipWidth > 1 ? mipWidth / 2 : 1;
+        int32_t nextMipHeight = mipHeight > 1 ? mipHeight / 2 : 1;
+
+        auto blit = vk::ImageBlit{}
+            .setSrcSubresource(vk::ImageSubresourceLayers{}
+                .setAspectMask(vk::ImageAspectFlagBits::eColor)
+                .setMipLevel(i - 1)
+                .setBaseArrayLayer(0)
+                .setLayerCount(1))
+            .setSrcOffsets({vk::Offset3D{0, 0, 0}, vk::Offset3D{mipWidth, mipHeight, 1}})
+            .setDstSubresource(vk::ImageSubresourceLayers{}
+                .setAspectMask(vk::ImageAspectFlagBits::eColor)
+                .setMipLevel(i)
+                .setBaseArrayLayer(0)
+                .setLayerCount(1))
+            .setDstOffsets({vk::Offset3D{0, 0, 0}, vk::Offset3D{nextMipWidth, nextMipHeight, 1}});
+
+        vkCmd.blitImage(
+            image, vk::ImageLayout::eTransferSrcOptimal,
+            image, vk::ImageLayout::eTransferDstOptimal,
+            blit, vk::Filter::eLinear);
+
+        // Transition previous mip level to shader read
+        barrier.setSubresourceRange(vk::ImageSubresourceRange{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setBaseMipLevel(i - 1)
+            .setLevelCount(1)
+            .setBaseArrayLayer(0)
+            .setLayerCount(1))
+            .setOldLayout(vk::ImageLayout::eTransferSrcOptimal)
+            .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+            .setSrcAccessMask(vk::AccessFlagBits::eTransferRead)
+            .setDstAccessMask(vk::AccessFlagBits::eShaderRead);
+
+        vkCmd.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eFragmentShader,
+            vk::DependencyFlags{},
+            nullptr, nullptr, barrier);
+
+        mipWidth = nextMipWidth;
+        mipHeight = nextMipHeight;
+    }
+
+    // Transition last mip level to shader read
+    auto finalBarrier = vk::ImageMemoryBarrier{}
+        .setImage(image)
+        .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+        .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+        .setSubresourceRange(vk::ImageSubresourceRange{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setBaseMipLevel(mipLevels - 1)
+            .setLevelCount(1)
+            .setBaseArrayLayer(0)
+            .setLayerCount(1))
+        .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+        .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eShaderRead);
+
+    vkCmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eTransfer,
+        vk::PipelineStageFlagBits::eFragmentShader,
+        vk::DependencyFlags{},
+        nullptr, nullptr, finalBarrier);
+
+    return cmd.end();
 }

--- a/src/terrain/TerrainTextures.h
+++ b/src/terrain/TerrainTextures.h
@@ -33,8 +33,9 @@ public:
 private:
     bool createAlbedoTexture();
     bool createGrassFarLODTexture();
-    bool uploadImageData(VkImage image, const void* data, uint32_t width, uint32_t height,
-                         VkFormat format, uint32_t bytesPerPixel);
+    bool uploadImageDataMipLevel(VkImage image, const void* data, uint32_t width, uint32_t height,
+                                  VkFormat format, uint32_t bytesPerPixel, uint32_t mipLevel);
+    bool generateMipmaps(VkImage image, uint32_t width, uint32_t height, uint32_t mipLevels);
 
     // Init params
     VkDevice device = VK_NULL_HANDLE;
@@ -48,10 +49,12 @@ private:
     VmaAllocation albedoAllocation = VK_NULL_HANDLE;
     VkImageView albedoView = VK_NULL_HANDLE;
     ManagedSampler albedoSampler;
+    uint32_t albedoMipLevels = 1;
 
     // Grass far LOD texture
     VkImage grassFarLODImage = VK_NULL_HANDLE;
     VmaAllocation grassFarLODAllocation = VK_NULL_HANDLE;
     VkImageView grassFarLODView = VK_NULL_HANDLE;
     ManagedSampler grassFarLODSampler;
+    uint32_t grassFarLODMipLevels = 1;
 };


### PR DESCRIPTION
Generate mipmaps on the GPU using vkCmdBlitImage for both the albedo and grass far LOD terrain textures. This enables proper trilinear filtering and reduces texture aliasing when viewing the terrain from a distance.

Changes:
- Calculate mip levels based on texture dimensions (log2(max(width,height))+1)
- Add eTransferSrc usage flag for mipmap blit operations
- Create image views with all mip levels
- Add GPU-based mipmap generation using image blits
- Proper barrier transitions through the mip chain