### PR TITLE
Fix dark halo shader effect underwater

### DIFF
--- a/shaders/froxel_integrate.comp
+++ b/shaders/froxel_integrate.comp
@@ -23,9 +23,10 @@ layout(binding = BINDING_FROXEL_UNIFORMS) uniform FroxelUniforms {
     vec4 toSunDirection;
     vec4 sunColor;
     vec4 fogParams;
-    vec4 layerParams;
+    vec4 layerParams;       // x = layer height, y = layer thickness, z = layer density, w = water level
     vec4 gridParams;        // x = volumetric far, y = depth distribution
     vec4 shadowParams;
+    vec4 underwaterParams;  // x = underwater density, y = absorption scale, z = water color multiplier, w = enabled
 } ubo;
 
 // Froxel grid constants

--- a/shaders/froxel_update.comp
+++ b/shaders/froxel_update.comp
@@ -31,9 +31,10 @@ layout(binding = BINDING_FROXEL_UNIFORMS) uniform FroxelUniforms {
     vec4 toSunDirection;      // xyz = direction toward sun, w = intensity
     vec4 sunColor;
     vec4 fogParams;         // x = base height, y = scale height, z = density, w = absorption
-    vec4 layerParams;       // x = layer height, y = layer thickness, z = layer density
+    vec4 layerParams;       // x = layer height, y = layer thickness, z = layer density, w = water level
     vec4 gridParams;        // x = volumetric far, y = depth distribution, z = frame index, w = temporal blend
     vec4 shadowParams;      // x = shadow map size, y = shadow bias, z = pcf radius
+    vec4 underwaterParams;  // x = underwater density, y = absorption scale, z = water color multiplier, w = enabled
 } ubo;
 
 // Temporal reprojection blend factor
@@ -76,10 +77,45 @@ float sigmoidalLayerDensity(float height) {
     return layerDensity / (1.0 + exp(t * 2.0));
 }
 
+// Underwater fog density (when below water surface)
+float underwaterDensity(vec3 worldPos) {
+    float waterLevel = ubo.layerParams.w;
+
+    // Only apply underwater fog if enabled and below water level
+    if (ubo.underwaterParams.w < 0.5 || worldPos.y >= waterLevel) {
+        return 0.0;
+    }
+
+    // Depth below water surface
+    float depth = waterLevel - worldPos.y;
+
+    // Underwater fog density increases with depth (exponential falloff)
+    // Uses underwaterParams.x as base density, .y as absorption scale
+    float baseDensity = ubo.underwaterParams.x;
+    float absorptionScale = ubo.underwaterParams.y;
+
+    // Exponential density increase with depth (denser fog deeper underwater)
+    return baseDensity * (1.0 + depth * absorptionScale * 0.1);
+}
+
 // Combined fog density at height
 float getHazeDensity(vec3 worldPos) {
     float height = worldPos.y;
-    return exponentialHeightDensity(height) + sigmoidalLayerDensity(height);
+
+    // Atmospheric fog (above water)
+    float atmoDensity = exponentialHeightDensity(height) + sigmoidalLayerDensity(height);
+
+    // Underwater fog (below water surface)
+    float waterDensity = underwaterDensity(worldPos);
+
+    // Combine: if underwater, use water fog; otherwise use atmospheric fog
+    // Water fog dominates when below water level
+    float waterLevel = ubo.layerParams.w;
+    if (ubo.underwaterParams.w > 0.5 && worldPos.y < waterLevel) {
+        return waterDensity;
+    }
+
+    return atmoDensity;
 }
 
 // henyeyGreensteinPhase is defined in dynamic_lights_common.glsl
@@ -327,6 +363,10 @@ void main() {
     // Combine sun visibility with shadow
     float totalShadow = sunVisibility * shadow;
 
+    // Check if this froxel is underwater
+    float waterLevel = ubo.layerParams.w;
+    bool isUnderwater = (ubo.underwaterParams.w > 0.5) && (worldPos.y < waterLevel);
+
     // In-scattering from sun (attenuated by shadow)
     vec3 sunInScatter = sunLight * phase * totalShadow * density;
 
@@ -340,6 +380,25 @@ void main() {
 
     // Total in-scattering
     vec3 totalInScatter = sunInScatter + skyInScatter + localLightScatter;
+
+    // Apply underwater tinting if below water level
+    if (isUnderwater) {
+        // Water absorbs red/green light, leaving blue-green
+        // Use underwaterParams.z as the color multiplier
+        float colorMult = ubo.underwaterParams.z;
+        vec3 waterTint = vec3(0.1, 0.4, 0.5);  // Blue-green underwater tint
+
+        // Depth below water surface affects color absorption
+        float depth = waterLevel - worldPos.y;
+        float depthFactor = 1.0 - exp(-depth * 0.05);  // Exponential absorption
+
+        // Tint the scattered light toward water color
+        totalInScatter = mix(totalInScatter, totalInScatter * waterTint * colorMult, depthFactor);
+
+        // Add ambient water glow (scattered light from above)
+        vec3 ambientWater = waterTint * 0.02 * (1.0 - depthFactor * 0.5);
+        totalInScatter += ambientWater * density;
+    }
 
     // =========================================================================
     // Temporal Reprojection

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -869,6 +869,10 @@ bool Renderer::render(const Camera& camera) {
             underwaterParams.waterColor,
             underwaterParams.waterLevel
         );
+
+        // Update froxel system with underwater state for volumetric underwater fog
+        systems_->froxel().setWaterLevel(underwaterParams.waterLevel);
+        systems_->froxel().setUnderwaterEnabled(underwaterParams.isUnderwater);
         systems_->profiler().endCpuZone("SystemUpdates:Water");
     }
 

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -363,13 +363,20 @@ void FroxelSystem::recordFroxelUpdate(VkCommandBuffer cmd, uint32_t frameIndex,
     ubo->toSunDirection = glm::vec4(sunDir, sunIntensity);
     ubo->sunColor = glm::vec4(sunColor, 1.0f);
     ubo->fogParams = glm::vec4(fogBaseHeight, fogScaleHeight, fogDensity, fogAbsorption);
-    ubo->layerParams = glm::vec4(layerHeight, layerThickness, layerDensity, 0.0f);
+    ubo->layerParams = glm::vec4(layerHeight, layerThickness, layerDensity, waterLevel);
     // Disable temporal blending on the first frame to avoid sampling uninitialized history volume
     // frameCounter is 0 on first call, so first frame temporal blend should be 0
     float effectiveTemporalBlend = (frameCounter == 0) ? 0.0f : temporalBlend;
     ubo->gridParams = glm::vec4(volumetricFarPlane, DEPTH_DISTRIBUTION,
                                  static_cast<float>(frameCounter), effectiveTemporalBlend);
     ubo->shadowParams = glm::vec4(2048.0f, 0.001f, 1.0f, 0.0f);  // Shadow map size, bias, pcf radius
+    // Underwater fog parameters (passed to froxel shader for underwater volumetrics)
+    ubo->underwaterParams = glm::vec4(
+        underwaterDensity,
+        underwaterAbsorptionScale,
+        underwaterColorMult,
+        underwaterEnabled ? 1.0f : 0.0f
+    );
 
     // Store for next frame's temporal reprojection
     prevViewProj = viewProj;

--- a/src/lighting/FroxelSystem.h
+++ b/src/lighting/FroxelSystem.h
@@ -96,6 +96,18 @@ public:
     void setLayerDensity(float d) override { layerDensity = d; resetTemporalHistory(); }
     float getLayerDensity() const override { return layerDensity; }
 
+    // Underwater fog parameters
+    void setWaterLevel(float level) { waterLevel = level; }
+    float getWaterLevel() const { return waterLevel; }
+    void setUnderwaterEnabled(bool e) { underwaterEnabled = e; resetTemporalHistory(); }
+    bool isUnderwaterEnabled() const { return underwaterEnabled; }
+    void setUnderwaterDensity(float d) { underwaterDensity = d; resetTemporalHistory(); }
+    float getUnderwaterDensity() const { return underwaterDensity; }
+    void setUnderwaterAbsorptionScale(float s) { underwaterAbsorptionScale = s; resetTemporalHistory(); }
+    float getUnderwaterAbsorptionScale() const { return underwaterAbsorptionScale; }
+    void setUnderwaterColorMult(float m) { underwaterColorMult = m; resetTemporalHistory(); }
+    float getUnderwaterColorMult() const { return underwaterColorMult; }
+
     // Reset temporal history (call when fog parameters change significantly)
     void resetTemporalHistory() { frameCounter = 0; }
 
@@ -181,6 +193,13 @@ private:
 
     // Temporal filtering (0 = disabled, 0.9 = typical value for stable fog)
     float temporalBlend = 0.9f;
+
+    // Underwater fog parameters
+    float waterLevel = 0.0f;              // Water surface Y position
+    bool underwaterEnabled = false;       // Is camera underwater
+    float underwaterDensity = 0.02f;      // Base underwater fog density
+    float underwaterAbsorptionScale = 0.5f;  // How quickly fog thickens with depth
+    float underwaterColorMult = 1.5f;     // Color intensity multiplier
 
     bool enabled = true;
 


### PR DESCRIPTION
The dark halo effect when going underwater was caused by the Snell's window effect in postprocess.frag simulating total internal reflection.

Changes:
- Enable froxel fog underwater instead of disabling it
- Remove Snell's window effect that created the radial halo
- Add underwater fog density to froxel_update.comp with depth-based scattering and water tint
- Pass water level and underwater state from WaterSystem to FroxelSystem
- Add underwater fog parameters (density, absorption, color) to FroxelSystem