### PR TITLE
Unify hardcoded constants in grass system

### DIFF
--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -5,6 +5,7 @@
 #extension GL_KHR_shader_subgroup_arithmetic : require
 
 #include "bindings.glsl"
+#include "grass_constants.glsl"
 #include "terrain_height_common.glsl"
 #include "instancing_common.glsl"
 
@@ -82,10 +83,8 @@ vec3 calculateTerrainNormal(vec2 uv, vec2 worldXZ) {
                                          grassParams.terrainSize, grassParams.terrainHeightScale, activeTileCount);
 }
 
-// Clumping parameters
-const float CLUMP_SCALE = 2.0;          // Size of clumps in world units
-const float CLUMP_HEIGHT_INFLUENCE = 0.4;  // How much clump affects height (0-1)
-const float CLUMP_FACING_INFLUENCE = 0.3;  // How much blades face toward/away from clump center
+// Clumping parameters - using unified constants from grass_constants.glsl
+// GRASS_CLUMP_SCALE, GRASS_CLUMP_HEIGHT_INFLUENCE, GRASS_CLUMP_FACING_INFLUENCE
 
 // Convert world position to displacement map UV coordinates
 vec2 worldPosToDispUV(vec2 worldPos) {
@@ -115,10 +114,9 @@ vec2 sampleDisplacement(vec2 worldPos) {
 
 // Voronoi-based clump calculation
 // Returns clumpId (0-1), clumpDistance, and clumpCenter
-void calculateClump(vec2 worldPos, float clumpScale,
-                    out float clumpId, out float clumpDist, out vec2 clumpCenter) {
-    // Scale position to clump space
-    vec2 scaledPos = worldPos / clumpScale;
+void calculateClump(vec2 worldPos, out float clumpId, out float clumpDist, out vec2 clumpCenter) {
+    // Scale position to clump space using unified constant
+    vec2 scaledPos = worldPos / GRASS_CLUMP_SCALE;
     vec2 cellId = floor(scaledPos);
 
     float minDist = 10.0;
@@ -132,7 +130,7 @@ void calculateClump(vec2 worldPos, float clumpScale,
 
             // Each cell's clump point is jittered based on hash
             vec2 jitter = hash2v(neighborCell) * 0.8 + 0.1;
-            vec2 clumpPoint = (neighborCell + jitter) * clumpScale;
+            vec2 clumpPoint = (neighborCell + jitter) * GRASS_CLUMP_SCALE;
 
             float dist = length(worldPos - clumpPoint);
             if (dist < minDist) {
@@ -155,29 +153,29 @@ void main() {
     uint gridZ = gl_GlobalInvocationID.y;
 
     // Set vertexCount (only first thread writes this constant value)
+    // Uses derived constant: GRASS_VERTICES_PER_BLADE = GRASS_NUM_SEGMENTS * 2 + 1 = 15
     if (gridX == 0 && gridZ == 0) {
-        drawCmd.vertexCount = 15;  // 5 segments * 3 vertices per triangle
+        drawCmd.vertexCount = GRASS_VERTICES_PER_BLADE;
     }
 
     // Generate grass positions in a grid pattern
-    // Grid: 1000x1000 = 1,000,000 potential blades (matching Ghost of Tsushima target)
-    // With 0.2m spacing = 200m x 200m area = 25 blades per square meter
-    // Culling systems (distance, frustum, LOD) will reduce to ~100k rendered
-    uint gridSize = 1000;
-    if (gridX >= gridSize || gridZ >= gridSize) return;
+    // Grid: GRASS_GRID_SIZE x GRASS_GRID_SIZE = 1,000,000 potential blades
+    // With GRASS_SPACING spacing = GRASS_COVERAGE_SIZE x GRASS_COVERAGE_SIZE area
+    // Density = GRASS_DENSITY blades per square meter
+    // Culling systems (distance, frustum, LOD) will reduce to ~GRASS_MAX_INSTANCES rendered
+    if (gridX >= GRASS_GRID_SIZE || gridZ >= GRASS_GRID_SIZE) return;
 
     // Map to world space (centered on origin)
-    float spacing = 0.2;  // 200m x 200m coverage
-    float x = (float(gridX) - float(gridSize) / 2.0) * spacing;
-    float z = (float(gridZ) - float(gridSize) / 2.0) * spacing;
+    float x = (float(gridX) - float(GRASS_GRID_SIZE) / 2.0) * GRASS_SPACING;
+    float z = (float(gridZ) - float(GRASS_GRID_SIZE) / 2.0) * GRASS_SPACING;
 
     // Add some randomness to position (jitter)
     vec2 cell = vec2(gridX, gridZ);
     float h1 = hash(cell);
     float h2 = hash2(cell);
 
-    x += (h1 - 0.5) * spacing * 0.8;
-    z += (hash(cell + vec2(100.0, 0.0)) - 0.5) * spacing * 0.8;
+    x += (h1 - 0.5) * GRASS_SPACING * GRASS_JITTER_FACTOR;
+    z += (hash(cell + vec2(100.0, 0.0)) - 0.5) * GRASS_SPACING * GRASS_JITTER_FACTOR;
 
     // Sample terrain heightmap to get Y position
     // Convert world XZ to heightmap UV: terrain is centered at origin with size = terrainSize
@@ -200,9 +198,9 @@ void main() {
     if (distToCamera > culling.maxDrawDistance) return;
 
     // Frustum culling using shared culling UBO
-    // Use large margin (15.0) to handle double-buffer lag during camera rotation
+    // Use GRASS_FRUSTUM_MARGIN to handle double-buffer lag during camera rotation
     // and ensure grass behind camera can still cast shadows
-    if (!isInFrustum(culling.frustumPlanes, worldPos, 15.0)) return;
+    if (!isInFrustum(culling.frustumPlanes, worldPos, GRASS_FRUSTUM_MARGIN)) return;
 
     // LOD blade dropping using shared culling UBO
     // maxLodDropRate from UBO controls max drop percentage at far LOD
@@ -223,21 +221,21 @@ void main() {
     baseSlot = subgroupBroadcastFirst(baseSlot);
     uint slot = baseSlot + laneOffset;
 
-    // Calculate clumping
+    // Calculate clumping using unified constants
     float clumpId, clumpDist;
     vec2 clumpCenter;
-    calculateClump(vec2(x, z), CLUMP_SCALE, clumpId, clumpDist, clumpCenter);
+    calculateClump(vec2(x, z), clumpId, clumpDist, clumpCenter);
 
-    // Base random properties
-    float randomFacing = h1 * 6.28318;     // Random facing direction
-    float baseHeight = 0.3 + h2 * 0.4;     // Height between 0.3 and 0.7
-    float bladeHash = h1;                  // For wind animation
-    float baseTilt = (hash(cell + vec2(50.0, 50.0)) - 0.5) * 0.3;  // Slight tilt
+    // Base random properties using unified constants
+    float randomFacing = h1 * GRASS_TWO_PI;  // Random facing direction (full rotation)
+    float baseHeight = GRASS_HEIGHT_MIN + h2 * GRASS_HEIGHT_RANGE;  // Height between min and max
+    float bladeHash = h1;                    // For wind animation
+    float baseTilt = (hash(cell + vec2(50.0, 50.0)) - 0.5) * GRASS_TILT_RANGE;  // Slight tilt
 
-    // Apply clump height influence
+    // Apply clump height influence using unified constant
     // Blades in the same clump have similar heights
     // clumpId varies 0-1, so we map it to a height multiplier
-    float clumpHeightMod = mix(1.0, 0.6 + clumpId * 0.8, CLUMP_HEIGHT_INFLUENCE);
+    float clumpHeightMod = mix(1.0, 0.6 + clumpId * 0.8, GRASS_CLUMP_HEIGHT_INFLUENCE);
     float height = baseHeight * clumpHeightMod;
 
     // Apply clump facing influence
@@ -258,10 +256,10 @@ void main() {
     float facingTarget = clumpId < 0.5 ? clumpFacingAngle : clumpFacingAngle + 3.14159;
 
     // Smooth blend between random and clump-oriented facing
-    float facing = mix(randomFacing, facingTarget, CLUMP_FACING_INFLUENCE);
+    float facing = mix(randomFacing, facingTarget, GRASS_CLUMP_FACING_INFLUENCE);
 
     // Tilt also influenced by distance to clump center (blades closer lean more)
-    float clumpTiltMod = (1.0 - clumpDist / CLUMP_SCALE) * 0.15;
+    float clumpTiltMod = (1.0 - clumpDist / GRASS_CLUMP_SCALE) * GRASS_CLUMP_TILT_MODIFIER;
     float tilt = baseTilt + clumpTiltMod;
 
     // Apply displacement from displacement buffer (player/NPC interaction)
@@ -269,7 +267,7 @@ void main() {
     vec2 displacement = sampleDisplacement(vec2(x, z));
     float dispMagnitude = length(displacement);
 
-    if (dispMagnitude > 0.01) {
+    if (dispMagnitude > GRASS_DISPLACEMENT_THRESHOLD) {
         // Normalize displacement direction
         vec2 dispDir = displacement / dispMagnitude;
 
@@ -278,7 +276,7 @@ void main() {
 
         // Blend facing toward displacement direction based on magnitude
         // Stronger displacement = blade faces more in push direction
-        float facingBlend = clamp(dispMagnitude * 0.9, 0.0, 0.9);
+        float facingBlend = clamp(dispMagnitude * GRASS_DISPLACEMENT_BLEND_MAX, 0.0, GRASS_DISPLACEMENT_BLEND_MAX);
         facing = mix(facing, dispAngle, facingBlend);
     }
 

--- a/shaders/grass.vert
+++ b/shaders/grass.vert
@@ -79,11 +79,11 @@ void main() {
         windParams
     );
 
-    // Wind offset combines sampled wind with phase offset
+    // Wind offset combines sampled wind with phase offset using unified constants
     float windAngle = atan(windParams.direction.y, windParams.direction.x);
     float relativeWindAngle = windAngle - facing;
-    float windEffect = windSample * 0.25;
-    float windOffset = (windEffect + grassPhaseOffset * 0.25) * cos(relativeWindAngle);
+    float windEffect = windSample * GRASS_WIND_EFFECT_MULTIPLIER;
+    float windOffset = (windEffect + grassPhaseOffset * GRASS_WIND_PHASE_MULTIPLIER) * cos(relativeWindAngle);
 
     // Calculate blade deformation (fold/droop) - shared with shadow pass
     GrassBladeControlPoints cp = grassCalculateBladeDeformation(height, bladeHash, tilt, windOffset);
@@ -104,8 +104,8 @@ void main() {
     // How much we're viewing edge-on (0 = face-on, 1 = edge-on)
     float edgeFactor = abs(dot(viewDir, bladeRight));
 
-    // Thicken by up to 3x when viewed edge-on
-    float thickenAmount = 1.0 + edgeFactor * 2.0;
+    // Thicken when viewed edge-on using unified constants
+    float thickenAmount = 1.0 + edgeFactor * GRASS_EDGE_THICKEN_FACTOR;
     vec3 thickenedPos = vec3(localPos.x * thickenAmount, localPos.y, localPos.z);
 
     // Transform from local blade space to world space using terrain basis
@@ -133,10 +133,8 @@ void main() {
     // Normal is perpendicular to both tangent and blade width direction
     vec3 normal = normalize(cross(worldTangent, bladeRight));
 
-    // Color gradient: darker at base, lighter at tip
-    vec3 baseColor = vec3(0.08, 0.22, 0.04);
-    vec3 tipColor = vec3(0.35, 0.65, 0.18);
-    fragColor = mix(baseColor, tipColor, t);
+    // Color gradient: darker at base, lighter at tip using unified constants
+    fragColor = mix(GRASS_COLOR_BASE, GRASS_COLOR_TIP, t);
 
     fragNormal = normal;
     fragHeight = t;

--- a/shaders/grass_constants.glsl
+++ b/shaders/grass_constants.glsl
@@ -1,0 +1,233 @@
+/*
+ * grass_constants.glsl - Unified grass system constants
+ *
+ * Central location for all grass-related constants to avoid duplication
+ * and ensure derived values stay consistent with their base values.
+ *
+ * Include this file in all grass shaders that need these constants.
+ */
+
+#ifndef GRASS_CONSTANTS_GLSL
+#define GRASS_CONSTANTS_GLSL
+
+// =============================================================================
+// GRID AND INSTANCE CONFIGURATION
+// =============================================================================
+
+// Grid dimensions (1000x1000 = 1,000,000 potential blades)
+const uint GRASS_GRID_SIZE = 1000;
+
+// Spacing between blades in world units (meters)
+// With 0.2m spacing: 200m x 200m coverage, 25 blades per square meter
+const float GRASS_SPACING = 0.2;
+
+// Derived: Total coverage area in each dimension
+// GRASS_GRID_SIZE * GRASS_SPACING = 200m
+const float GRASS_COVERAGE_SIZE = float(GRASS_GRID_SIZE) * GRASS_SPACING;
+
+// Derived: Blades per square meter
+// 1.0 / (GRASS_SPACING * GRASS_SPACING) = 25
+const float GRASS_DENSITY = 1.0 / (GRASS_SPACING * GRASS_SPACING);
+
+// Position jitter as fraction of spacing (80%)
+const float GRASS_JITTER_FACTOR = 0.8;
+
+// Workgroup size for compute shaders (16x16 = 256 threads)
+const uint GRASS_WORKGROUP_SIZE = 16;
+
+// Derived: Number of workgroups needed to cover grid
+// ceil(GRASS_GRID_SIZE / GRASS_WORKGROUP_SIZE) = ceil(1000/16) = 63
+const uint GRASS_DISPATCH_SIZE = (GRASS_GRID_SIZE + GRASS_WORKGROUP_SIZE - 1) / GRASS_WORKGROUP_SIZE;
+
+// Maximum instances rendered after culling (~100k target like Ghost of Tsushima)
+const uint GRASS_MAX_INSTANCES = 100000;
+
+// =============================================================================
+// BLADE GEOMETRY
+// =============================================================================
+
+// Number of segments per blade (determines detail level)
+const uint GRASS_NUM_SEGMENTS = 7;
+
+// Derived: Vertices per blade (2 per segment for strip + 1 tip vertex)
+// (GRASS_NUM_SEGMENTS * 2) + 1 = 15
+const uint GRASS_VERTICES_PER_BLADE = GRASS_NUM_SEGMENTS * 2 + 1;
+
+// Derived: Tip vertex index (for width=0 check)
+const uint GRASS_TIP_VERTEX_INDEX = GRASS_VERTICES_PER_BLADE - 1;
+
+// Base width of grass blade at ground level (2cm)
+const float GRASS_BASE_WIDTH = 0.02;
+
+// Width taper from base to tip (90% taper)
+const float GRASS_WIDTH_TAPER = 0.9;
+
+// =============================================================================
+// BLADE HEIGHT PROPERTIES
+// =============================================================================
+
+// Height range for blades (normalized 0-1 scale, actual height = h * heightScale)
+const float GRASS_HEIGHT_MIN = 0.3;
+const float GRASS_HEIGHT_MAX = 0.7;
+
+// Derived: Height variation range
+const float GRASS_HEIGHT_RANGE = GRASS_HEIGHT_MAX - GRASS_HEIGHT_MIN;
+
+// Blade fold/droop parameters (short grass folds more)
+const float GRASS_FOLD_MIN = 0.1;    // Tall grass fold amount
+const float GRASS_FOLD_MAX = 0.6;    // Short grass fold amount
+const float GRASS_DROOP_MAX = 0.3;   // Maximum droop factor for shortest grass
+
+// Tilt range (random tilt in radians)
+const float GRASS_TILT_RANGE = 0.3;
+
+// =============================================================================
+// DISPLACEMENT SYSTEM
+// =============================================================================
+
+// Displacement texture resolution (512x512 texels)
+const uint GRASS_DISPLACEMENT_TEXTURE_SIZE = 512;
+
+// Displacement region coverage in world units (50m x 50m)
+const float GRASS_DISPLACEMENT_REGION_SIZE = 50.0;
+
+// Derived: Texel size in world units
+// GRASS_DISPLACEMENT_REGION_SIZE / GRASS_DISPLACEMENT_TEXTURE_SIZE = ~0.0977m
+const float GRASS_DISPLACEMENT_TEXEL_SIZE = GRASS_DISPLACEMENT_REGION_SIZE / float(GRASS_DISPLACEMENT_TEXTURE_SIZE);
+
+// Derived: Dispatch size for displacement compute shader
+// GRASS_DISPLACEMENT_TEXTURE_SIZE / GRASS_WORKGROUP_SIZE = 32
+const uint GRASS_DISPLACEMENT_DISPATCH_SIZE = GRASS_DISPLACEMENT_TEXTURE_SIZE / GRASS_WORKGROUP_SIZE;
+
+// Maximum displacement sources per frame (player, NPCs, etc.)
+const uint GRASS_MAX_DISPLACEMENT_SOURCES = 16;
+
+// Displacement blend factor (how much displacement affects facing)
+const float GRASS_DISPLACEMENT_BLEND_MAX = 0.9;
+
+// Displacement magnitude threshold
+const float GRASS_DISPLACEMENT_THRESHOLD = 0.01;
+
+// =============================================================================
+// CULLING AND LOD
+// =============================================================================
+
+// Maximum draw distance (meters)
+const float GRASS_MAX_DRAW_DISTANCE = 50.0;
+
+// LOD transition zone
+const float GRASS_LOD_TRANSITION_START = 30.0;
+const float GRASS_LOD_TRANSITION_END = 50.0;
+
+// Maximum blade drop rate at far LOD (50%)
+const float GRASS_MAX_LOD_DROP_RATE = 0.5;
+
+// Frustum culling margin (accounts for double-buffer lag and shadow casting)
+const float GRASS_FRUSTUM_MARGIN = 15.0;
+
+// =============================================================================
+// CLUMPING PARAMETERS
+// =============================================================================
+
+// Size of clumps in world units
+const float GRASS_CLUMP_SCALE = 2.0;
+
+// How much clump affects blade height (0-1)
+const float GRASS_CLUMP_HEIGHT_INFLUENCE = 0.4;
+
+// How much blades face toward/away from clump center (0-1)
+const float GRASS_CLUMP_FACING_INFLUENCE = 0.3;
+
+// Tilt modifier from clump distance
+const float GRASS_CLUMP_TILT_MODIFIER = 0.15;
+
+// =============================================================================
+// WIND PARAMETERS
+// =============================================================================
+
+// Wind effect multiplier
+const float GRASS_WIND_EFFECT_MULTIPLIER = 0.25;
+
+// Wind phase offset multiplier
+const float GRASS_WIND_PHASE_MULTIPLIER = 0.25;
+
+// Wind base frequency (10m wavelength)
+const float GRASS_WIND_BASE_FREQ = 0.1;
+
+// Multi-octave frequency multipliers
+const float GRASS_WIND_OCTAVE2_MULT = 2.0;
+const float GRASS_WIND_OCTAVE3_MULT = 4.0;
+
+// Multi-octave weights
+const float GRASS_WIND_OCTAVE1_WEIGHT = 0.7;
+const float GRASS_WIND_OCTAVE2_WEIGHT = 0.2;
+const float GRASS_WIND_OCTAVE3_WEIGHT = 0.1;
+
+// =============================================================================
+// BLADE COLORS
+// =============================================================================
+
+// Base color (dark green at blade base)
+const vec3 GRASS_COLOR_BASE = vec3(0.08, 0.22, 0.04);
+
+// Tip color (lighter green at blade tip)
+const vec3 GRASS_COLOR_TIP = vec3(0.35, 0.65, 0.18);
+
+// Clump color variation influence (subtle)
+const float GRASS_CLUMP_COLOR_INFLUENCE = 0.15;
+
+// Warm/cool color shifts for clump variation
+const vec3 GRASS_COLOR_SHIFT_WARM = vec3(0.05, 0.03, -0.02);
+const vec3 GRASS_COLOR_SHIFT_COOL = vec3(-0.02, 0.02, 0.03);
+
+// Brightness variation range per clump
+const float GRASS_BRIGHTNESS_MIN = 0.9;
+const float GRASS_BRIGHTNESS_MAX = 1.1;
+
+// =============================================================================
+// MATERIAL PROPERTIES
+// =============================================================================
+
+// Surface roughness (fairly matte)
+const float GRASS_ROUGHNESS = 0.7;
+
+// Subsurface scattering intensity
+const float GRASS_SSS_STRENGTH = 0.35;
+
+// Specular highlight intensity (subtle)
+const float GRASS_SPECULAR_STRENGTH = 0.15;
+
+// Two-sided diffuse multiplier (for backlit blades)
+const float GRASS_BACKLIT_DIFFUSE = 0.6;
+
+// =============================================================================
+// RENDERING ENHANCEMENTS
+// =============================================================================
+
+// Edge-on view thickening multiplier
+const float GRASS_EDGE_THICKEN_MAX = 3.0;
+const float GRASS_EDGE_THICKEN_FACTOR = 2.0;
+
+// Rim lighting parameters
+const float GRASS_RIM_FRESNEL_POWER = 4.0;
+const float GRASS_RIM_INTENSITY = 0.15;
+
+// Ambient occlusion range (darker at base)
+const float GRASS_AO_BASE = 0.4;
+const float GRASS_AO_TIP = 1.0;
+
+// Shadow tip discard threshold (top 5%)
+const float GRASS_SHADOW_TIP_THRESHOLD = 0.95;
+
+// Depth bias for shadow pipeline
+const float GRASS_SHADOW_DEPTH_BIAS_CONSTANT = 0.25;
+const float GRASS_SHADOW_DEPTH_BIAS_SLOPE = 0.75;
+
+// =============================================================================
+// MATHEMATICAL CONSTANTS
+// =============================================================================
+
+// 2*PI for full rotation
+const float GRASS_TWO_PI = 6.28318530718;
+
+#endif // GRASS_CONSTANTS_GLSL

--- a/shaders/grass_shadow.frag
+++ b/shaders/grass_shadow.frag
@@ -1,12 +1,16 @@
 #version 450
 
+#extension GL_GOOGLE_include_directive : require
+
+#include "grass_constants.glsl"
+
 layout(location = 0) in float fragHeight;
 layout(location = 1) in float fragHash;
 
 void main() {
     // Render solid shadows - no dithering for now
-    // Just discard the very tip for a softer look
-    if (fragHeight > 0.95) {
+    // Just discard the very tip for a softer look using unified constant
+    if (fragHeight > GRASS_SHADOW_TIP_THRESHOLD) {
         discard;
     }
 

--- a/shaders/grass_shadow.vert
+++ b/shaders/grass_shadow.vert
@@ -70,11 +70,11 @@ void main() {
         windParams
     );
 
-    // Wind offset combines sampled wind with phase offset (same as grass.vert)
+    // Wind offset combines sampled wind with phase offset (same as grass.vert) using unified constants
     float windAngle = atan(windParams.direction.y, windParams.direction.x);
     float relativeWindAngle = windAngle - facing;
-    float windEffect = windSample * 0.25;
-    float windOffset = (windEffect + grassPhaseOffset * 0.25) * cos(relativeWindAngle);
+    float windEffect = windSample * GRASS_WIND_EFFECT_MULTIPLIER;
+    float windOffset = (windEffect + grassPhaseOffset * GRASS_WIND_PHASE_MULTIPLIER) * cos(relativeWindAngle);
 
     // Calculate blade deformation (fold/droop) - SAME as main render pass
     GrassBladeControlPoints cp = grassCalculateBladeDeformation(height, bladeHash, tilt, windOffset);

--- a/src/vegetation/GrassConstants.h
+++ b/src/vegetation/GrassConstants.h
@@ -1,0 +1,113 @@
+#pragma once
+
+/**
+ * GrassConstants.h - Unified grass system constants for C++
+ *
+ * Central location for all grass-related constants to avoid duplication
+ * and ensure derived values stay consistent with their base values.
+ *
+ * NOTE: These values must match shaders/grass_constants.glsl
+ */
+
+#include <cstdint>
+
+namespace GrassConstants {
+
+// =============================================================================
+// GRID AND INSTANCE CONFIGURATION
+// =============================================================================
+
+// Grid dimensions (1000x1000 = 1,000,000 potential blades)
+inline constexpr uint32_t GRID_SIZE = 1000;
+
+// Spacing between blades in world units (meters)
+// With 0.2m spacing: 200m x 200m coverage, 25 blades per square meter
+inline constexpr float SPACING = 0.2f;
+
+// Derived: Total coverage area in each dimension
+// GRID_SIZE * SPACING = 200m
+inline constexpr float COVERAGE_SIZE = static_cast<float>(GRID_SIZE) * SPACING;
+
+// Derived: Blades per square meter
+// 1.0 / (SPACING * SPACING) = 25
+inline constexpr float DENSITY = 1.0f / (SPACING * SPACING);
+
+// Workgroup size for compute shaders (16x16 = 256 threads)
+inline constexpr uint32_t WORKGROUP_SIZE = 16;
+
+// Derived: Number of workgroups needed to cover grid
+// ceil(GRID_SIZE / WORKGROUP_SIZE) = ceil(1000/16) = 63
+inline constexpr uint32_t DISPATCH_SIZE = (GRID_SIZE + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+
+// Maximum instances rendered after culling (~100k target like Ghost of Tsushima)
+inline constexpr uint32_t MAX_INSTANCES = 100000;
+
+// =============================================================================
+// BLADE GEOMETRY
+// =============================================================================
+
+// Number of segments per blade (determines detail level)
+inline constexpr uint32_t NUM_SEGMENTS = 7;
+
+// Derived: Vertices per blade (2 per segment for strip + 1 tip vertex)
+// (NUM_SEGMENTS * 2) + 1 = 15
+inline constexpr uint32_t VERTICES_PER_BLADE = NUM_SEGMENTS * 2 + 1;
+
+// Base width of grass blade at ground level (2cm)
+inline constexpr float BASE_WIDTH = 0.02f;
+
+// =============================================================================
+// BLADE HEIGHT PROPERTIES
+// =============================================================================
+
+// Height range for blades (normalized 0-1 scale, actual height = h * heightScale)
+inline constexpr float HEIGHT_MIN = 0.3f;
+inline constexpr float HEIGHT_MAX = 0.7f;
+
+// Derived: Height variation range
+inline constexpr float HEIGHT_RANGE = HEIGHT_MAX - HEIGHT_MIN;
+
+// =============================================================================
+// DISPLACEMENT SYSTEM
+// =============================================================================
+
+// Displacement texture resolution (512x512 texels)
+inline constexpr uint32_t DISPLACEMENT_TEXTURE_SIZE = 512;
+
+// Displacement region coverage in world units (50m x 50m)
+inline constexpr float DISPLACEMENT_REGION_SIZE = 50.0f;
+
+// Derived: Texel size in world units
+// DISPLACEMENT_REGION_SIZE / DISPLACEMENT_TEXTURE_SIZE = ~0.0977m
+inline constexpr float DISPLACEMENT_TEXEL_SIZE = DISPLACEMENT_REGION_SIZE / static_cast<float>(DISPLACEMENT_TEXTURE_SIZE);
+
+// Derived: Dispatch size for displacement compute shader
+// DISPLACEMENT_TEXTURE_SIZE / WORKGROUP_SIZE = 32
+inline constexpr uint32_t DISPLACEMENT_DISPATCH_SIZE = DISPLACEMENT_TEXTURE_SIZE / WORKGROUP_SIZE;
+
+// Maximum displacement sources per frame (player, NPCs, etc.)
+inline constexpr uint32_t MAX_DISPLACEMENT_SOURCES = 16;
+
+// =============================================================================
+// CULLING AND LOD
+// =============================================================================
+
+// Maximum draw distance (meters)
+inline constexpr float MAX_DRAW_DISTANCE = 50.0f;
+
+// LOD transition zone
+inline constexpr float LOD_TRANSITION_START = 30.0f;
+inline constexpr float LOD_TRANSITION_END = 50.0f;
+
+// Maximum blade drop rate at far LOD (50%)
+inline constexpr float MAX_LOD_DROP_RATE = 0.5f;
+
+// =============================================================================
+// SHADOW PIPELINE
+// =============================================================================
+
+// Depth bias for shadow pipeline
+inline constexpr float SHADOW_DEPTH_BIAS_CONSTANT = 0.25f;
+inline constexpr float SHADOW_DEPTH_BIAS_SLOPE = 0.75f;
+
+} // namespace GrassConstants

--- a/src/vegetation/GrassSystem.h
+++ b/src/vegetation/GrassSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EnvironmentSettings.h"
+#include "GrassConstants.h"
 #include <vulkan/vulkan.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
@@ -185,10 +186,10 @@ private:
     ManagedPipelineLayout shadowPipelineLayout_;
     ManagedPipeline shadowPipeline_;
 
-    // Displacement texture resources (for player/NPC grass interaction)
-    static constexpr uint32_t DISPLACEMENT_TEXTURE_SIZE = 512;  // 512x512 texels
-    static constexpr float DISPLACEMENT_REGION_SIZE = 50.0f;    // 50m x 50m coverage
-    static constexpr uint32_t MAX_DISPLACEMENT_SOURCES = 16;    // Max sources per frame
+    // Displacement texture resources use unified constants from GrassConstants.h:
+    // GrassConstants::DISPLACEMENT_TEXTURE_SIZE (512x512 texels)
+    // GrassConstants::DISPLACEMENT_REGION_SIZE (50m x 50m coverage)
+    // GrassConstants::MAX_DISPLACEMENT_SOURCES (max sources per frame)
 
     vk::Image displacementImage_;
     VmaAllocation displacementAllocation_ = VK_NULL_HANDLE;
@@ -244,7 +245,8 @@ private:
     // to avoid per-frame descriptor set updates
     const BufferUtils::DynamicUniformBuffer* dynamicRendererUBO_ = nullptr;
 
-    static constexpr uint32_t MAX_INSTANCES = 100000;  // ~100k rendered after culling
+    // MAX_INSTANCES uses unified constant from GrassConstants.h:
+    // GrassConstants::MAX_INSTANCES (~100k rendered after culling)
 
     const EnvironmentSettings* environmentSettings = nullptr;
 };


### PR DESCRIPTION
Create centralized constant definitions for the grass system:
- shaders/grass_constants.glsl: Unified constants for GLSL shaders
- src/vegetation/GrassConstants.h: Matching C++ constants

Key improvements:
- Derived values are now computed from base values (e.g., DISPATCH_SIZE from GRID_SIZE and WORKGROUP_SIZE, VERTICES_PER_BLADE from NUM_SEGMENTS)
- Single source of truth for grid size (1000), spacing (0.2m), workgroup size (16), displacement texture size (512), culling distances, etc.
- Removes magic numbers like 63 (dispatch size), 15 (vertices per blade), 0.95 (shadow tip threshold), 0.25 (wind multipliers)
- All grass shaders and C++ code now reference these unified constants