### PR TITLE
Offload terrain and trees to background threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCES
     src/vegetation/RockSystem.cpp
     src/vegetation/TreeSystem.cpp
     src/vegetation/TreeGenerator.cpp
+    src/vegetation/ThreadedTreeGenerator.cpp
     src/vegetation/TreeOptions.cpp
     src/vegetation/TreeRenderer.cpp
     src/vegetation/TreeLeafCulling.cpp

--- a/src/core/loading/LoadJobQueue.h
+++ b/src/core/loading/LoadJobQueue.h
@@ -89,6 +89,42 @@ struct StagedBuffer : public StagedResource {
 };
 
 /**
+ * Staged tree mesh data (for threaded tree generation)
+ * Contains CPU-side geometry ready for GPU upload
+ */
+struct StagedTreeMesh : public StagedResource {
+    // Branch mesh geometry
+    std::vector<uint8_t> branchVertexData;  // Vertex data as raw bytes
+    std::vector<uint32_t> branchIndices;
+    uint32_t branchVertexCount = 0;
+    uint32_t branchVertexStride = 0;
+
+    // Leaf instance data (32 bytes per instance: vec4 positionAndSize + vec4 orientation)
+    std::vector<uint8_t> leafInstanceData;
+    uint32_t leafInstanceCount = 0;
+
+    // Tree placement info
+    float positionX = 0.0f;
+    float positionY = 0.0f;
+    float positionZ = 0.0f;
+    float rotation = 0.0f;
+    float scale = 1.0f;
+
+    // Tree options index (references pre-loaded options)
+    uint32_t optionsIndex = 0;
+
+    // For impostor archetype assignment
+    uint32_t archetypeIndex = 0;
+
+    std::string name;
+
+    size_t getMemorySize() const override {
+        return branchVertexData.size() + branchIndices.size() * sizeof(uint32_t) + leafInstanceData.size();
+    }
+    const char* getTypeName() const override { return "TreeMesh"; }
+};
+
+/**
  * Result of a completed load job
  */
 struct LoadJobResult {

--- a/src/vegetation/ThreadedTreeGenerator.cpp
+++ b/src/vegetation/ThreadedTreeGenerator.cpp
@@ -1,0 +1,362 @@
+#include "ThreadedTreeGenerator.h"
+#include "core/Mesh.h"
+#include <SDL3/SDL.h>
+#include <glm/gtc/constants.hpp>
+#include <cstring>
+
+std::unique_ptr<ThreadedTreeGenerator> ThreadedTreeGenerator::create(uint32_t workerCount) {
+    std::unique_ptr<ThreadedTreeGenerator> gen(new ThreadedTreeGenerator());
+    if (!gen->init(workerCount)) {
+        return nullptr;
+    }
+    return gen;
+}
+
+ThreadedTreeGenerator::~ThreadedTreeGenerator() {
+    if (jobQueue_) {
+        jobQueue_->shutdown();
+    }
+}
+
+bool ThreadedTreeGenerator::init(uint32_t workerCount) {
+    jobQueue_ = Loading::LoadJobQueue::create(workerCount);
+    if (!jobQueue_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ThreadedTreeGenerator: Failed to create job queue");
+        return false;
+    }
+    SDL_Log("ThreadedTreeGenerator initialized with %u workers", workerCount);
+    return true;
+}
+
+void ThreadedTreeGenerator::queueTree(const TreeRequest& request) {
+    pendingCount_++;
+    totalQueued_++;
+    jobQueue_->setTotalJobs(totalQueued_.load());
+
+    // Capture request by value for thread safety
+    Loading::LoadJob job;
+    job.id = "tree_" + std::to_string(totalQueued_.load());
+    job.phase = "Trees";
+    job.priority = 0;
+
+    job.execute = [request]() -> std::unique_ptr<Loading::StagedResource> {
+        // Generate tree mesh on worker thread
+        TreeGenerator generator;
+        TreeMeshData meshData = generator.generate(request.options);
+
+        // Build branch mesh vertices (same algorithm as TreeSystem::generateTreeMesh)
+        std::vector<Vertex> branchVertices;
+        std::vector<uint32_t> branchIndices;
+
+        glm::vec2 textureScale = request.options.bark.textureScale;
+        float vRepeat = 1.0f / textureScale.y;
+
+        uint32_t indexOffset = 0;
+        for (const auto& branch : meshData.branches) {
+            int sectionCount = branch.sectionCount;
+            int segmentCount = branch.segmentCount;
+
+            for (size_t sectionIdx = 0; sectionIdx < branch.sections.size(); ++sectionIdx) {
+                const SectionData& section = branch.sections[sectionIdx];
+                float vCoord = (sectionIdx % 2 == 0) ? 0.0f : vRepeat;
+
+                for (int seg = 0; seg <= segmentCount; ++seg) {
+                    float angle = 2.0f * glm::pi<float>() * static_cast<float>(seg) / static_cast<float>(segmentCount);
+
+                    glm::vec3 localPos(std::cos(angle), 0.0f, std::sin(angle));
+                    glm::vec3 localNormal = -localPos;
+
+                    glm::vec3 worldOffset = section.orientation * (localPos * section.radius);
+                    glm::vec3 worldNormal = glm::normalize(section.orientation * localNormal);
+
+                    float uCoord = static_cast<float>(seg) / static_cast<float>(segmentCount) * textureScale.x;
+
+                    Vertex v{};
+                    v.position = section.origin + worldOffset;
+                    v.normal = worldNormal;
+                    v.texCoord = glm::vec2(uCoord, vCoord);
+                    v.tangent = glm::vec4(
+                        glm::normalize(section.orientation * glm::vec3(0.0f, 1.0f, 0.0f)),
+                        1.0f
+                    );
+
+                    float normalizedLevel = static_cast<float>(branch.level) / 3.0f * 0.95f;
+                    if (branch.level == 0) {
+                        v.color = glm::vec4(1.0f, 1.0f, 1.0f, 0.0f);
+                    } else {
+                        v.color = glm::vec4(branch.origin, normalizedLevel);
+                    }
+
+                    branchVertices.push_back(v);
+                }
+            }
+
+            // Generate indices for this branch
+            uint32_t vertsPerRing = static_cast<uint32_t>(segmentCount + 1);
+            for (int section = 0; section < sectionCount; ++section) {
+                for (int seg = 0; seg < segmentCount; ++seg) {
+                    uint32_t v0 = indexOffset + section * vertsPerRing + seg;
+                    uint32_t v1 = v0 + 1;
+                    uint32_t v2 = v0 + vertsPerRing;
+                    uint32_t v3 = v2 + 1;
+
+                    branchIndices.push_back(v0);
+                    branchIndices.push_back(v2);
+                    branchIndices.push_back(v1);
+
+                    branchIndices.push_back(v1);
+                    branchIndices.push_back(v2);
+                    branchIndices.push_back(v3);
+                }
+            }
+
+            indexOffset += static_cast<uint32_t>(branch.sections.size()) * vertsPerRing;
+        }
+
+        // Build leaf instance data (matching LeafInstanceGPU layout: 32 bytes)
+        struct LeafInstanceGPU {
+            glm::vec4 positionAndSize;
+            glm::vec4 orientation;
+        };
+        static_assert(sizeof(LeafInstanceGPU) == 32, "LeafInstanceGPU must be 32 bytes");
+
+        std::vector<LeafInstanceGPU> leafInstances;
+        for (const auto& leaf : meshData.leaves) {
+            int quadsPerLeaf = (request.options.leaves.billboard == BillboardMode::Double) ? 2 : 1;
+
+            for (int quad = 0; quad < quadsPerLeaf; ++quad) {
+                float yRotation = (quad == 1) ? glm::half_pi<float>() : 0.0f;
+                glm::quat yQuat = glm::angleAxis(yRotation, glm::vec3(0.0f, 1.0f, 0.0f));
+                glm::quat finalQuat = leaf.orientation * yQuat;
+
+                LeafInstanceGPU instance;
+                instance.positionAndSize = glm::vec4(leaf.position, leaf.size);
+                instance.orientation = glm::vec4(finalQuat.x, finalQuat.y, finalQuat.z, finalQuat.w);
+                leafInstances.push_back(instance);
+            }
+        }
+
+        // Create staged tree mesh result
+        auto staged = std::make_unique<Loading::StagedTreeMesh>();
+
+        // Copy vertex data as raw bytes
+        staged->branchVertexData.resize(branchVertices.size() * sizeof(Vertex));
+        std::memcpy(staged->branchVertexData.data(), branchVertices.data(), staged->branchVertexData.size());
+        staged->branchVertexCount = static_cast<uint32_t>(branchVertices.size());
+        staged->branchVertexStride = sizeof(Vertex);
+
+        // Copy indices
+        staged->branchIndices = std::move(branchIndices);
+
+        // Copy leaf instance data as raw bytes
+        staged->leafInstanceData.resize(leafInstances.size() * sizeof(LeafInstanceGPU));
+        std::memcpy(staged->leafInstanceData.data(), leafInstances.data(), staged->leafInstanceData.size());
+        staged->leafInstanceCount = static_cast<uint32_t>(leafInstances.size());
+
+        // Store placement info
+        staged->positionX = request.position.x;
+        staged->positionY = request.position.y;
+        staged->positionZ = request.position.z;
+        staged->rotation = request.rotation;
+        staged->scale = request.scale;
+        staged->archetypeIndex = request.archetypeIndex;
+
+        return staged;
+    };
+
+    jobQueue_->submit(std::move(job));
+}
+
+void ThreadedTreeGenerator::queueTrees(const std::vector<TreeRequest>& requests) {
+    std::vector<Loading::LoadJob> jobs;
+    jobs.reserve(requests.size());
+
+    uint32_t startId = totalQueued_.load();
+    pendingCount_ += static_cast<uint32_t>(requests.size());
+    totalQueued_ += static_cast<uint32_t>(requests.size());
+    jobQueue_->setTotalJobs(totalQueued_.load());
+
+    for (size_t i = 0; i < requests.size(); ++i) {
+        const auto& request = requests[i];
+
+        Loading::LoadJob job;
+        job.id = "tree_" + std::to_string(startId + i);
+        job.phase = "Trees";
+        job.priority = 0;
+
+        // Same execution lambda as queueTree
+        job.execute = [request]() -> std::unique_ptr<Loading::StagedResource> {
+            TreeGenerator generator;
+            TreeMeshData meshData = generator.generate(request.options);
+
+            std::vector<Vertex> branchVertices;
+            std::vector<uint32_t> branchIndices;
+
+            glm::vec2 textureScale = request.options.bark.textureScale;
+            float vRepeat = 1.0f / textureScale.y;
+
+            uint32_t indexOffset = 0;
+            for (const auto& branch : meshData.branches) {
+                int sectionCount = branch.sectionCount;
+                int segmentCount = branch.segmentCount;
+
+                for (size_t sectionIdx = 0; sectionIdx < branch.sections.size(); ++sectionIdx) {
+                    const SectionData& section = branch.sections[sectionIdx];
+                    float vCoord = (sectionIdx % 2 == 0) ? 0.0f : vRepeat;
+
+                    for (int seg = 0; seg <= segmentCount; ++seg) {
+                        float angle = 2.0f * glm::pi<float>() * static_cast<float>(seg) / static_cast<float>(segmentCount);
+
+                        glm::vec3 localPos(std::cos(angle), 0.0f, std::sin(angle));
+                        glm::vec3 localNormal = -localPos;
+
+                        glm::vec3 worldOffset = section.orientation * (localPos * section.radius);
+                        glm::vec3 worldNormal = glm::normalize(section.orientation * localNormal);
+
+                        float uCoord = static_cast<float>(seg) / static_cast<float>(segmentCount) * textureScale.x;
+
+                        Vertex v{};
+                        v.position = section.origin + worldOffset;
+                        v.normal = worldNormal;
+                        v.texCoord = glm::vec2(uCoord, vCoord);
+                        v.tangent = glm::vec4(
+                            glm::normalize(section.orientation * glm::vec3(0.0f, 1.0f, 0.0f)),
+                            1.0f
+                        );
+
+                        float normalizedLevel = static_cast<float>(branch.level) / 3.0f * 0.95f;
+                        if (branch.level == 0) {
+                            v.color = glm::vec4(1.0f, 1.0f, 1.0f, 0.0f);
+                        } else {
+                            v.color = glm::vec4(branch.origin, normalizedLevel);
+                        }
+
+                        branchVertices.push_back(v);
+                    }
+                }
+
+                uint32_t vertsPerRing = static_cast<uint32_t>(segmentCount + 1);
+                for (int section = 0; section < sectionCount; ++section) {
+                    for (int seg = 0; seg < segmentCount; ++seg) {
+                        uint32_t v0 = indexOffset + section * vertsPerRing + seg;
+                        uint32_t v1 = v0 + 1;
+                        uint32_t v2 = v0 + vertsPerRing;
+                        uint32_t v3 = v2 + 1;
+
+                        branchIndices.push_back(v0);
+                        branchIndices.push_back(v2);
+                        branchIndices.push_back(v1);
+
+                        branchIndices.push_back(v1);
+                        branchIndices.push_back(v2);
+                        branchIndices.push_back(v3);
+                    }
+                }
+
+                indexOffset += static_cast<uint32_t>(branch.sections.size()) * vertsPerRing;
+            }
+
+            struct LeafInstanceGPU {
+                glm::vec4 positionAndSize;
+                glm::vec4 orientation;
+            };
+
+            std::vector<LeafInstanceGPU> leafInstances;
+            for (const auto& leaf : meshData.leaves) {
+                int quadsPerLeaf = (request.options.leaves.billboard == BillboardMode::Double) ? 2 : 1;
+
+                for (int quad = 0; quad < quadsPerLeaf; ++quad) {
+                    float yRotation = (quad == 1) ? glm::half_pi<float>() : 0.0f;
+                    glm::quat yQuat = glm::angleAxis(yRotation, glm::vec3(0.0f, 1.0f, 0.0f));
+                    glm::quat finalQuat = leaf.orientation * yQuat;
+
+                    LeafInstanceGPU instance;
+                    instance.positionAndSize = glm::vec4(leaf.position, leaf.size);
+                    instance.orientation = glm::vec4(finalQuat.x, finalQuat.y, finalQuat.z, finalQuat.w);
+                    leafInstances.push_back(instance);
+                }
+            }
+
+            auto staged = std::make_unique<Loading::StagedTreeMesh>();
+
+            staged->branchVertexData.resize(branchVertices.size() * sizeof(Vertex));
+            std::memcpy(staged->branchVertexData.data(), branchVertices.data(), staged->branchVertexData.size());
+            staged->branchVertexCount = static_cast<uint32_t>(branchVertices.size());
+            staged->branchVertexStride = sizeof(Vertex);
+
+            staged->branchIndices = std::move(branchIndices);
+
+            staged->leafInstanceData.resize(leafInstances.size() * sizeof(LeafInstanceGPU));
+            std::memcpy(staged->leafInstanceData.data(), leafInstances.data(), staged->leafInstanceData.size());
+            staged->leafInstanceCount = static_cast<uint32_t>(leafInstances.size());
+
+            staged->positionX = request.position.x;
+            staged->positionY = request.position.y;
+            staged->positionZ = request.position.z;
+            staged->rotation = request.rotation;
+            staged->scale = request.scale;
+            staged->archetypeIndex = request.archetypeIndex;
+
+            return staged;
+        };
+
+        jobs.push_back(std::move(job));
+    }
+
+    jobQueue_->submitBatch(std::move(jobs));
+}
+
+std::vector<ThreadedTreeGenerator::StagedTree> ThreadedTreeGenerator::getCompletedTrees() {
+    auto results = jobQueue_->getCompletedJobs();
+    std::vector<StagedTree> trees;
+    trees.reserve(results.size());
+
+    for (auto& result : results) {
+        if (!result.success || !result.resource) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ThreadedTreeGenerator: Job '%s' failed: %s",
+                        result.jobId.c_str(), result.error.c_str());
+            pendingCount_--;
+            continue;
+        }
+
+        // Cast to StagedTreeMesh
+        auto* stagedMesh = dynamic_cast<Loading::StagedTreeMesh*>(result.resource.get());
+        if (!stagedMesh) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ThreadedTreeGenerator: Job '%s' returned wrong resource type",
+                        result.jobId.c_str());
+            pendingCount_--;
+            continue;
+        }
+
+        StagedTree tree;
+        tree.branchVertexData = std::move(stagedMesh->branchVertexData);
+        tree.branchIndices = std::move(stagedMesh->branchIndices);
+        tree.branchVertexCount = stagedMesh->branchVertexCount;
+        tree.leafInstanceData = std::move(stagedMesh->leafInstanceData);
+        tree.leafInstanceCount = stagedMesh->leafInstanceCount;
+        tree.position = glm::vec3(stagedMesh->positionX, stagedMesh->positionY, stagedMesh->positionZ);
+        tree.rotation = stagedMesh->rotation;
+        tree.scale = stagedMesh->scale;
+        tree.archetypeIndex = stagedMesh->archetypeIndex;
+
+        trees.push_back(std::move(tree));
+        pendingCount_--;
+        completedCount_++;
+    }
+
+    return trees;
+}
+
+bool ThreadedTreeGenerator::isComplete() const {
+    return jobQueue_->isComplete();
+}
+
+Loading::LoadProgress ThreadedTreeGenerator::getProgress() const {
+    return jobQueue_->getProgress();
+}
+
+void ThreadedTreeGenerator::waitForAll() {
+    jobQueue_->waitForAll();
+}

--- a/src/vegetation/ThreadedTreeGenerator.h
+++ b/src/vegetation/ThreadedTreeGenerator.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "TreeOptions.h"
+#include "TreeGenerator.h"
+#include "core/loading/LoadJobQueue.h"
+#include <glm/glm.hpp>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <atomic>
+
+/**
+ * ThreadedTreeGenerator - Generates tree meshes in parallel using LoadJobQueue
+ *
+ * Usage:
+ * 1. Create with worker count
+ * 2. Add tree generation requests via queueTree()
+ * 3. Call update() periodically to retrieve completed trees
+ * 4. Upload staged trees to GPU as they complete
+ *
+ * Thread safety:
+ * - queueTree() can be called from any thread
+ * - update() must be called from main thread (retrieves completed jobs)
+ * - Tree mesh generation happens on worker threads (CPU only)
+ */
+class ThreadedTreeGenerator {
+public:
+    /**
+     * Request for tree generation
+     */
+    struct TreeRequest {
+        glm::vec3 position;
+        float rotation = 0.0f;
+        float scale = 1.0f;
+        TreeOptions options;
+        uint32_t archetypeIndex = 0;  // For impostor archetype assignment
+    };
+
+    /**
+     * Completed tree mesh data (CPU-side, ready for GPU upload)
+     */
+    struct StagedTree {
+        // Branch mesh geometry
+        std::vector<uint8_t> branchVertexData;
+        std::vector<uint32_t> branchIndices;
+        uint32_t branchVertexCount = 0;
+
+        // Leaf instance data
+        std::vector<uint8_t> leafInstanceData;  // LeafInstanceGPU structs
+        uint32_t leafInstanceCount = 0;
+
+        // Tree placement
+        glm::vec3 position;
+        float rotation = 0.0f;
+        float scale = 1.0f;
+
+        // Options for texture selection
+        TreeOptions options;
+        uint32_t archetypeIndex = 0;
+
+        // Raw mesh data for collision
+        TreeMeshData meshData;
+    };
+
+    /**
+     * Factory: Create and initialize the threaded generator
+     * @param workerCount Number of worker threads (default: 4)
+     */
+    static std::unique_ptr<ThreadedTreeGenerator> create(uint32_t workerCount = 4);
+
+    ~ThreadedTreeGenerator();
+
+    // Non-copyable, non-movable
+    ThreadedTreeGenerator(const ThreadedTreeGenerator&) = delete;
+    ThreadedTreeGenerator& operator=(const ThreadedTreeGenerator&) = delete;
+
+    /**
+     * Queue a tree for generation on a background thread
+     * Thread-safe: can be called from any thread
+     */
+    void queueTree(const TreeRequest& request);
+
+    /**
+     * Queue multiple trees at once (more efficient)
+     * Thread-safe: can be called from any thread
+     */
+    void queueTrees(const std::vector<TreeRequest>& requests);
+
+    /**
+     * Retrieve completed trees (call from main thread)
+     * Returns trees ready for GPU upload
+     */
+    std::vector<StagedTree> getCompletedTrees();
+
+    /**
+     * Check if all queued trees have been generated
+     */
+    bool isComplete() const;
+
+    /**
+     * Get progress information
+     */
+    Loading::LoadProgress getProgress() const;
+
+    /**
+     * Block until all trees are generated
+     */
+    void waitForAll();
+
+    /**
+     * Get count of pending trees
+     */
+    uint32_t getPendingCount() const { return pendingCount_.load(); }
+
+    /**
+     * Get count of completed trees
+     */
+    uint32_t getCompletedCount() const { return completedCount_.load(); }
+
+private:
+    ThreadedTreeGenerator() = default;
+    bool init(uint32_t workerCount);
+
+    std::unique_ptr<Loading::LoadJobQueue> jobQueue_;
+    std::atomic<uint32_t> pendingCount_{0};
+    std::atomic<uint32_t> completedCount_{0};
+    std::atomic<uint32_t> totalQueued_{0};
+};

--- a/src/vegetation/TreeSystem.h
+++ b/src/vegetation/TreeSystem.h
@@ -79,6 +79,39 @@ public:
 
     // Tree management
     uint32_t addTree(const glm::vec3& position, float rotation, float scale, const TreeOptions& options);
+
+    /**
+     * Add a tree from pre-generated staged data (for threaded loading)
+     * This uploads pre-generated mesh data to GPU without regenerating
+     *
+     * @param position World position
+     * @param rotation Y-axis rotation in radians
+     * @param scale Uniform scale factor
+     * @param options Tree options for texture selection
+     * @param branchVertexData Raw vertex data (Vertex structs)
+     * @param branchVertexCount Number of vertices
+     * @param branchIndices Index buffer data
+     * @param leafInstanceData Raw leaf instance data (LeafInstanceGPU structs)
+     * @param leafInstanceCount Number of leaf instances
+     * @param archetypeIndex Impostor archetype index
+     * @return Tree index, or UINT32_MAX on failure
+     */
+    uint32_t addTreeFromStagedData(
+        const glm::vec3& position, float rotation, float scale,
+        const TreeOptions& options,
+        const std::vector<uint8_t>& branchVertexData,
+        uint32_t branchVertexCount,
+        const std::vector<uint32_t>& branchIndices,
+        const std::vector<uint8_t>& leafInstanceData,
+        uint32_t leafInstanceCount,
+        uint32_t archetypeIndex);
+
+    /**
+     * Batch upload leaf instance buffer after adding multiple trees
+     * Call this after adding all trees to avoid re-uploading for each tree
+     */
+    bool finalizeLeafInstanceBuffer();
+
     void removeTree(uint32_t index);
     void selectTree(int index);
     int getSelectedTreeIndex() const { return selectedTreeIndex_; }


### PR DESCRIPTION
Implements parallel tree generation using LoadJobQueue infrastructure:

- Add StagedTreeMesh struct to LoadJobQueue.h for CPU-side tree data
- Create ThreadedTreeGenerator class that generates tree meshes on worker threads (4 workers by default)
- Add TreeSystem::addTreeFromStagedData() for uploading pre-generated mesh data to GPU without regeneration
- Add TreeSystem::finalizeLeafInstanceBuffer() for batch upload after adding multiple trees
- Modify RendererInitPhases to queue forest trees for parallel generation, continuing with other init work while trees generate

The 500 forest trees are now generated in parallel on 4 worker threads instead of serially on the main thread. Tree mesh generation (CPU work) happens in background while TreeRenderer and TreeLODSystem initialize. GPU upload still happens on main thread after all trees complete.

Includes fallback to serial generation if threaded generator fails.