### PR TITLE
Fix deprecated Vulkan HPP dependency warning

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,7 @@
       "platform": "linux"
     },
     "vulkan",
-    "vulkan-hpp",
+    "vulkan-headers",
     "glm",
     "stb",
     "vk-bootstrap",


### PR DESCRIPTION
The vulkan-hpp vcpkg port is deprecated. This replaces it with vulkan-headers which provides the same vulkan.hpp header files. The CMakeLists.txt was already using find_package(VulkanHeaders), so only the vcpkg dependency needed updating.