### PR TITLE
Migrate terrain files to Vulkan RAII types

### DIFF
--- a/src/core/InitContext.cpp
+++ b/src/core/InitContext.cpp
@@ -10,6 +10,7 @@ InitContext InitContext::build(
     std::optional<DescriptorPoolSizes> poolSizes
 ) {
     InitContext ctx{};
+    ctx.raiiDevice = &vulkanContext.getRaiiDevice();
     ctx.device = vulkanContext.getDevice();
     ctx.physicalDevice = vulkanContext.getPhysicalDevice();
     ctx.allocator = vulkanContext.getAllocator();

--- a/src/core/InitContext.h
+++ b/src/core/InitContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <string>
 #include <cstdint>
@@ -21,6 +22,7 @@ class VulkanContext;
  */
 struct InitContext {
     // Core Vulkan handles (from VulkanContext)
+    const vk::raii::Device* raiiDevice = nullptr;
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;

--- a/src/terrain/TerrainCBT.h
+++ b/src/terrain/TerrainCBT.h
@@ -3,7 +3,7 @@
 #include <vulkan/vulkan.h>
 #include <vk_mem_alloc.h>
 #include <cstdint>
-#include "VulkanRAII.h"
+#include "VmaResources.h"
 
 // Concurrent Binary Tree (CBT) buffer for terrain subdivision
 class TerrainCBT {

--- a/src/terrain/TerrainMeshlet.h
+++ b/src/terrain/TerrainMeshlet.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <vector>
 #include <memory>
-#include "VulkanRAII.h"
+#include "VmaResources.h"
 
 // Pre-subdivided meshlet for terrain rendering
 // Each CBT leaf node is rendered as an instance of this meshlet,

--- a/src/terrain/TerrainPipelines.h
+++ b/src/terrain/TerrainPipelines.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <string>
 #include <memory>
-#include "VulkanRAII.h"
+#include <optional>
 
 struct SubgroupCapabilities;
 class TerrainMeshlet;
@@ -13,6 +14,7 @@ class TerrainMeshlet;
 class TerrainPipelines {
 public:
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
         VkDevice device;
         VkPhysicalDevice physicalDevice;
         VkRenderPass renderPass;
@@ -40,46 +42,46 @@ public:
     TerrainPipelines& operator=(TerrainPipelines&&) = delete;
 
     // Compute pipeline accessors
-    VkPipelineLayout getDispatcherPipelineLayout() const { return dispatcherPipelineLayout_.get(); }
-    VkPipeline getDispatcherPipeline() const { return dispatcherPipeline_.get(); }
+    VkPipelineLayout getDispatcherPipelineLayout() const { return dispatcherPipelineLayout_ ? **dispatcherPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getDispatcherPipeline() const { return dispatcherPipeline_ ? **dispatcherPipeline_ : VK_NULL_HANDLE; }
 
-    VkPipelineLayout getSubdivisionPipelineLayout() const { return subdivisionPipelineLayout_.get(); }
-    VkPipeline getSubdivisionPipeline() const { return subdivisionPipeline_.get(); }
+    VkPipelineLayout getSubdivisionPipelineLayout() const { return subdivisionPipelineLayout_ ? **subdivisionPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getSubdivisionPipeline() const { return subdivisionPipeline_ ? **subdivisionPipeline_ : VK_NULL_HANDLE; }
 
-    VkPipelineLayout getSumReductionPipelineLayout() const { return sumReductionPipelineLayout_.get(); }
-    VkPipeline getSumReductionPrepassPipeline() const { return sumReductionPrepassPipeline_.get(); }
-    VkPipeline getSumReductionPrepassSubgroupPipeline() const { return sumReductionPrepassSubgroupPipeline_.get(); }
-    VkPipeline getSumReductionPipeline() const { return sumReductionPipeline_.get(); }
+    VkPipelineLayout getSumReductionPipelineLayout() const { return sumReductionPipelineLayout_ ? **sumReductionPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getSumReductionPrepassPipeline() const { return sumReductionPrepassPipeline_ ? **sumReductionPrepassPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getSumReductionPrepassSubgroupPipeline() const { return sumReductionPrepassSubgroupPipeline_ ? **sumReductionPrepassSubgroupPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getSumReductionPipeline() const { return sumReductionPipeline_ ? **sumReductionPipeline_ : VK_NULL_HANDLE; }
 
-    VkPipelineLayout getSumReductionBatchedPipelineLayout() const { return sumReductionBatchedPipelineLayout_.get(); }
-    VkPipeline getSumReductionBatchedPipeline() const { return sumReductionBatchedPipeline_.get(); }
+    VkPipelineLayout getSumReductionBatchedPipelineLayout() const { return sumReductionBatchedPipelineLayout_ ? **sumReductionBatchedPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getSumReductionBatchedPipeline() const { return sumReductionBatchedPipeline_ ? **sumReductionBatchedPipeline_ : VK_NULL_HANDLE; }
 
-    VkPipelineLayout getFrustumCullPipelineLayout() const { return frustumCullPipelineLayout_.get(); }
-    VkPipeline getFrustumCullPipeline() const { return frustumCullPipeline_.get(); }
+    VkPipelineLayout getFrustumCullPipelineLayout() const { return frustumCullPipelineLayout_ ? **frustumCullPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getFrustumCullPipeline() const { return frustumCullPipeline_ ? **frustumCullPipeline_ : VK_NULL_HANDLE; }
 
-    VkPipelineLayout getPrepareDispatchPipelineLayout() const { return prepareDispatchPipelineLayout_.get(); }
-    VkPipeline getPrepareDispatchPipeline() const { return prepareDispatchPipeline_.get(); }
+    VkPipelineLayout getPrepareDispatchPipelineLayout() const { return prepareDispatchPipelineLayout_ ? **prepareDispatchPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getPrepareDispatchPipeline() const { return prepareDispatchPipeline_ ? **prepareDispatchPipeline_ : VK_NULL_HANDLE; }
 
     // Render pipeline accessors
-    VkPipelineLayout getRenderPipelineLayout() const { return renderPipelineLayout_.get(); }
-    VkPipeline getRenderPipeline() const { return renderPipeline_.get(); }
-    VkPipeline getWireframePipeline() const { return wireframePipeline_.get(); }
-    VkPipeline getMeshletRenderPipeline() const { return meshletRenderPipeline_.get(); }
-    VkPipeline getMeshletWireframePipeline() const { return meshletWireframePipeline_.get(); }
+    VkPipelineLayout getRenderPipelineLayout() const { return renderPipelineLayout_ ? **renderPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getRenderPipeline() const { return renderPipeline_ ? **renderPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getWireframePipeline() const { return wireframePipeline_ ? **wireframePipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getMeshletRenderPipeline() const { return meshletRenderPipeline_ ? **meshletRenderPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getMeshletWireframePipeline() const { return meshletWireframePipeline_ ? **meshletWireframePipeline_ : VK_NULL_HANDLE; }
 
     // Shadow pipeline accessors
-    VkPipelineLayout getShadowPipelineLayout() const { return shadowPipelineLayout_.get(); }
-    VkPipeline getShadowPipeline() const { return shadowPipeline_.get(); }
-    VkPipeline getMeshletShadowPipeline() const { return meshletShadowPipeline_.get(); }
+    VkPipelineLayout getShadowPipelineLayout() const { return shadowPipelineLayout_ ? **shadowPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getShadowPipeline() const { return shadowPipeline_ ? **shadowPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getMeshletShadowPipeline() const { return meshletShadowPipeline_ ? **meshletShadowPipeline_ : VK_NULL_HANDLE; }
 
     // Shadow culling pipeline accessors
-    VkPipelineLayout getShadowCullPipelineLayout() const { return shadowCullPipelineLayout_.get(); }
-    VkPipeline getShadowCullPipeline() const { return shadowCullPipeline_.get(); }
-    VkPipeline getShadowCulledPipeline() const { return shadowCulledPipeline_.get(); }
-    VkPipeline getMeshletShadowCulledPipeline() const { return meshletShadowCulledPipeline_.get(); }
+    VkPipelineLayout getShadowCullPipelineLayout() const { return shadowCullPipelineLayout_ ? **shadowCullPipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getShadowCullPipeline() const { return shadowCullPipeline_ ? **shadowCullPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getShadowCulledPipeline() const { return shadowCulledPipeline_ ? **shadowCulledPipeline_ : VK_NULL_HANDLE; }
+    VkPipeline getMeshletShadowCulledPipeline() const { return meshletShadowCulledPipeline_ ? **meshletShadowCulledPipeline_ : VK_NULL_HANDLE; }
 
     // Check if shadow culling is available
-    bool hasShadowCulling() const { return static_cast<bool>(shadowCullPipeline_); }
+    bool hasShadowCulling() const { return shadowCullPipeline_.has_value(); }
 
 private:
     TerrainPipelines() = default;  // Private: use factory
@@ -100,6 +102,7 @@ private:
     bool createShadowCullPipelines();
 
     // Stored from InitInfo for pipeline creation
+    const vk::raii::Device* raiiDevice_ = nullptr;
     VkDevice device = VK_NULL_HANDLE;
     VkRenderPass renderPass = VK_NULL_HANDLE;
     VkRenderPass shadowRenderPass = VK_NULL_HANDLE;
@@ -111,41 +114,41 @@ private:
     const SubgroupCapabilities* subgroupCaps = nullptr;
 
     // Compute pipelines
-    ManagedPipelineLayout dispatcherPipelineLayout_;
-    ManagedPipeline dispatcherPipeline_;
+    std::optional<vk::raii::PipelineLayout> dispatcherPipelineLayout_;
+    std::optional<vk::raii::Pipeline> dispatcherPipeline_;
 
-    ManagedPipelineLayout subdivisionPipelineLayout_;
-    ManagedPipeline subdivisionPipeline_;
+    std::optional<vk::raii::PipelineLayout> subdivisionPipelineLayout_;
+    std::optional<vk::raii::Pipeline> subdivisionPipeline_;
 
-    ManagedPipelineLayout sumReductionPipelineLayout_;
-    ManagedPipeline sumReductionPrepassPipeline_;
-    ManagedPipeline sumReductionPrepassSubgroupPipeline_;
-    ManagedPipeline sumReductionPipeline_;
+    std::optional<vk::raii::PipelineLayout> sumReductionPipelineLayout_;
+    std::optional<vk::raii::Pipeline> sumReductionPrepassPipeline_;
+    std::optional<vk::raii::Pipeline> sumReductionPrepassSubgroupPipeline_;
+    std::optional<vk::raii::Pipeline> sumReductionPipeline_;
 
-    ManagedPipelineLayout sumReductionBatchedPipelineLayout_;
-    ManagedPipeline sumReductionBatchedPipeline_;
+    std::optional<vk::raii::PipelineLayout> sumReductionBatchedPipelineLayout_;
+    std::optional<vk::raii::Pipeline> sumReductionBatchedPipeline_;
 
-    ManagedPipelineLayout frustumCullPipelineLayout_;
-    ManagedPipeline frustumCullPipeline_;
+    std::optional<vk::raii::PipelineLayout> frustumCullPipelineLayout_;
+    std::optional<vk::raii::Pipeline> frustumCullPipeline_;
 
-    ManagedPipelineLayout prepareDispatchPipelineLayout_;
-    ManagedPipeline prepareDispatchPipeline_;
+    std::optional<vk::raii::PipelineLayout> prepareDispatchPipelineLayout_;
+    std::optional<vk::raii::Pipeline> prepareDispatchPipeline_;
 
     // Render pipelines
-    ManagedPipelineLayout renderPipelineLayout_;
-    ManagedPipeline renderPipeline_;
-    ManagedPipeline wireframePipeline_;
-    ManagedPipeline meshletRenderPipeline_;
-    ManagedPipeline meshletWireframePipeline_;
+    std::optional<vk::raii::PipelineLayout> renderPipelineLayout_;
+    std::optional<vk::raii::Pipeline> renderPipeline_;
+    std::optional<vk::raii::Pipeline> wireframePipeline_;
+    std::optional<vk::raii::Pipeline> meshletRenderPipeline_;
+    std::optional<vk::raii::Pipeline> meshletWireframePipeline_;
 
     // Shadow pipelines
-    ManagedPipelineLayout shadowPipelineLayout_;
-    ManagedPipeline shadowPipeline_;
-    ManagedPipeline meshletShadowPipeline_;
+    std::optional<vk::raii::PipelineLayout> shadowPipelineLayout_;
+    std::optional<vk::raii::Pipeline> shadowPipeline_;
+    std::optional<vk::raii::Pipeline> meshletShadowPipeline_;
 
     // Shadow culling pipelines
-    ManagedPipelineLayout shadowCullPipelineLayout_;
-    ManagedPipeline shadowCullPipeline_;
-    ManagedPipeline shadowCulledPipeline_;
-    ManagedPipeline meshletShadowCulledPipeline_;
+    std::optional<vk::raii::PipelineLayout> shadowCullPipelineLayout_;
+    std::optional<vk::raii::Pipeline> shadowCullPipeline_;
+    std::optional<vk::raii::Pipeline> shadowCulledPipeline_;
+    std::optional<vk::raii::Pipeline> meshletShadowCulledPipeline_;
 };

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -27,6 +27,11 @@ TerrainSystem::~TerrainSystem() {
 }
 
 bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg) {
+    if (!info.raiiDevice) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TerrainSystem: raiiDevice is null");
+        return false;
+    }
+    raiiDevice_ = info.raiiDevice;
     device = info.device;
     physicalDevice = info.physicalDevice;
     allocator = info.allocator;
@@ -47,6 +52,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
 
     // Initialize textures with RAII wrapper
     TerrainTextures::InitInfo texturesInfo{};
+    texturesInfo.raiiDevice = raiiDevice_;
     texturesInfo.device = device;
     texturesInfo.allocator = allocator;
     texturesInfo.graphicsQueue = graphicsQueue;
@@ -85,6 +91,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
     // Initialize tile cache for LOD-based height streaming (if configured) with RAII wrapper
     if (!config.tileCacheDir.empty()) {
         TerrainTileCache::InitInfo tileCacheInfo{};
+        tileCacheInfo.raiiDevice = raiiDevice_;
         tileCacheInfo.cacheDirectory = config.tileCacheDir;
         tileCacheInfo.device = device;
         tileCacheInfo.allocator = allocator;
@@ -148,6 +155,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
 
     // Initialize pipelines subsystem (RAII-managed)
     TerrainPipelines::InitInfo pipelineInfo{};
+    pipelineInfo.raiiDevice = raiiDevice_;
     pipelineInfo.device = device;
     pipelineInfo.physicalDevice = physicalDevice;
     pipelineInfo.renderPass = renderPass;
@@ -169,6 +177,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
 
 bool TerrainSystem::initInternal(const InitContext& ctx, const TerrainInitParams& params, const TerrainConfig& cfg) {
     InitInfo info{};
+    info.raiiDevice = ctx.raiiDevice;
     info.device = ctx.device;
     info.physicalDevice = ctx.physicalDevice;
     info.allocator = ctx.allocator;

--- a/src/terrain/TerrainSystem.h
+++ b/src/terrain/TerrainSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
 #include <vector>
@@ -124,6 +125,7 @@ struct TerrainConfig {
 class TerrainSystem : public ITerrainControl {
 public:
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
         vk::Device device;
         vk::PhysicalDevice physicalDevice;
         VmaAllocator allocator;
@@ -320,6 +322,7 @@ private:
     void querySubgroupCapabilities();
 
     // Vulkan resources
+    const vk::raii::Device* raiiDevice_ = nullptr;
     vk::Device device;
     vk::PhysicalDevice physicalDevice;
     VmaAllocator allocator = VK_NULL_HANDLE;

--- a/src/terrain/TerrainTextures.h
+++ b/src/terrain/TerrainTextures.h
@@ -1,14 +1,17 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <string>
-#include "VulkanRAII.h"
+#include <optional>
+#include "VmaResources.h"
 
 // Terrain textures - albedo and grass far LOD textures
 class TerrainTextures {
 public:
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
         VkDevice device;
         VmaAllocator allocator;
         VkQueue graphicsQueue;
@@ -24,11 +27,11 @@ public:
 
     // Terrain albedo texture
     VkImageView getAlbedoView() const { return albedoView; }
-    VkSampler getAlbedoSampler() const { return albedoSampler.get(); }
+    VkSampler getAlbedoSampler() const { return albedoSampler_ ? **albedoSampler_ : VK_NULL_HANDLE; }
 
     // Grass far LOD texture (for terrain blending at distance)
     VkImageView getGrassFarLODView() const { return grassFarLODView; }
-    VkSampler getGrassFarLODSampler() const { return grassFarLODSampler.get(); }
+    VkSampler getGrassFarLODSampler() const { return grassFarLODSampler_ ? **grassFarLODSampler_ : VK_NULL_HANDLE; }
 
 private:
     bool createAlbedoTexture();
@@ -38,6 +41,7 @@ private:
     bool generateMipmaps(VkImage image, uint32_t width, uint32_t height, uint32_t mipLevels);
 
     // Init params
+    const vk::raii::Device* raiiDevice_ = nullptr;
     VkDevice device = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
     VkQueue graphicsQueue = VK_NULL_HANDLE;
@@ -48,13 +52,13 @@ private:
     VkImage albedoImage = VK_NULL_HANDLE;
     VmaAllocation albedoAllocation = VK_NULL_HANDLE;
     VkImageView albedoView = VK_NULL_HANDLE;
-    ManagedSampler albedoSampler;
+    std::optional<vk::raii::Sampler> albedoSampler_;
     uint32_t albedoMipLevels = 1;
 
     // Grass far LOD texture
     VkImage grassFarLODImage = VK_NULL_HANDLE;
     VmaAllocation grassFarLODAllocation = VK_NULL_HANDLE;
     VkImageView grassFarLODView = VK_NULL_HANDLE;
-    ManagedSampler grassFarLODSampler;
+    std::optional<vk::raii::Sampler> grassFarLODSampler_;
     uint32_t grassFarLODMipLevels = 1;
 };


### PR DESCRIPTION
Replace custom ManagedPipeline/ManagedPipelineLayout/ManagedSampler wrappers with standard vk::raii types from vulkan-hpp:
- TerrainPipelines: All pipelines and layouts to std::optional<vk::raii::*>
- TerrainTextures: ManagedSampler to std::optional<vk::raii::Sampler>
- TerrainTileCache: ManagedSampler to std::optional<vk::raii::Sampler>
- TerrainCBT/TerrainMeshlet: Update includes (only use VmaBuffer)

Pass raiiDevice through initialization chain:
- Add raiiDevice to InitContext
- Pass through TerrainSystem to sub-components

Part of VulkanRAII.h removal effort.