### PR TITLE
Migrate virtual texture files to vk::raii

### DIFF
--- a/src/core/InitContext.cpp
+++ b/src/core/InitContext.cpp
@@ -13,6 +13,7 @@ InitContext InitContext::build(
     ctx.device = vulkanContext.getDevice();
     ctx.physicalDevice = vulkanContext.getPhysicalDevice();
     ctx.allocator = vulkanContext.getAllocator();
+    ctx.raiiDevice = &vulkanContext.getRaiiDevice();
     ctx.graphicsQueue = vulkanContext.getGraphicsQueue();
     ctx.commandPool = cmdPool;
     ctx.descriptorPool = descPool;

--- a/src/core/InitContext.h
+++ b/src/core/InitContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <string>
 #include <cstdint>
@@ -24,6 +25,7 @@ struct InitContext {
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
+    const vk::raii::Device* raiiDevice = nullptr;
 
     // Queue for one-time command submission (uploads, etc.)
     VkQueue graphicsQueue = VK_NULL_HANDLE;

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -30,6 +30,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
     device = info.device;
     physicalDevice = info.physicalDevice;
     allocator = info.allocator;
+    raiiDevice_ = info.raiiDevice;
     renderPass = info.renderPass;
     shadowRenderPass = info.shadowRenderPass;
     descriptorPool = info.descriptorPool;
@@ -118,8 +119,17 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
         vtConfig.borderPixels = 4;
         vtConfig.maxMipLevels = 6;
 
-        if (!virtualTexture->init(device, allocator, commandPool, graphicsQueue,
-                                   config.virtualTextureTileDir, vtConfig, framesInFlight)) {
+        VirtualTexture::VirtualTextureSystem::InitInfo vtInfo;
+        vtInfo.raiiDevice = raiiDevice_;
+        vtInfo.device = device;
+        vtInfo.allocator = allocator;
+        vtInfo.commandPool = commandPool;
+        vtInfo.queue = graphicsQueue;
+        vtInfo.tilePath = config.virtualTextureTileDir;
+        vtInfo.config = vtConfig;
+        vtInfo.framesInFlight = framesInFlight;
+
+        if (!virtualTexture->init(vtInfo)) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize virtual texture system");
             virtualTexture.reset();
         } else {
@@ -172,6 +182,7 @@ bool TerrainSystem::initInternal(const InitContext& ctx, const TerrainInitParams
     info.device = ctx.device;
     info.physicalDevice = ctx.physicalDevice;
     info.allocator = ctx.allocator;
+    info.raiiDevice = ctx.raiiDevice;
     info.renderPass = params.renderPass;
     info.shadowRenderPass = params.shadowRenderPass;
     info.descriptorPool = ctx.descriptorPool;

--- a/src/terrain/TerrainSystem.h
+++ b/src/terrain/TerrainSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
 #include <vector>
@@ -127,6 +128,7 @@ public:
         vk::Device device;
         vk::PhysicalDevice physicalDevice;
         VmaAllocator allocator;
+        const vk::raii::Device* raiiDevice = nullptr;
         vk::RenderPass renderPass;
         vk::RenderPass shadowRenderPass;
         DescriptorManager::Pool* descriptorPool;  // Auto-growing pool
@@ -323,6 +325,7 @@ private:
     vk::Device device;
     vk::PhysicalDevice physicalDevice;
     VmaAllocator allocator = VK_NULL_HANDLE;
+    const vk::raii::Device* raiiDevice_ = nullptr;
     vk::RenderPass renderPass;
     vk::RenderPass shadowRenderPass;
     DescriptorManager::Pool* descriptorPool = nullptr;

--- a/src/terrain/virtual_texture/VirtualTextureFeedback.h
+++ b/src/terrain/virtual_texture/VirtualTextureFeedback.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "VirtualTextureTypes.h"
-#include "VulkanRAII.h"
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <vector>
 #include <unordered_set>
 #include <memory>
+#include <optional>
+#include "VmaResources.h"
 
 namespace VirtualTexture {
 
@@ -93,10 +95,10 @@ private:
     void cleanup();
 
     struct FrameBuffer {
-        ManagedBuffer feedbackBuffer;
-        ManagedBuffer counterBuffer;
-        ManagedBuffer readbackBuffer;
-        ManagedBuffer counterReadbackBuffer;
+        VmaBuffer feedbackBuffer;
+        VmaBuffer counterBuffer;
+        VmaBuffer readbackBuffer;
+        VmaBuffer counterReadbackBuffer;
         void* readbackMapped = nullptr;
         void* counterReadbackMapped = nullptr;
     };

--- a/src/terrain/virtual_texture/VirtualTextureSystem.h
+++ b/src/terrain/virtual_texture/VirtualTextureSystem.h
@@ -7,6 +7,7 @@
 #include "VirtualTextureTileLoader.h"
 #include "RAIIAdapter.h"
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <string>
 #include <vector>
@@ -42,22 +43,22 @@ public:
     VirtualTextureSystem(const VirtualTextureSystem&) = delete;
     VirtualTextureSystem& operator=(const VirtualTextureSystem&) = delete;
 
+    struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
+        VkDevice device = VK_NULL_HANDLE;
+        VmaAllocator allocator = VK_NULL_HANDLE;
+        VkCommandPool commandPool = VK_NULL_HANDLE;
+        VkQueue queue = VK_NULL_HANDLE;
+        std::string tilePath;
+        VirtualTextureConfig config;
+        uint32_t framesInFlight = 2;
+    };
+
     /**
      * Initialize the virtual texture system
-     * @param device Vulkan device
-     * @param allocator VMA allocator
-     * @param commandPool Command pool for one-time commands
-     * @param queue Graphics queue
-     * @param tilePath Path to pre-generated tile directory
-     * @param cfg Configuration options
-     * @param framesInFlight Number of frames in flight for synchronization
      * @return true on success
      */
-    bool init(VkDevice device, VmaAllocator allocator,
-              VkCommandPool commandPool, VkQueue queue,
-              const std::string& tilePath,
-              const VirtualTextureConfig& cfg = VirtualTextureConfig{},
-              uint32_t framesInFlight = 2);
+    bool init(const InitInfo& info);
 
     /**
      * Destroy all resources


### PR DESCRIPTION
Replace VulkanRAII.h with vk::raii types in virtual texture system:
- VirtualTextureCache: ManagedSampler → std::optional<vk::raii::Sampler>
- VirtualTextureFeedback: Update includes (ManagedBuffer → VmaBuffer)
- VirtualTexturePageTable: ManagedSampler → std::optional<vk::raii::Sampler>
- VirtualTextureSystem: Add InitInfo struct with raiiDevice

Changes:
- Add raiiDevice to InitContext for propagation through subsystems
- Add raiiDevice to TerrainSystem::InitInfo for VT system init
- Replace factory function calls with InitInfo structs
- Update sampler creation to use vk::raii::Sampler::emplace()