### PR TITLE
Migrate vegetation files to vk::raii types

### DIFF
--- a/src/core/InitContext.h
+++ b/src/core/InitContext.h
@@ -27,9 +27,6 @@ struct InitContext {
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
 
-    // vulkan-hpp RAII device for creating vk::raii::* objects
-    const vk::raii::Device* raiiDevice = nullptr;
-
     // Queue for one-time command submission (uploads, etc.)
     VkQueue graphicsQueue = VK_NULL_HANDLE;
     VkCommandPool commandPool = VK_NULL_HANDLE;

--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -350,6 +350,7 @@ bool Renderer::initSubsystems(const InitContext& initCtx) {
     // Initialize TreeRenderer for dedicated tree shaders with wind animation
     {
         TreeRenderer::InitInfo treeRendererInfo{};
+        treeRendererInfo.raiiDevice = &vulkanContext_->getRaiiDevice();
         treeRendererInfo.device = vk::Device(device);
         treeRendererInfo.physicalDevice = vk::PhysicalDevice(physicalDevice);
         treeRendererInfo.allocator = allocator;

--- a/src/vegetation/ImpostorCullSystem.h
+++ b/src/vegetation/ImpostorCullSystem.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
 #include <vector>
 #include <memory>
 #include <string>
+#include <optional>
 
 #include "CullCommon.h"
-#include "VulkanRAII.h"
 #include "DescriptorManager.h"
 #include "BufferUtils.h"
 
@@ -68,6 +69,7 @@ struct ImpostorOutputData {
 class ImpostorCullSystem {
 public:
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
         VkDevice device;
         VkPhysicalDevice physicalDevice;
         VmaAllocator allocator;
@@ -184,6 +186,7 @@ private:
 
     void updateHiZDescriptor(uint32_t frameIndex, VkImageView hiZPyramidView, VkSampler hiZSampler);
 
+    const vk::raii::Device* raiiDevice_ = nullptr;
     VkDevice device_ = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice_ = VK_NULL_HANDLE;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
@@ -195,9 +198,9 @@ private:
     uint32_t maxArchetypes_ = 0;
 
     // Compute pipeline
-    ManagedPipeline cullPipeline_;
-    ManagedPipelineLayout cullPipelineLayout_;
-    ManagedDescriptorSetLayout cullDescriptorSetLayout_;
+    std::optional<vk::raii::Pipeline> cullPipeline_;
+    std::optional<vk::raii::PipelineLayout> cullPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> cullDescriptorSetLayout_;
 
     // Per-frame descriptor sets
     std::vector<VkDescriptorSet> cullDescriptorSets_;

--- a/src/vegetation/TreeLODSystem.h
+++ b/src/vegetation/TreeLODSystem.h
@@ -7,9 +7,9 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <optional>
 
 #include "TreeImpostorAtlas.h"
-#include "VulkanRAII.h"
 #include "DescriptorManager.h"
 
 class TreeSystem;
@@ -175,6 +175,7 @@ private:
     bool createBillboardMesh();
     void updateInstanceBuffer(const std::vector<ImpostorInstanceGPU>& instances);
 
+    const vk::raii::Device* raiiDevice_ = nullptr;
     VkDevice device_ = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice_ = VK_NULL_HANDLE;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
@@ -195,14 +196,14 @@ private:
     std::vector<TreeLODState> lodStates_;
 
     // Impostor rendering pipeline
-    ManagedPipeline impostorPipeline_;
-    ManagedPipelineLayout impostorPipelineLayout_;
-    ManagedDescriptorSetLayout impostorDescriptorSetLayout_;
+    std::optional<vk::raii::Pipeline> impostorPipeline_;
+    std::optional<vk::raii::PipelineLayout> impostorPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> impostorDescriptorSetLayout_;
 
     // Shadow rendering pipeline
-    ManagedPipeline shadowPipeline_;
-    ManagedPipelineLayout shadowPipelineLayout_;
-    ManagedDescriptorSetLayout shadowDescriptorSetLayout_;
+    std::optional<vk::raii::Pipeline> shadowPipeline_;
+    std::optional<vk::raii::PipelineLayout> shadowPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> shadowDescriptorSetLayout_;
 
     // Per-frame descriptor sets
     std::vector<VkDescriptorSet> impostorDescriptorSets_;

--- a/src/vegetation/TreeRenderer.h
+++ b/src/vegetation/TreeRenderer.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
 #include <vector>
 #include <string>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -13,7 +15,6 @@
 #include "TreeLODSystem.h"
 #include "TreeLeafCulling.h"
 #include "TreeBranchCulling.h"
-#include "VulkanRAII.h"
 #include "DescriptorManager.h"
 
 // Push constants for tree rendering
@@ -53,6 +54,7 @@ struct TreeBranchShadowInstancedPushConstants {
 class TreeRenderer {
 public:
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;
         vk::Device device;
         vk::PhysicalDevice physicalDevice;
         VmaAllocator allocator;
@@ -179,6 +181,7 @@ private:
     bool createDescriptorSetLayout();
     bool allocateDescriptorSets(uint32_t maxFramesInFlight);
 
+    const vk::raii::Device* raiiDevice_ = nullptr;
     vk::Device device_;
     vk::PhysicalDevice physicalDevice_;
     VmaAllocator allocator_ = VK_NULL_HANDLE;
@@ -188,20 +191,20 @@ private:
     uint32_t maxFramesInFlight_ = 0;
 
     // Graphics Pipelines
-    ManagedPipeline branchPipeline_;
-    ManagedPipeline leafPipeline_;
-    ManagedPipeline branchShadowPipeline_;
-    ManagedPipeline leafShadowPipeline_;
+    std::optional<vk::raii::Pipeline> branchPipeline_;
+    std::optional<vk::raii::Pipeline> leafPipeline_;
+    std::optional<vk::raii::Pipeline> branchShadowPipeline_;
+    std::optional<vk::raii::Pipeline> leafShadowPipeline_;
 
     // Pipeline layouts
-    ManagedPipelineLayout branchPipelineLayout_;
-    ManagedPipelineLayout leafPipelineLayout_;
-    ManagedPipelineLayout branchShadowPipelineLayout_;
-    ManagedPipelineLayout leafShadowPipelineLayout_;
+    std::optional<vk::raii::PipelineLayout> branchPipelineLayout_;
+    std::optional<vk::raii::PipelineLayout> leafPipelineLayout_;
+    std::optional<vk::raii::PipelineLayout> branchShadowPipelineLayout_;
+    std::optional<vk::raii::PipelineLayout> leafShadowPipelineLayout_;
 
     // Descriptor set layouts
-    ManagedDescriptorSetLayout branchDescriptorSetLayout_;
-    ManagedDescriptorSetLayout leafDescriptorSetLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> branchDescriptorSetLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> leafDescriptorSetLayout_;
 
     // Per-frame descriptor sets (indexed by frame, then by texture type)
     std::vector<std::unordered_map<std::string, vk::DescriptorSet>> branchDescriptorSets_;
@@ -227,8 +230,8 @@ private:
     std::unique_ptr<TreeBranchCulling> branchShadowCulling_;
 
     // Instanced branch shadow rendering pipeline
-    ManagedPipeline branchShadowInstancedPipeline_;
-    ManagedPipelineLayout branchShadowInstancedPipelineLayout_;
-    ManagedDescriptorSetLayout branchShadowInstancedDescriptorSetLayout_;
+    std::optional<vk::raii::Pipeline> branchShadowInstancedPipeline_;
+    std::optional<vk::raii::PipelineLayout> branchShadowInstancedPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> branchShadowInstancedDescriptorSetLayout_;
     std::vector<vk::DescriptorSet> branchShadowInstancedDescriptorSets_;
 };


### PR DESCRIPTION
Replace custom VulkanRAII.h wrappers (ManagedPipeline, ManagedPipelineLayout, ManagedDescriptorSetLayout) with std::optional wrapped vk::raii types from vulkan-hpp.

Files migrated:
- TreeRenderer.h/.cpp
- TreeLODSystem.h/.cpp
- TreeLeafCulling.h/.cpp
- ImpostorCullSystem.h/.cpp

The migration uses std::optional<vk::raii::*> for nullable RAII resources, allowing proper lifecycle management without custom wrapper types.