### PR TITLE
Migrate core files to vk::raii types

### DIFF
--- a/src/animation/SkinnedMesh.cpp
+++ b/src/animation/SkinnedMesh.cpp
@@ -1,5 +1,6 @@
 #include "SkinnedMesh.h"
-#include "VulkanRAII.h"
+#include "VmaResources.h"
+#include "VulkanHelpers.h"
 #include <SDL3/SDL_log.h>
 #include <vulkan/vulkan.hpp>
 #include <cstring>

--- a/src/animation/SkinnedMeshRenderer.h
+++ b/src/animation/SkinnedMeshRenderer.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <vk_mem_alloc.h>
 #include <glm/glm.hpp>
 #include <vector>
 #include <string>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "SkinnedMesh.h"
 #include "DescriptorManager.h"
@@ -14,7 +16,6 @@
 #include "RenderableBuilder.h"
 #include "GlobalBufferManager.h"
 #include "BufferUtils.h"
-#include "VulkanRAII.h"
 
 class AnimatedCharacter;
 
@@ -33,6 +34,7 @@ public:
         std::string shaderPath;
         uint32_t framesInFlight;
         AddCommonBindingsCallback addCommonBindings;
+        const vk::raii::Device* raiiDevice = nullptr;
     };
 
     // Resources needed for descriptor set writing
@@ -93,9 +95,9 @@ public:
     void setExtent(VkExtent2D newExtent) { extent = newExtent; }
 
     // Accessors for ShadowSystem integration
-    VkDescriptorSetLayout getDescriptorSetLayout() const { return descriptorSetLayout_.get(); }
-    VkPipelineLayout getPipelineLayout() const { return pipelineLayout_.get(); }
-    VkPipeline getPipeline() const { return pipeline_.get(); }
+    VkDescriptorSetLayout getDescriptorSetLayout() const { return descriptorSetLayout_ ? **descriptorSetLayout_ : VK_NULL_HANDLE; }
+    VkPipelineLayout getPipelineLayout() const { return pipelineLayout_ ? **pipelineLayout_ : VK_NULL_HANDLE; }
+    VkPipeline getPipeline() const { return pipeline_ ? **pipeline_ : VK_NULL_HANDLE; }
     VkDescriptorSet getDescriptorSet(uint32_t frameIndex) const { return descriptorSets[frameIndex]; }
 
 private:
@@ -116,11 +118,12 @@ private:
     std::string shaderPath;
     uint32_t framesInFlight = 0;
     AddCommonBindingsCallback addCommonBindings;
+    const vk::raii::Device* raiiDevice_ = nullptr;
 
     // Created resources (RAII-managed)
-    ManagedDescriptorSetLayout descriptorSetLayout_;
-    ManagedPipelineLayout pipelineLayout_;
-    ManagedPipeline pipeline_;
+    std::optional<vk::raii::DescriptorSetLayout> descriptorSetLayout_;
+    std::optional<vk::raii::PipelineLayout> pipelineLayout_;
+    std::optional<vk::raii::Pipeline> pipeline_;
 
     std::vector<VkDescriptorSet> descriptorSets;
     BufferUtils::PerFrameBufferSet boneMatricesBuffers;

--- a/src/atmosphere/AtmosphereLUTExport.cpp
+++ b/src/atmosphere/AtmosphereLUTExport.cpp
@@ -1,6 +1,6 @@
 #include "AtmosphereLUTSystem.h"
 #include "VulkanBarriers.h"
-#include "VulkanRAII.h"
+#include "VmaResources.h"
 #include <SDL3/SDL_log.h>
 #include <vulkan/vulkan.hpp>
 #include <vector>

--- a/src/core/Mesh.cpp
+++ b/src/core/Mesh.cpp
@@ -1,5 +1,6 @@
 #include "Mesh.h"
-#include "VulkanRAII.h"
+#include "VmaResources.h"
+#include "VulkanHelpers.h"
 #include "VulkanResourceFactory.h"
 #include <vulkan/vulkan.hpp>
 #include <cstring>

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -1639,6 +1639,7 @@ void Renderer::recordHDRPass(VkCommandBuffer cmd, uint32_t frameIndex, float gra
 bool Renderer::initSkinnedMeshRenderer() {
     SkinnedMeshRenderer::InitInfo info{};
     info.device = vulkanContext_->getDevice();
+    info.raiiDevice = &vulkanContext_->getRaiiDevice();
     info.allocator = vulkanContext_->getAllocator();
     info.descriptorPool = &*descriptorManagerPool;
     info.renderPass = systems_->postProcess().getHDRRenderPass();

--- a/src/postprocess/BloomSystem.cpp
+++ b/src/postprocess/BloomSystem.cpp
@@ -107,19 +107,19 @@ bool BloomSystem::createMipChain() {
 
         // Create image using ImageBuilder
         ManagedImage managedImage;
-        ManagedImageView managedView;
+        VkImageView imageView;
         if (!ImageBuilder(allocator)
                 .setExtent(width, height)
                 .setFormat(BLOOM_FORMAT)
                 .asColorAttachment()
                 .setGpuOnly()
-                .build(device, managedImage, managedView)) {
+                .build(device, managedImage, imageView)) {
             return false;
         }
 
         // Release to raw handles (BloomSystem uses raw handles for mip chain)
         managedImage.releaseToRaw(mip.image, mip.allocation);
-        mip.imageView = managedView.release();
+        mip.imageView = imageView;
 
         mipChain.push_back(mip);
     }

--- a/src/postprocess/HiZSystem.h
+++ b/src/postprocess/HiZSystem.h
@@ -122,7 +122,7 @@ public:
     uint32_t getVisibleCount(uint32_t frameIndex) const;
 
     // Hi-Z pyramid access (for debugging/visualization and external occlusion culling)
-    VkImageView getHiZPyramidView() const { return hiZPyramid.fullView.get(); }
+    VkImageView getHiZPyramidView() const { return hiZPyramid.fullView ? **hiZPyramid.fullView : VK_NULL_HANDLE; }
     VkSampler getHiZSampler() const { return hiZSampler_ ? **hiZSampler_ : VK_NULL_HANDLE; }
     VkImageView getHiZMipView(uint32_t mipLevel) const;
     uint32_t getMipLevelCount() const { return mipLevelCount; }


### PR DESCRIPTION
Replace custom RAII wrappers with standard vulkan-hpp RAII types:
- ImageBuilder: MipChainBuilder now uses std::optional<vk::raii::ImageView>
- SkinnedMeshRenderer: Use std::optional<vk::raii::*> for pipeline objects
- Texture: Use direct Vulkan API calls instead of ManagedImageView/Sampler
- Simple includes update for SkinnedMesh, Mesh, AtmosphereLUTExport

Updated HiZSystem and BloomSystem for API compatibility. Added raiiDevice to SkinnedMeshRenderer initialization in Renderer.cpp.