### PR TITLE
Fix tree textures at full LOD

### DIFF
--- a/src/core/loading/LoadJobQueue.h
+++ b/src/core/loading/LoadJobQueue.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <variant>
+#include "vegetation/TreeOptions.h"
 
 /**
  * LoadJobQueue - Generic async job queue for startup loading
@@ -110,8 +111,8 @@ struct StagedTreeMesh : public StagedResource {
     float rotation = 0.0f;
     float scale = 1.0f;
 
-    // Tree options index (references pre-loaded options)
-    uint32_t optionsIndex = 0;
+    // Tree options for texture selection (bark/leaf types)
+    TreeOptions options;
 
     // For impostor archetype assignment
     uint32_t archetypeIndex = 0;

--- a/src/vegetation/ThreadedTreeGenerator.cpp
+++ b/src/vegetation/ThreadedTreeGenerator.cpp
@@ -160,6 +160,7 @@ void ThreadedTreeGenerator::queueTree(const TreeRequest& request) {
         staged->rotation = request.rotation;
         staged->scale = request.scale;
         staged->archetypeIndex = request.archetypeIndex;
+        staged->options = request.options;
 
         return staged;
     };
@@ -296,6 +297,7 @@ void ThreadedTreeGenerator::queueTrees(const std::vector<TreeRequest>& requests)
             staged->rotation = request.rotation;
             staged->scale = request.scale;
             staged->archetypeIndex = request.archetypeIndex;
+            staged->options = request.options;
 
             return staged;
         };
@@ -340,6 +342,7 @@ std::vector<ThreadedTreeGenerator::StagedTree> ThreadedTreeGenerator::getComplet
         tree.rotation = stagedMesh->rotation;
         tree.scale = stagedMesh->scale;
         tree.archetypeIndex = stagedMesh->archetypeIndex;
+        tree.options = std::move(stagedMesh->options);
 
         trees.push_back(std::move(tree));
         pendingCount_--;


### PR DESCRIPTION
The threaded tree generator was not propagating TreeOptions through the staged mesh pipeline. StagedTreeMesh only stored archetypeIndex but not the actual options, so forest trees ended up with default empty options which caused them to fall back to default textures.

Fixed by:
- Adding TreeOptions field to StagedTreeMesh in LoadJobQueue.h
- Storing request.options in the staged mesh during tree generation
- Transferring options from stagedMesh to StagedTree in getCompletedTrees()

This ensures bark and leaf types are preserved when trees are generated on worker threads and uploaded to the GPU.