### PR TITLE
Port key algorithms from mfcg.js reference to town_generator

### DIFF
--- a/tools/town_generator/CMakeLists.txt
+++ b/tools/town_generator/CMakeLists.txt
@@ -26,6 +26,9 @@ set(BUILDING_SOURCES
     src/building/Cutter.cpp
     src/building/Topology.cpp
     src/building/CurtainWall.cpp
+    src/building/Canal.cpp
+    src/building/WardGroup.cpp
+    src/building/Block.cpp
     src/building/Model.cpp
 )
 

--- a/tools/town_generator/include/town_generator/building/Block.h
+++ b/tools/town_generator/include/town_generator/building/Block.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "town_generator/geom/Point.h"
+#include "town_generator/geom/Polygon.h"
+#include "town_generator/wards/Ward.h"
+#include <vector>
+#include <map>
+
+namespace town_generator {
+namespace building {
+
+class WardGroup;
+
+/**
+ * Block - A city block within a WardGroup
+ *
+ * Faithful port from mfcg.js Block class (lines 12176-12287).
+ * A Block is created by recursive alley subdivision and contains:
+ * - shape: the block perimeter polygon
+ * - lots: individual building lots from TwistedBlock partitioning
+ * - rects: rectangular approximations of lots (for simple rendering)
+ * - buildings: complex building shapes (from Dwellings engine)
+ * - courtyard: inner lots filtered out during building creation
+ */
+class Block {
+public:
+    // The perimeter shape of this block
+    geom::Polygon shape;
+
+    // The WardGroup this block belongs to
+    WardGroup* group = nullptr;
+
+    // Building lots from TwistedBlock partitioning
+    std::vector<geom::Polygon> lots;
+
+    // Rectangular approximations of lots (createRects output)
+    std::vector<geom::Polygon> rects;
+
+    // Complex building shapes (createBuildings output)
+    std::vector<geom::Polygon> buildings;
+
+    // Inner (courtyard) lots filtered out of buildings
+    std::vector<geom::Polygon> courtyard;
+
+    // Cache for polygon areas (optimization from mfcg.js)
+    std::map<const geom::Polygon*, double> cacheArea;
+
+    // Cache for OBBs (optimization from mfcg.js)
+    std::map<const geom::Polygon*, std::vector<geom::Point>> cacheOBB;
+
+    // Center point of the block (cached)
+    geom::Point center;
+    bool centerComputed = false;
+
+    Block() = default;
+    explicit Block(const geom::Polygon& shape, WardGroup* group = nullptr);
+
+    // Create lots using TwistedBlock partitioning algorithm
+    // Faithful to mfcg.js TwistedBlock.createLots (lines 12287-12325)
+    void createLots();
+
+    // Convert lots to rectangular approximations
+    // Faithful to mfcg.js Block.createRects (lines 12177-12220)
+    void createRects();
+
+    // Create building shapes from rectangles
+    // Faithful to mfcg.js Block.createBuildings (lines 12221-12252)
+    void createBuildings();
+
+    // Filter out inner lots that don't touch the block perimeter
+    // Faithful to mfcg.js Block.filterInner (lines 12253-12286)
+    // Returns inner lots, removes them from lots vector
+    std::vector<geom::Polygon> filterInner();
+
+    // Indent lots away from block center for setback variation
+    // Faithful to mfcg.js Block.indentFronts (lines 12287-12302)
+    void indentFronts();
+
+    // Spawn trees in courtyard areas
+    // Faithful to mfcg.js Block.spawnTrees (lines 12303-12325)
+    std::vector<geom::Point> spawnTrees();
+
+    // Get cached area of a polygon
+    double getArea(const geom::Polygon& poly);
+
+    // Get cached OBB of a polygon
+    std::vector<geom::Point> getOBB(const geom::Polygon& poly);
+
+    // Check if a polygon is approximately rectangular
+    // Faithful to mfcg.js Block.isRectangle (lines 12213-12219)
+    bool isRectangle(const geom::Polygon& poly);
+
+    // Get the center of this block (cached)
+    geom::Point getCenter();
+
+private:
+    // Check if a lot edge converges with any block edge
+    bool edgeConvergesWithBlock(const geom::Point& v0, const geom::Point& v1) const;
+};
+
+/**
+ * TwistedBlock - Partitioning algorithm for irregular block shapes
+ *
+ * Faithful port from mfcg.js TwistedBlock (lines 12267-12325).
+ * Creates building lots by recursive subdivision with non-axis-aligned cuts.
+ */
+class TwistedBlock {
+public:
+    // Create lots from a block shape
+    // minSq: minimum lot area
+    // sizeChaos: variation in lot sizes (0-1)
+    static std::vector<geom::Polygon> createLots(
+        Block* block,
+        const wards::AlleyParams& params
+    );
+
+private:
+    // Recursive partitioning
+    static void partition(
+        const geom::Polygon& shape,
+        double minSq,
+        double sizeChaos,
+        double minTurnOffset,
+        std::vector<geom::Polygon>& result
+    );
+};
+
+} // namespace building
+} // namespace town_generator

--- a/tools/town_generator/include/town_generator/building/EdgeData.h
+++ b/tools/town_generator/include/town_generator/building/EdgeData.h
@@ -1,0 +1,68 @@
+#pragma once
+
+namespace town_generator {
+namespace building {
+
+/**
+ * EdgeData - Edge type classification from mfcg.js (Tc enum)
+ *
+ * Used to track what type of feature each edge of a patch borders.
+ * This enables proper inset calculations in getAvailable() and correct
+ * rendering of different edge types.
+ *
+ * Reference: mfcg.js lines 11136-11150
+ */
+enum class EdgeType {
+    NONE = 0,       // No special data (interior edge between patches)
+    COAST = 1,      // Edge borders water (sea, lake)
+    ROAD = 2,       // Edge borders a road/artery
+    WALL = 3,       // Edge borders a city wall
+    CANAL = 4,      // Edge borders a canal/river
+    HORIZON = 5     // Edge is on the map boundary
+};
+
+/**
+ * Get inset distance for an edge type (faithful to mfcg.js getAvailable)
+ *
+ * Reference: mfcg.js lines 12359-12379
+ */
+inline double getEdgeInset(EdgeType type, bool isLanding = false, double canalWidth = 0.0) {
+    switch (type) {
+        case EdgeType::COAST:
+            return isLanding ? 2.0 : 1.2;  // Harbor landing vs regular coast
+        case EdgeType::ROAD:
+            return 1.0;  // pc.THICKNESS / 2
+        case EdgeType::WALL:
+            return 1.5 / 2.0 + 1.2;  // pc.THICKNESS / 2 + ALLEY
+        case EdgeType::CANAL:
+            return canalWidth / 2.0 + 1.2;  // canal width / 2 + ALLEY
+        case EdgeType::HORIZON:
+            return 0.0;  // No inset for horizon
+        case EdgeType::NONE:
+        default:
+            return 1.2 / 2.0;  // Default is ALLEY / 2
+    }
+}
+
+/**
+ * Get inset distance for farms (different rules than urban wards)
+ *
+ * Reference: mfcg.js Farm.getAvailable lines 12606-12637
+ */
+inline double getFarmEdgeInset(EdgeType type, bool neighborIsFarm = false, double canalWidth = 0.0) {
+    switch (type) {
+        case EdgeType::ROAD:
+            return 3.0;  // Larger setback from roads for farms
+        case EdgeType::WALL:
+            return 2.0 * 1.5;  // 2 * pc.THICKNESS
+        case EdgeType::CANAL:
+            return canalWidth / 2.0 + 1.2;
+        case EdgeType::NONE:
+            return neighborIsFarm ? 1.0 : 0.0;  // Buffer between farms, no buffer to other wards
+        default:
+            return 2.0;  // Default farm inset
+    }
+}
+
+} // namespace building
+} // namespace town_generator

--- a/tools/town_generator/include/town_generator/building/Model.h
+++ b/tools/town_generator/include/town_generator/building/Model.h
@@ -6,6 +6,7 @@
 #include "town_generator/building/Patch.h"
 #include "town_generator/building/Topology.h"
 #include "town_generator/building/Canal.h"
+#include "town_generator/building/WardGroup.h"
 #include "town_generator/utils/Random.h"
 #include <vector>
 #include <memory>
@@ -68,6 +69,9 @@ public:
     std::vector<std::unique_ptr<wards::Ward>> wards_;
     std::vector<std::unique_ptr<Patch>> ownedPatches_;
 
+    // Ward groups for unified geometry generation
+    std::vector<std::unique_ptr<WardGroup>> wardGroups_;
+
     Model(int nPatches, int seed = -1);
     ~Model();
 
@@ -94,6 +98,9 @@ public:
     // Like Ic.split in mfcg.js - uses flood fill through neighbor relationships
     static std::vector<std::vector<Patch*>> splitIntoConnectedComponents(const std::vector<Patch*>& patches);
 
+    // Get canal width at a vertex/edge (faithful to mfcg.js getCanalWidth)
+    double getCanalWidth(const geom::Point& v) const;
+
     // Equality
     bool operator==(const Model& other) const {
         return patches.size() == other.patches.size();
@@ -117,6 +124,8 @@ private:
     void tidyUpRoads();
     void createWards();
     void buildGeometry();
+    void setEdgeData();      // Set edge types (COAST, ROAD, WALL, CANAL) on all patches
+    void createWardGroups(); // Create WardGroups from adjacent same-type patches
 
     static std::vector<geom::Point> generateRandomPoints(int count, double width, double height);
 };

--- a/tools/town_generator/include/town_generator/building/Patch.h
+++ b/tools/town_generator/include/town_generator/building/Patch.h
@@ -3,7 +3,9 @@
 #include "town_generator/geom/Point.h"
 #include "town_generator/geom/Polygon.h"
 #include "town_generator/geom/Voronoi.h"
+#include "town_generator/building/EdgeData.h"
 #include <vector>
+#include <map>
 
 namespace town_generator {
 
@@ -14,8 +16,16 @@ namespace wards {
 
 namespace building {
 
+class WardGroup;
+
 /**
  * Patch - City district, faithful port from Haxe TownGeneratorOS
+ *
+ * Each patch represents a Voronoi cell and contains:
+ * - shape: the polygon boundary
+ * - ward: the ward type (Castle, Market, etc.)
+ * - neighbors: adjacent patches that share an edge
+ * - edgeData: per-edge type classification (COAST, ROAD, WALL, CANAL)
  */
 class Patch {
 public:
@@ -23,10 +33,20 @@ public:
     wards::Ward* ward = nullptr;
     std::vector<Patch*> neighbors;  // Adjacent patches (share an edge)
 
+    // Per-edge data: maps edge index -> EdgeType
+    // Edge i is from shape[i] to shape[(i+1) % length]
+    std::map<size_t, EdgeType> edgeData;
+
+    // Group of adjacent patches with same ward type for unified geometry generation
+    WardGroup* group = nullptr;
+
     bool withinWalls = false;
     bool withinCity = false;
     bool waterbody = false;    // True if this patch is water (sea, lake, river)
     bool landing = false;      // True if this patch is a harbour landing
+
+    // Seed for reproducible random in this patch (faithful to mfcg.js patch.seed)
+    int seed = 0;
 
     Patch() = default;
 
@@ -43,6 +63,45 @@ public:
             vertices.push_back(tr->c);
         }
         return Patch(vertices);
+    }
+
+    // Get edge type for edge at index i (from shape[i] to shape[(i+1) % length])
+    EdgeType getEdgeType(size_t edgeIndex) const {
+        auto it = edgeData.find(edgeIndex);
+        return (it != edgeData.end()) ? it->second : EdgeType::NONE;
+    }
+
+    // Set edge type for edge at index i
+    void setEdgeType(size_t edgeIndex, EdgeType type) {
+        edgeData[edgeIndex] = type;
+    }
+
+    // Find edge index for an edge defined by two vertices (in either direction)
+    // Returns -1 if not found
+    int findEdgeIndex(const geom::Point& v0, const geom::Point& v1) const {
+        size_t len = shape.length();
+        for (size_t i = 0; i < len; ++i) {
+            const geom::Point& a = shape[i];
+            const geom::Point& b = shape[(i + 1) % len];
+            if ((a == v0 && b == v1) || (a == v1 && b == v0)) {
+                return static_cast<int>(i);
+            }
+        }
+        return -1;
+    }
+
+    // Set edge type by vertex coordinates
+    void setEdgeTypeByVertices(const geom::Point& v0, const geom::Point& v1, EdgeType type) {
+        int idx = findEdgeIndex(v0, v1);
+        if (idx >= 0) {
+            setEdgeType(static_cast<size_t>(idx), type);
+        }
+    }
+
+    // Get inset amount for an edge (uses edge data and patch properties)
+    double getEdgeInsetAmount(size_t edgeIndex, double canalWidth = 0.0) const {
+        EdgeType type = getEdgeType(edgeIndex);
+        return getEdgeInset(type, landing, canalWidth);
     }
 
     // Equality

--- a/tools/town_generator/include/town_generator/building/WardGroup.h
+++ b/tools/town_generator/include/town_generator/building/WardGroup.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "town_generator/geom/Point.h"
+#include "town_generator/geom/Polygon.h"
+#include "town_generator/building/Patch.h"
+#include "town_generator/building/Block.h"
+#include "town_generator/wards/Ward.h"
+#include <vector>
+#include <memory>
+
+namespace town_generator {
+namespace building {
+
+class Model;
+
+/**
+ * WardGroup - Groups adjacent patches with the same ward type
+ *
+ * Faithful port from mfcg.js WardGroup (lines 12847-12956).
+ * A WardGroup allows multiple adjacent Alleys-type patches to share
+ * unified geometry generation, creating more realistic block structures.
+ *
+ * Key concepts from reference:
+ * - core: The "main" patch face that triggers geometry creation
+ * - border: Combined circumference of all patches in the group
+ * - blocks: Individual city blocks created by alley subdivision
+ * - urban: Whether this group is within city walls
+ */
+class WardGroup {
+public:
+    // The patches in this group
+    std::vector<Patch*> patches;
+
+    // The "core" patch (first patch added, triggers geometry creation)
+    Patch* core = nullptr;
+
+    // Combined border of all patches
+    geom::Polygon border;
+
+    // City blocks after alley subdivision
+    std::vector<std::unique_ptr<Block>> blocks;
+
+    // Whether this is an urban (walled) district
+    bool urban = false;
+
+    // The model this group belongs to
+    Model* model = nullptr;
+
+    // Shared alley parameters for the group (from mfcg.js District.createParams)
+    wards::AlleyParams alleys;
+
+    // Greenery level (0-1)
+    double greenery = 0.0;
+
+    WardGroup() = default;
+    explicit WardGroup(Model* model);
+
+    // Add a patch to this group
+    void addPatch(Patch* patch);
+
+    // Build the group border from patch circumferences
+    void buildBorder();
+
+    // Create alley parameters for this group
+    void createParams();
+
+    // Create geometry for all blocks in this group
+    // This is called once when the core patch's createGeometry is invoked
+    void createGeometry();
+
+    // Get trees spawned by blocks in this group
+    std::vector<geom::Point> spawnTrees();
+
+    // Check if a patch can be added to this group (same ward type, adjacent)
+    bool canAddPatch(Patch* patch) const;
+
+    // Get the ward type name for this group
+    std::string getTypeName() const;
+};
+
+/**
+ * WardGroupBuilder - Creates WardGroups from a model's patches
+ *
+ * Faithful port from mfcg.js DistrictBuilder/WardGroup creation logic.
+ * Groups adjacent patches with the same ward type into unified WardGroups.
+ */
+class WardGroupBuilder {
+public:
+    explicit WardGroupBuilder(Model* model) : model_(model) {}
+
+    // Build all ward groups from patches
+    std::vector<std::unique_ptr<WardGroup>> build();
+
+private:
+    Model* model_;
+
+    // Grow a group by adding adjacent patches of the same type
+    void growGroup(WardGroup* group, std::vector<Patch*>& unassigned);
+};
+
+} // namespace building
+} // namespace town_generator

--- a/tools/town_generator/include/town_generator/wards/Park.h
+++ b/tools/town_generator/include/town_generator/wards/Park.h
@@ -1,23 +1,56 @@
 #pragma once
 
 #include "town_generator/wards/Ward.h"
+#include <vector>
 
 namespace town_generator {
 namespace wards {
 
 /**
- * Park - Open green space
+ * Park - Open green space with paths and features
+ *
+ * Faithful port from mfcg.js Park/Hf (green area generation).
+ * Parks contain:
+ * - Smoothed organic boundary
+ * - Internal paths
+ * - Optional structures (pavilion, fountain, benches)
+ * - Tree spawn points for rendering
  */
 class Park : public Ward {
 public:
+    // Smoothed green area boundary
+    geom::Polygon greenArea;
+
+    // Internal paths through the park
+    std::vector<std::vector<geom::Point>> paths;
+
+    // Tree spawn points
+    std::vector<geom::Point> trees;
+
+    // Features (fountains, benches, etc.)
+    std::vector<geom::Polygon> features;
+
     Park() = default;
 
     std::string getName() const override { return "Park"; }
 
     void createGeometry() override;
 
+    // Spawn trees for rendering (faithful to mfcg.js spawnTrees)
+    std::vector<geom::Point> spawnTrees() const;
+
     bool operator==(const Park& other) const { return Ward::operator==(other); }
     bool operator!=(const Park& other) const { return !(*this == other); }
+
+private:
+    // Create wavy boundary for organic look
+    geom::Polygon createWavyBoundary(const geom::Polygon& shape);
+
+    // Create internal paths
+    void createPaths();
+
+    // Add park features (fountain, benches)
+    void addFeatures();
 };
 
 } // namespace wards

--- a/tools/town_generator/src/building/WardGroup.cpp
+++ b/tools/town_generator/src/building/WardGroup.cpp
@@ -1,0 +1,326 @@
+#include "town_generator/building/WardGroup.h"
+#include "town_generator/building/Block.h"
+#include "town_generator/building/Model.h"
+#include "town_generator/building/Cutter.h"
+#include "town_generator/utils/Random.h"
+#include "town_generator/wards/Ward.h"
+#include <algorithm>
+#include <cmath>
+#include <SDL3/SDL_log.h>
+
+namespace town_generator {
+namespace building {
+
+// Forward declaration of helper function
+static void subdivideIntoBlocksHelper(
+    const geom::Polygon& area,
+    const wards::AlleyParams& params,
+    std::vector<geom::Polygon>& result
+);
+
+WardGroup::WardGroup(Model* model) : model(model) {}
+
+void WardGroup::addPatch(Patch* patch) {
+    if (!patch) return;
+
+    patches.push_back(patch);
+    patch->group = this;
+
+    if (!core) {
+        core = patch;
+        urban = patch->withinWalls;
+    }
+}
+
+void WardGroup::buildBorder() {
+    if (patches.empty()) return;
+
+    if (patches.size() == 1) {
+        border = patches[0]->shape;
+        return;
+    }
+
+    // Use Model::findCircumference to get combined border
+    border = Model::findCircumference(patches);
+}
+
+void WardGroup::createParams() {
+    // Faithful to mfcg.js District.createParams()
+    // Uses normal3 and normal4 distributions for natural variation
+
+    // minSq: 15 + 40 * abs(normal4 - 1) where normal4 is sum of 4 randoms / 2
+    double normal4 = (utils::Random::floatVal() + utils::Random::floatVal() +
+                     utils::Random::floatVal() + utils::Random::floatVal()) / 2.0 - 1.0;
+    alleys.minSq = 15.0 + 40.0 * std::abs(normal4);
+
+    // gridChaos: 0.2 + normal3 * 0.8
+    double normal3 = (utils::Random::floatVal() + utils::Random::floatVal() +
+                     utils::Random::floatVal()) / 3.0;
+    alleys.gridChaos = 0.2 + normal3 * 0.8;
+
+    // sizeChaos: 0.4 + normal3 * 0.6
+    normal3 = (utils::Random::floatVal() + utils::Random::floatVal() +
+              utils::Random::floatVal()) / 3.0;
+    alleys.sizeChaos = 0.4 + normal3 * 0.6;
+
+    // shapeFactor: 0.25 + normal3 * 2
+    normal3 = (utils::Random::floatVal() + utils::Random::floatVal() +
+              utils::Random::floatVal()) / 3.0;
+    alleys.shapeFactor = 0.25 + normal3 * 2.0;
+
+    // inset: 0.6 * (1 - abs(normal4))
+    normal4 = (utils::Random::floatVal() + utils::Random::floatVal() +
+              utils::Random::floatVal() + utils::Random::floatVal()) / 2.0 - 1.0;
+    alleys.inset = 0.6 * (1.0 - std::abs(normal4));
+
+    // blockSize: 4 + 10 * normal3
+    normal3 = (utils::Random::floatVal() + utils::Random::floatVal() +
+              utils::Random::floatVal()) / 3.0;
+    alleys.blockSize = 4.0 + 10.0 * normal3;
+
+    // Compute derived values
+    alleys.computeDerived();
+
+    // greenery: normal3^2 (or ^1 for parks)
+    normal3 = (utils::Random::floatVal() + utils::Random::floatVal() +
+              utils::Random::floatVal()) / 3.0;
+    std::string typeName = getTypeName();
+    greenery = (typeName == "Park") ? normal3 : normal3 * normal3;
+
+    // Adjust for sprawl (outer areas)
+    if (!urban) {
+        alleys.gridChaos *= 0.5;
+        alleys.blockSize *= 2.0;
+        greenery = (1.0 + greenery) / 2.0;
+    }
+}
+
+void WardGroup::createGeometry() {
+    if (border.length() < 3) {
+        buildBorder();
+    }
+
+    if (border.length() < 3) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "WardGroup: Cannot create geometry with invalid border");
+        return;
+    }
+
+    createParams();
+
+    // Get available area after street/wall insets
+    // For now, use simplified inset based on alleys.inset
+    std::vector<double> insets(border.length(), alleys.inset);
+    geom::Polygon available = border.shrink(insets);
+
+    if (available.length() < 3) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "WardGroup: Available area too small after inset");
+        return;
+    }
+
+    // Create blocks by recursive subdivision
+    // Faithful to mfcg.js createAlleys
+    std::vector<geom::Polygon> blockShapes;
+    subdivideIntoBlocksHelper(available, alleys, blockShapes);
+
+    // Create Block objects from shapes
+    blocks.clear();
+    for (const auto& shape : blockShapes) {
+        auto block = std::make_unique<Block>(shape, this);
+        block->createLots();
+        block->createRects();
+        block->createBuildings();
+        blocks.push_back(std::move(block));
+    }
+
+    SDL_Log("WardGroup: Created %zu blocks from %zu patches", blocks.size(), patches.size());
+}
+
+std::vector<geom::Point> WardGroup::spawnTrees() {
+    std::vector<geom::Point> trees;
+
+    for (const auto& block : blocks) {
+        auto blockTrees = block->spawnTrees();
+        trees.insert(trees.end(), blockTrees.begin(), blockTrees.end());
+    }
+
+    return trees;
+}
+
+bool WardGroup::canAddPatch(Patch* patch) const {
+    if (!patch || !patch->ward) return false;
+    if (patches.empty()) return true;
+
+    // Must be same ward type
+    std::string typeName = getTypeName();
+    if (patch->ward->getName() != typeName) return false;
+
+    // Must be adjacent to at least one patch in the group
+    for (Patch* existing : patches) {
+        for (Patch* neighbor : existing->neighbors) {
+            if (neighbor == patch) return true;
+        }
+    }
+
+    return false;
+}
+
+std::string WardGroup::getTypeName() const {
+    if (patches.empty() || !patches[0]->ward) return "";
+    return patches[0]->ward->getName();
+}
+
+// Helper function to subdivide area into blocks
+static void subdivideIntoBlocksHelper(
+    const geom::Polygon& area,
+    const wards::AlleyParams& params,
+    std::vector<geom::Polygon>& result
+) {
+    double areaSize = std::abs(area.square());
+    double threshold = params.minSq * params.blockSize;
+
+    // Apply size chaos to threshold
+    double chaosMultiplier = std::pow(2.0, params.sizeChaos * (2.0 * utils::Random::floatVal() - 1.0));
+    threshold *= chaosMultiplier;
+
+    // If area is small enough, it's a block
+    if (areaSize < threshold || area.length() < 3) {
+        if (areaSize > params.minSq / 4.0) {
+            result.push_back(area);
+        }
+        return;
+    }
+
+    // Find longest edge for bisection
+    size_t longestEdge = 0;
+    double longestLen = 0;
+    for (size_t i = 0; i < area.length(); ++i) {
+        geom::Point v = area.vectori(static_cast<int>(i));
+        double len = v.length();
+        if (len > longestLen) {
+            longestLen = len;
+            longestEdge = i;
+        }
+    }
+
+    // Calculate cut ratio with grid chaos
+    double spread = 0.8 * params.gridChaos;
+    double ratio = (1.0 - spread) / 2.0 + utils::Random::floatVal() * spread;
+
+    // Angle spread for larger blocks (faithful to mfcg.js)
+    double angleSpread = M_PI / 6.0 * params.gridChaos * (areaSize < params.minSq * 4 ? 0.0 : 1.0);
+    double angle = (utils::Random::floatVal() - 0.5) * angleSpread;
+
+    // Gap for alleys
+    double gap = wards::Ward::ALLEY;
+
+    // Bisect the area
+    auto halves = Cutter::bisect(area, area[longestEdge], ratio, angle, gap);
+
+    if (halves.size() < 2) {
+        // Bisection failed, treat as a block
+        if (areaSize > params.minSq / 4.0) {
+            result.push_back(area);
+        }
+        return;
+    }
+
+    // Recursively subdivide each half
+    for (const auto& half : halves) {
+        subdivideIntoBlocksHelper(half, params, result);
+    }
+}
+
+// WardGroupBuilder implementation
+
+std::vector<std::unique_ptr<WardGroup>> WardGroupBuilder::build() {
+    std::vector<std::unique_ptr<WardGroup>> groups;
+
+    // Get all city patches with wards that support grouping
+    std::vector<Patch*> unassigned;
+    for (auto* patch : model_->patches) {
+        if (patch->withinCity && !patch->waterbody && patch->ward) {
+            // Only group "Alleys" type wards (CommonWard, MerchantWard, CraftsmenWard, etc.)
+            std::string wardName = patch->ward->getName();
+            if (wardName == "CommonWard" || wardName == "MerchantWard" ||
+                wardName == "CraftsmenWard" || wardName == "PatriciateWard" ||
+                wardName == "Slum" || wardName == "AdministrationWard" ||
+                wardName == "MilitaryWard") {
+                unassigned.push_back(patch);
+            }
+        }
+    }
+
+    // Group patches into WardGroups
+    while (!unassigned.empty()) {
+        Patch* seed = unassigned.front();
+        auto group = std::make_unique<WardGroup>(model_);
+        group->addPatch(seed);
+
+        // Remove seed from unassigned
+        unassigned.erase(unassigned.begin());
+
+        // Grow the group by adding adjacent patches of the same type
+        growGroup(group.get(), unassigned);
+
+        // Build the group border
+        group->buildBorder();
+
+        groups.push_back(std::move(group));
+    }
+
+    return groups;
+}
+
+void WardGroupBuilder::growGroup(WardGroup* group, std::vector<Patch*>& unassigned) {
+    if (!group || unassigned.empty()) return;
+
+    std::string typeName = group->getTypeName();
+    bool keepGrowing = true;
+
+    while (keepGrowing && !unassigned.empty()) {
+        // Find candidates: neighbors of current group patches that are in unassigned
+        std::vector<Patch*> candidates;
+        for (Patch* patch : group->patches) {
+            for (Patch* neighbor : patch->neighbors) {
+                // Check if neighbor is in unassigned
+                auto it = std::find(unassigned.begin(), unassigned.end(), neighbor);
+                if (it != unassigned.end()) {
+                    // Check if same ward type
+                    if (neighbor->ward && neighbor->ward->getName() == typeName) {
+                        // Not already a candidate
+                        if (std::find(candidates.begin(), candidates.end(), neighbor) == candidates.end()) {
+                            candidates.push_back(neighbor);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (candidates.empty()) {
+            break;
+        }
+
+        // Probability to stop growing increases with size (faithful to mfcg.js)
+        double stopProb = static_cast<double>(group->patches.size() - 3) / group->patches.size();
+        if (stopProb < 0) stopProb = 0;
+        if (group->patches.size() > 1 && unassigned.size() > 1 && utils::Random::floatVal() < stopProb) {
+            break;
+        }
+
+        // Add a random candidate
+        size_t idx = static_cast<size_t>(utils::Random::floatVal() * candidates.size());
+        if (idx >= candidates.size()) idx = candidates.size() - 1;
+
+        Patch* chosen = candidates[idx];
+        group->addPatch(chosen);
+
+        // Remove from unassigned
+        auto it = std::find(unassigned.begin(), unassigned.end(), chosen);
+        if (it != unassigned.end()) {
+            unassigned.erase(it);
+        }
+    }
+}
+
+} // namespace building
+} // namespace town_generator


### PR DESCRIPTION
- Add EdgeData enum for per-edge type tracking (COAST, ROAD, WALL, CANAL)
- Add WardGroup class for unified block generation across adjacent patches
- Port TwistedBlock partitioning algorithm for building lot creation
- Implement Block class with createRects, createBuildings, filterInner
- Update Model to set edge data and use WardGroups
- Enhance Harbour ward with proper pier generation using edge data
- Implement Park ward with wavy boundaries, paths, and tree spawning

These changes make the C++ town_generator more faithful to the MFCG
reference implementation, improving:
- Edge-level data tracking for proper inset calculations
- Unified geometry generation for adjacent same-type patches
- More sophisticated block partitioning and building placement
- Better waterfront (harbour) and green area (park) geometry