### PR TITLE
Document frame graph threading migration phase 3

### DIFF
--- a/docs/THREADING_MIGRATION.md
+++ b/docs/THREADING_MIGRATION.md
@@ -378,9 +378,20 @@ SDL_Log("%s", frameGraph_.debugString().c_str());
    - Migrate texture loading to AsyncTransferManager
    - Update LoadJobQueue to use async transfers
 
-3. **Phase 3**: Frame graph
+3. **Phase 3**: Frame graph (done)
    - Convert RenderPipeline stages to FrameGraph passes
    - Identify parallel opportunities between passes
+   - Implementation in `Renderer::setupFrameGraph()`:
+     ```
+     ComputeStage ──┬──> ShadowPass ──┐
+                    ├──> Froxel ──────┼──> HDR ──┬──> SSR ─────────┐
+                    └──> WaterGBuffer ┘          ├──> WaterTileCull┼──> PostProcess
+                                                 ├──> HiZ ──> Bloom┤
+                                                 └──> BilateralGrid┘
+     ```
+   - Toggle with `Renderer::useFrameGraph` (default: true)
+   - Shadow and Froxel can run in parallel after Compute completes
+   - SSR, WaterTileCull, HiZ, and BilateralGrid can all run in parallel after HDR
 
 4. **Phase 4**: Secondary command buffers
    - Group draw calls by pipeline

--- a/src/core/FrameData.h
+++ b/src/core/FrameData.h
@@ -31,6 +31,8 @@ struct FrameData {
     glm::mat4 view = glm::mat4(1.0f);
     glm::mat4 projection = glm::mat4(1.0f);
     glm::mat4 viewProj = glm::mat4(1.0f);
+    float nearPlane = 0.1f;
+    float farPlane = 1000.0f;
 
     // Lighting
     glm::vec3 sunDirection = glm::vec3(0.0f, 1.0f, 0.0f);

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -249,6 +249,9 @@ private:
     // Setup render pipeline stages with lambdas (called once during init)
     void setupRenderPipeline();
 
+    // Setup frame graph passes with dependencies (Phase 3: frame graph integration)
+    void setupFrameGraph();
+
     // Pure calculation helpers (no state mutation)
     glm::vec2 calculateSunScreenPos(const Camera& camera, const glm::vec3& sunDir) const;
 
@@ -332,6 +335,7 @@ private:
     float skyExposure = 5.0f;              // Sky brightness multiplier (1-20)
     bool framebufferResized = false;       // true = window resized, need to recreate swapchain
     bool windowSuspended = false;          // true = window minimized/hidden (macOS screen lock)
+    bool useFrameGraph = true;             // true = use FrameGraph for pass scheduling (Phase 3)
 
     // Player position for grass displacement
     glm::vec3 playerPosition = glm::vec3(0.0f);


### PR DESCRIPTION
…ase 3)

This implements Phase 3 of the threading migration:
- Add setupFrameGraph() method to Renderer with 11 passes and dependencies
- Enable parallel execution of independent passes (Shadow/Froxel, post-HDR passes)
- Add useFrameGraph toggle (default: true) to switch between frame graph and legacy
- Add nearPlane/farPlane to FrameData for camera plane access in passes
- Update THREADING_MIGRATION.md to mark Phase 3 as complete

Pass dependency graph:
  ComputeStage --> Shadow/Froxel/WaterGBuffer --> HDR --> SSR/WaterTileCull/HiZ/BilateralGrid --> PostProcess