### PR TITLE
Complete threading migration phase 4

### DIFF
--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -247,6 +247,9 @@ private:
     // Render pass recording helpers (pure - only record commands, no state mutation)
     void recordShadowPass(VkCommandBuffer cmd, uint32_t frameIndex, float grassTime, const glm::vec3& cameraPosition);
     void recordHDRPass(VkCommandBuffer cmd, uint32_t frameIndex, float grassTime);
+    void recordHDRPassWithSecondaries(VkCommandBuffer cmd, uint32_t frameIndex, float grassTime,
+                                      const std::vector<vk::CommandBuffer>& secondaries);
+    void recordHDRPassSecondarySlot(VkCommandBuffer cmd, uint32_t frameIndex, float grassTime, uint32_t slot);
     void recordSceneObjects(VkCommandBuffer cmd, uint32_t frameIndex);
 
     // Setup render pipeline stages with lambdas (called once during init)


### PR DESCRIPTION
Add infrastructure for parallel secondary command buffer recording in the HDR render pass. This enables recording multiple independent draw call groups in parallel across worker threads.

Key changes:
- FrameGraph: Add secondarySlots, secondaryRecord to PassConfig
- FrameGraph: Add RenderContext fields for threadedCommandPool, renderPass, framebuffer, and secondaryBuffers pointer
- FrameGraph: Add executeWithSecondaryBuffers() for parallel recording
- Renderer: Add recordHDRPassWithSecondaries() for secondary execution
- Renderer: Add recordHDRPassSecondarySlot() for slot-based recording
- Renderer: Configure HDR pass with 3 parallel slots:
  - Slot 0: Sky + Terrain + Catmull-Clark
  - Slot 1: Scene Objects + Skinned Character
  - Slot 2: Grass + Water + Leaves + Weather + Debug lines
- Documentation: Update THREADING_MIGRATION.md with Phase 4 details

The parallel recording uses ThreadedCommandPool to allocate secondary buffers per-thread, avoiding synchronization during recording. Each slot records independently and the main execute function collects all secondaries with vkCmdExecuteCommands.