### PR TITLE
Replace manual barrier calls with BarrierHelpers

### DIFF
--- a/src/core/vulkan/BarrierHelpers.h
+++ b/src/core/vulkan/BarrierHelpers.h
@@ -116,6 +116,26 @@ inline void imageToColorAttachment(
 }
 
 /**
+ * Transition image from shader read-only back to general layout (for re-compute)
+ */
+inline void shaderReadToGeneral(
+        vk::CommandBuffer cmd,
+        vk::Image image,
+        vk::PipelineStageFlags srcStage = vk::PipelineStageFlagBits::eFragmentShader,
+        vk::ImageAspectFlags aspectMask = vk::ImageAspectFlagBits::eColor,
+        uint32_t mipLevels = 1) {
+
+    transitionImageLayout(cmd, image,
+        vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::ImageLayout::eGeneral,
+        srcStage,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::AccessFlagBits::eShaderRead,
+        vk::AccessFlagBits::eShaderWrite,
+        aspectMask, 0, mipLevels);
+}
+
+/**
  * Compute shader write barrier (within compute, same image)
  * Use between compute passes that write then read the same image
  */


### PR DESCRIPTION
Replace verbose manual image memory barriers with concise helper function calls across 7 files, reducing ~300 lines of boilerplate code.

Changes:
- Add shaderReadToGeneral() helper to BarrierHelpers.h for re-compute transitions (ShaderReadOnlyOptimal → General)
- AtmosphereLUTCompute.cpp: Replace 12+ manual barriers with helpers
- FroxelSystem.cpp: Replace 4 compute barriers with helpers
- WaterDisplacement.cpp: Replace 2 barriers with helpers
- SnowMaskSystem.cpp: Replace 1 barrier (keep conditional first-frame barrier that needs read+write access)
- CloudShadowSystem.cpp: Replace 1 barrier (keep special srcAccess case)
- GrassSystem.cpp: Replace 2 displacement barriers with helpers
- BloomSystem.cpp: Replace 1 barrier with imageToColorAttachment()

Skipped VirtualTextureCache.cpp as its barriers are transfer-specific and don't match the compute-focused helper patterns.