### PR TITLE
Refactor duplicate SystemGroup boilerplate code

### DIFF
--- a/src/atmosphere/AtmosphereSystemGroup.h
+++ b/src/atmosphere/AtmosphereSystemGroup.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <vulkan/vulkan.h>
+#include "SystemGroupMacros.h"
 
 // Forward declarations
 class SkySystem;
@@ -28,23 +27,16 @@ class CloudShadowSystem;
  */
 struct AtmosphereSystemGroup {
     // Non-owning references to systems (owned by RendererSystems)
-    SkySystem* sky_ = nullptr;
-    FroxelSystem* froxel_ = nullptr;
-    AtmosphereLUTSystem* atmosphereLUT_ = nullptr;
-    CloudShadowSystem* cloudShadow_ = nullptr;
+    SYSTEM_MEMBER(SkySystem, sky);
+    SYSTEM_MEMBER(FroxelSystem, froxel);
+    SYSTEM_MEMBER(AtmosphereLUTSystem, atmosphereLUT);
+    SYSTEM_MEMBER(CloudShadowSystem, cloudShadow);
 
     // Accessors
-    SkySystem& sky() { return *sky_; }
-    const SkySystem& sky() const { return *sky_; }
-
-    FroxelSystem& froxel() { return *froxel_; }
-    const FroxelSystem& froxel() const { return *froxel_; }
-
-    AtmosphereLUTSystem& atmosphereLUT() { return *atmosphereLUT_; }
-    const AtmosphereLUTSystem& atmosphereLUT() const { return *atmosphereLUT_; }
-
-    CloudShadowSystem& cloudShadow() { return *cloudShadow_; }
-    const CloudShadowSystem& cloudShadow() const { return *cloudShadow_; }
+    REQUIRED_SYSTEM_ACCESSORS(SkySystem, sky)
+    REQUIRED_SYSTEM_ACCESSORS(FroxelSystem, froxel)
+    REQUIRED_SYSTEM_ACCESSORS(AtmosphereLUTSystem, atmosphereLUT)
+    REQUIRED_SYSTEM_ACCESSORS(CloudShadowSystem, cloudShadow)
 
     // Validation
     bool isValid() const {

--- a/src/atmosphere/SnowSystemGroup.h
+++ b/src/atmosphere/SnowSystemGroup.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <vulkan/vulkan.h>
+#include "SystemGroupMacros.h"
 
 // Forward declarations
 class SnowMaskSystem;
@@ -28,23 +27,16 @@ class LeafSystem;
  */
 struct SnowSystemGroup {
     // Non-owning references to systems (owned by RendererSystems)
-    SnowMaskSystem* mask_ = nullptr;
-    VolumetricSnowSystem* volumetric_ = nullptr;
-    WeatherSystem* weather_ = nullptr;
-    LeafSystem* leaf_ = nullptr;
+    SYSTEM_MEMBER(SnowMaskSystem, mask);
+    SYSTEM_MEMBER(VolumetricSnowSystem, volumetric);
+    SYSTEM_MEMBER(WeatherSystem, weather);
+    SYSTEM_MEMBER(LeafSystem, leaf);
 
     // Accessors
-    SnowMaskSystem& mask() { return *mask_; }
-    const SnowMaskSystem& mask() const { return *mask_; }
-
-    VolumetricSnowSystem& volumetric() { return *volumetric_; }
-    const VolumetricSnowSystem& volumetric() const { return *volumetric_; }
-
-    WeatherSystem& weather() { return *weather_; }
-    const WeatherSystem& weather() const { return *weather_; }
-
-    LeafSystem& leaf() { return *leaf_; }
-    const LeafSystem& leaf() const { return *leaf_; }
+    REQUIRED_SYSTEM_ACCESSORS(SnowMaskSystem, mask)
+    REQUIRED_SYSTEM_ACCESSORS(VolumetricSnowSystem, volumetric)
+    REQUIRED_SYSTEM_ACCESSORS(WeatherSystem, weather)
+    REQUIRED_SYSTEM_ACCESSORS(LeafSystem, leaf)
 
     // Validation
     bool isValid() const {

--- a/src/core/SystemGroupMacros.h
+++ b/src/core/SystemGroupMacros.h
@@ -1,0 +1,58 @@
+#pragma once
+
+/**
+ * SystemGroupMacros.h - Helper macros for SystemGroup pattern
+ *
+ * These macros reduce boilerplate in SystemGroup structs that hold
+ * non-owning pointers to related rendering systems.
+ *
+ * Pattern usage:
+ *   struct MySystemGroup {
+ *       // Members
+ *       SYSTEM_MEMBER(FooSystem, foo);
+ *       SYSTEM_MEMBER(BarSystem, bar);
+ *
+ *       // Required system accessors (returns reference, must not be null)
+ *       REQUIRED_SYSTEM_ACCESSORS(FooSystem, foo)
+ *
+ *       // Optional system accessors (returns pointer, may be null)
+ *       OPTIONAL_SYSTEM_ACCESSORS(BarSystem, bar, Bar)
+ *
+ *       bool isValid() const { return foo_; }
+ *   };
+ */
+
+/**
+ * Declares a system member pointer with nullptr default.
+ * Generates: Type* name_ = nullptr;
+ */
+#define SYSTEM_MEMBER(Type, name) Type* name##_ = nullptr
+
+/**
+ * Generates reference accessors for a required system.
+ * Assumes member name_ exists. Dereferences without null check.
+ *
+ * Generates:
+ *   Type& name() { return *name_; }
+ *   const Type& name() const { return *name_; }
+ */
+#define REQUIRED_SYSTEM_ACCESSORS(Type, name) \
+    Type& name() { return *name##_; } \
+    const Type& name() const { return *name##_; }
+
+/**
+ * Generates pointer accessors and has-check for an optional system.
+ * Assumes member name_ exists. Returns pointer (may be null).
+ *
+ * HasName parameter is used to generate hasHasName() method.
+ * Example: OPTIONAL_SYSTEM_ACCESSORS(TreeSystem, tree, Tree) generates hasTree()
+ *
+ * Generates:
+ *   Type* name() { return name_; }
+ *   const Type* name() const { return name_; }
+ *   bool hasHasName() const { return name_ != nullptr; }
+ */
+#define OPTIONAL_SYSTEM_ACCESSORS(Type, name, HasName) \
+    Type* name() { return name##_; } \
+    const Type* name() const { return name##_; } \
+    bool has##HasName() const { return name##_ != nullptr; }

--- a/src/vegetation/VegetationSystemGroup.h
+++ b/src/vegetation/VegetationSystemGroup.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <vulkan/vulkan.h>
+#include "SystemGroupMacros.h"
 
 // Forward declarations
 class GrassSystem;
@@ -38,45 +37,26 @@ class RockSystem;
  */
 struct VegetationSystemGroup {
     // Non-owning references to systems (owned by RendererSystems)
-    GrassSystem* grass_ = nullptr;
-    WindSystem* wind_ = nullptr;
-    TreeSystem* tree_ = nullptr;
-    TreeRenderer* treeRenderer_ = nullptr;
-    TreeLODSystem* treeLOD_ = nullptr;
-    ImpostorCullSystem* impostorCull_ = nullptr;
-    DetritusSystem* detritus_ = nullptr;
-    RockSystem* rock_ = nullptr;
+    SYSTEM_MEMBER(GrassSystem, grass);
+    SYSTEM_MEMBER(WindSystem, wind);
+    SYSTEM_MEMBER(TreeSystem, tree);
+    SYSTEM_MEMBER(TreeRenderer, treeRenderer);
+    SYSTEM_MEMBER(TreeLODSystem, treeLOD);
+    SYSTEM_MEMBER(ImpostorCullSystem, impostorCull);
+    SYSTEM_MEMBER(DetritusSystem, detritus);
+    SYSTEM_MEMBER(RockSystem, rock);
 
     // Required system accessors
-    GrassSystem& grass() { return *grass_; }
-    const GrassSystem& grass() const { return *grass_; }
-
-    WindSystem& wind() { return *wind_; }
-    const WindSystem& wind() const { return *wind_; }
-
-    RockSystem& rock() { return *rock_; }
-    const RockSystem& rock() const { return *rock_; }
+    REQUIRED_SYSTEM_ACCESSORS(GrassSystem, grass)
+    REQUIRED_SYSTEM_ACCESSORS(WindSystem, wind)
+    REQUIRED_SYSTEM_ACCESSORS(RockSystem, rock)
 
     // Optional system accessors (may be null)
-    TreeSystem* tree() { return tree_; }
-    const TreeSystem* tree() const { return tree_; }
-    bool hasTree() const { return tree_ != nullptr; }
-
-    TreeRenderer* treeRenderer() { return treeRenderer_; }
-    const TreeRenderer* treeRenderer() const { return treeRenderer_; }
-    bool hasTreeRenderer() const { return treeRenderer_ != nullptr; }
-
-    TreeLODSystem* treeLOD() { return treeLOD_; }
-    const TreeLODSystem* treeLOD() const { return treeLOD_; }
-    bool hasTreeLOD() const { return treeLOD_ != nullptr; }
-
-    ImpostorCullSystem* impostorCull() { return impostorCull_; }
-    const ImpostorCullSystem* impostorCull() const { return impostorCull_; }
-    bool hasImpostorCull() const { return impostorCull_ != nullptr; }
-
-    DetritusSystem* detritus() { return detritus_; }
-    const DetritusSystem* detritus() const { return detritus_; }
-    bool hasDetritus() const { return detritus_ != nullptr; }
+    OPTIONAL_SYSTEM_ACCESSORS(TreeSystem, tree, Tree)
+    OPTIONAL_SYSTEM_ACCESSORS(TreeRenderer, treeRenderer, TreeRenderer)
+    OPTIONAL_SYSTEM_ACCESSORS(TreeLODSystem, treeLOD, TreeLOD)
+    OPTIONAL_SYSTEM_ACCESSORS(ImpostorCullSystem, impostorCull, ImpostorCull)
+    OPTIONAL_SYSTEM_ACCESSORS(DetritusSystem, detritus, Detritus)
 
     // Validation (only required systems)
     bool isValid() const {

--- a/src/water/WaterSystemGroup.h
+++ b/src/water/WaterSystemGroup.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <vulkan/vulkan.h>
+#include "SystemGroupMacros.h"
 
 // Forward declarations
 class WaterSystem;
@@ -34,38 +33,24 @@ class WaterGBuffer;
  */
 struct WaterSystemGroup {
     // Non-owning references to systems (owned by RendererSystems)
-    WaterSystem* system_ = nullptr;
-    WaterDisplacement* displacement_ = nullptr;
-    FlowMapGenerator* flowMap_ = nullptr;
-    FoamBuffer* foam_ = nullptr;
-    SSRSystem* ssr_ = nullptr;
-    WaterTileCull* tileCull_ = nullptr;
-    WaterGBuffer* gBuffer_ = nullptr;
+    SYSTEM_MEMBER(WaterSystem, system);
+    SYSTEM_MEMBER(WaterDisplacement, displacement);
+    SYSTEM_MEMBER(FlowMapGenerator, flowMap);
+    SYSTEM_MEMBER(FoamBuffer, foam);
+    SYSTEM_MEMBER(SSRSystem, ssr);
+    SYSTEM_MEMBER(WaterTileCull, tileCull);
+    SYSTEM_MEMBER(WaterGBuffer, gBuffer);
 
     // Required system accessors
-    WaterSystem& system() { return *system_; }
-    const WaterSystem& system() const { return *system_; }
-
-    WaterDisplacement& displacement() { return *displacement_; }
-    const WaterDisplacement& displacement() const { return *displacement_; }
-
-    FlowMapGenerator& flowMap() { return *flowMap_; }
-    const FlowMapGenerator& flowMap() const { return *flowMap_; }
-
-    FoamBuffer& foam() { return *foam_; }
-    const FoamBuffer& foam() const { return *foam_; }
-
-    SSRSystem& ssr() { return *ssr_; }
-    const SSRSystem& ssr() const { return *ssr_; }
+    REQUIRED_SYSTEM_ACCESSORS(WaterSystem, system)
+    REQUIRED_SYSTEM_ACCESSORS(WaterDisplacement, displacement)
+    REQUIRED_SYSTEM_ACCESSORS(FlowMapGenerator, flowMap)
+    REQUIRED_SYSTEM_ACCESSORS(FoamBuffer, foam)
+    REQUIRED_SYSTEM_ACCESSORS(SSRSystem, ssr)
 
     // Optional system accessors (may be null)
-    WaterTileCull* tileCull() { return tileCull_; }
-    const WaterTileCull* tileCull() const { return tileCull_; }
-    bool hasTileCull() const { return tileCull_ != nullptr; }
-
-    WaterGBuffer* gBuffer() { return gBuffer_; }
-    const WaterGBuffer* gBuffer() const { return gBuffer_; }
-    bool hasGBuffer() const { return gBuffer_ != nullptr; }
+    OPTIONAL_SYSTEM_ACCESSORS(WaterTileCull, tileCull, TileCull)
+    OPTIONAL_SYSTEM_ACCESSORS(WaterGBuffer, gBuffer, GBuffer)
 
     // Validation (only required systems)
     bool isValid() const {


### PR DESCRIPTION
Extract common boilerplate into SystemGroupMacros.h with macros:
- SYSTEM_MEMBER: pointer member declaration
- REQUIRED_SYSTEM_ACCESSORS: ref accessors for non-null systems
- OPTIONAL_SYSTEM_ACCESSORS: ptr accessors + has*() for nullable systems

Reduces ~50 lines of repetitive accessor code across 4 files while maintaining the same public API.