### PR TITLE
Consolidate sampler creation into factory functions

### DIFF
--- a/src/core/Texture.cpp
+++ b/src/core/Texture.cpp
@@ -201,6 +201,7 @@ bool Texture::loadInternal(const std::string& path, VmaAllocator allocator, VkDe
     }
 
     // Create sampler using vulkan-hpp builder
+    // Note: Equivalent to SamplerFactory::createSamplerLinearRepeatLimitedMip(device, 0.0f) for RAII code paths
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eLinear)
         .setMinFilter(vk::Filter::eLinear)
@@ -334,6 +335,7 @@ bool Texture::loadDDS(const std::string& path, VmaAllocator allocator, VkDevice 
     }
 
     // Create sampler using vulkan-hpp builder
+    // Note: Equivalent to SamplerFactory::createSamplerLinearRepeatLimitedMip(device, mipLevels) for RAII code paths
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eLinear)
         .setMinFilter(vk::Filter::eLinear)
@@ -430,6 +432,7 @@ bool Texture::createSolidColorInternal(uint8_t r, uint8_t g, uint8_t b, uint8_t 
     }
 
     // Create sampler using vulkan-hpp builder
+    // Note: Equivalent to SamplerFactory::createSamplerNearestRepeat() for RAII code paths
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eNearest)
         .setMinFilter(vk::Filter::eNearest)
@@ -796,6 +799,8 @@ bool Texture::loadWithMipmapsInternal(const std::string& path, VmaAllocator allo
     }
 
     // Create sampler with mipmapping and optional anisotropy using vulkan-hpp builder
+    // Note: For RAII code paths, use SamplerFactory::createSamplerLinearClampAnisotropic(device, 8.0f, mipLevels)
+    //       for anisotropic mode, or SamplerFactory::createSamplerLinearClampLimitedMip(device, mipLevels) without anisotropy
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eLinear)
         .setMinFilter(vk::Filter::eLinear)

--- a/src/core/vulkan/VmaResources.h
+++ b/src/core/vulkan/VmaResources.h
@@ -491,7 +491,7 @@ inline std::optional<vk::raii::Sampler> createSamplerLinearRepeat(const vk::raii
 }
 
 inline std::optional<vk::raii::Sampler> createSamplerLinearRepeatAnisotropic(
-        const vk::raii::Device& device, float maxAnisotropy) {
+        const vk::raii::Device& device, float maxAnisotropy, float maxLod = VK_LOD_CLAMP_NONE) {
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eLinear)
         .setMinFilter(vk::Filter::eLinear)
@@ -502,7 +502,7 @@ inline std::optional<vk::raii::Sampler> createSamplerLinearRepeatAnisotropic(
         .setAnisotropyEnable(vk::True)
         .setMaxAnisotropy(maxAnisotropy)
         .setMinLod(0.0f)
-        .setMaxLod(VK_LOD_CLAMP_NONE);
+        .setMaxLod(maxLod);
 
     try {
         return vk::raii::Sampler(device, samplerInfo);
@@ -589,6 +589,70 @@ inline std::optional<vk::raii::Sampler> createSamplerLinearBorder(
         .setBorderColor(borderColor)
         .setMinLod(0.0f)
         .setMaxLod(VK_LOD_CLAMP_NONE);
+
+    try {
+        return vk::raii::Sampler(device, samplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create sampler: %s", e.what());
+        return std::nullopt;
+    }
+}
+
+// Linear sampler with clamp and anisotropy (for textures that need high quality sampling)
+inline std::optional<vk::raii::Sampler> createSamplerLinearClampAnisotropic(
+        const vk::raii::Device& device, float maxAnisotropy, float maxLod = VK_LOD_CLAMP_NONE) {
+    auto samplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eLinear)
+        .setMinFilter(vk::Filter::eLinear)
+        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
+        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
+        .setAnisotropyEnable(vk::True)
+        .setMaxAnisotropy(maxAnisotropy)
+        .setMinLod(0.0f)
+        .setMaxLod(maxLod);
+
+    try {
+        return vk::raii::Sampler(device, samplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create sampler: %s", e.what());
+        return std::nullopt;
+    }
+}
+
+// Nearest sampler with repeat (for solid color textures and similar)
+inline std::optional<vk::raii::Sampler> createSamplerNearestRepeat(const vk::raii::Device& device) {
+    auto samplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eNearest)
+        .setMinFilter(vk::Filter::eNearest)
+        .setMipmapMode(vk::SamplerMipmapMode::eNearest)
+        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
+        .setMinLod(0.0f)
+        .setMaxLod(0.0f);
+
+    try {
+        return vk::raii::Sampler(device, samplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create sampler: %s", e.what());
+        return std::nullopt;
+    }
+}
+
+// Linear sampler with repeat and limited mip range (for simple textures without mipmaps)
+inline std::optional<vk::raii::Sampler> createSamplerLinearRepeatLimitedMip(
+        const vk::raii::Device& device, float maxLod = 0.0f) {
+    auto samplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eLinear)
+        .setMinFilter(vk::Filter::eLinear)
+        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
+        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
+        .setMinLod(0.0f)
+        .setMaxLod(maxLod);
 
     try {
         return vk::raii::Sampler(device, samplerInfo);

--- a/src/core/vulkan/VulkanHelpers.h
+++ b/src/core/vulkan/VulkanHelpers.h
@@ -204,6 +204,7 @@ inline bool createDepthResources(
     }
 
     // Create depth sampler for Hi-Z pyramid generation
+    // Note: Equivalent to SamplerFactory::createSamplerNearestClamp() for RAII code paths
     auto samplerInfo = vk::SamplerCreateInfo{}
         .setMagFilter(vk::Filter::eNearest)
         .setMinFilter(vk::Filter::eNearest)
@@ -389,6 +390,7 @@ inline bool createDepthArrayResources(
     }
 
     if (config.createSampler) {
+        // Note: Equivalent to SamplerFactory::createSamplerShadowComparison() for RAII code paths
         auto samplerInfo = vk::SamplerCreateInfo{}
             .setMagFilter(vk::Filter::eLinear)
             .setMinFilter(vk::Filter::eLinear)

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -2,6 +2,7 @@
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
 #include "core/vulkan/BarrierHelpers.h"
+#include "core/vulkan/VmaResources.h"
 #include <SDL3/SDL_log.h>
 #include <vulkan/vulkan.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -190,27 +191,12 @@ bool FroxelSystem::createIntegratedVolume() {
 }
 
 bool FroxelSystem::createSampler() {
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setMipLodBias(0.0f)
-        .setAnisotropyEnable(VK_FALSE)
-        .setCompareEnable(VK_FALSE)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f)
-        .setBorderColor(vk::BorderColor::eFloatTransparentBlack);
-
-    try {
-        volumeSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const std::exception& e) {
-        SDL_Log("Failed to create volume sampler: %s", e.what());
+    auto sampler = SamplerFactory::createSamplerLinearClampLimitedMip(*raiiDevice_, 0.0f);
+    if (!sampler) {
+        SDL_Log("Failed to create volume sampler");
         return false;
     }
-
+    volumeSampler_ = std::move(*sampler);
     return true;
 }
 

--- a/src/terrain/TerrainTextures.cpp
+++ b/src/terrain/TerrainTextures.cpp
@@ -169,25 +169,14 @@ bool TerrainTextures::createAlbedoTexture() {
         return false;
     }
 
-    // Create sampler using vk::raii
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
-        .setAnisotropyEnable(vk::True)
-        .setMaxAnisotropy(16.0f)
-        .setMinLod(0.0f)
-        .setMaxLod(VK_LOD_CLAMP_NONE);
-    try {
-        albedoSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create terrain albedo sampler: %s", e.what());
+    // Create sampler using factory
+    auto albedoSampler = SamplerFactory::createSamplerLinearRepeatAnisotropic(*raiiDevice_, 16.0f);
+    if (!albedoSampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create terrain albedo sampler");
         stbi_image_free(pixels);
         return false;
     }
+    albedoSampler_ = std::move(*albedoSampler);
 
     // Upload base level texture to GPU
     if (!uploadImageDataMipLevel(albedoImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4, 0)) {
@@ -266,25 +255,14 @@ bool TerrainTextures::createGrassFarLODTexture() {
         return false;
     }
 
-    // Create sampler using vk::raii
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
-        .setAnisotropyEnable(vk::True)
-        .setMaxAnisotropy(16.0f)
-        .setMinLod(0.0f)
-        .setMaxLod(VK_LOD_CLAMP_NONE);
-    try {
-        grassFarLODSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create grass far LOD sampler: %s", e.what());
+    // Create sampler using factory
+    auto grassSampler = SamplerFactory::createSamplerLinearRepeatAnisotropic(*raiiDevice_, 16.0f);
+    if (!grassSampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create grass far LOD sampler");
         stbi_image_free(pixels);
         return false;
     }
+    grassFarLODSampler_ = std::move(*grassSampler);
 
     // Upload base level texture to GPU
     if (!uploadImageDataMipLevel(grassFarLODImage, pixels, width, height, VK_FORMAT_R8G8B8A8_SRGB, 4, 0)) {

--- a/src/terrain/virtual_texture/VirtualTextureCache.cpp
+++ b/src/terrain/virtual_texture/VirtualTextureCache.cpp
@@ -274,22 +274,12 @@ bool VirtualTextureCache::createSampler(VkDevice device) {
         return false;
     }
 
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setMinLod(0.0f)
-        .setMaxLod(VK_LOD_CLAMP_NONE);
-
-    try {
-        cacheSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create cache sampler: %s", e.what());
+    auto sampler = SamplerFactory::createSamplerLinearClamp(*raiiDevice_);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create cache sampler");
         return false;
     }
+    cacheSampler_ = std::move(*sampler);
     return true;
 }
 

--- a/src/terrain/virtual_texture/VirtualTexturePageTable.cpp
+++ b/src/terrain/virtual_texture/VirtualTexturePageTable.cpp
@@ -227,22 +227,12 @@ bool VirtualTexturePageTable::createSampler(VkDevice device) {
         return false;
     }
 
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eNearest)
-        .setMinFilter(vk::Filter::eNearest)
-        .setMipmapMode(vk::SamplerMipmapMode::eNearest)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f);
-
-    try {
-        pageTableSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create page table sampler: %s", e.what());
+    auto sampler = SamplerFactory::createSamplerNearestClamp(*raiiDevice_);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create page table sampler");
         return false;
     }
+    pageTableSampler_ = std::move(*sampler);
     return true;
 }
 

--- a/src/vegetation/TreeImpostorAtlas.cpp
+++ b/src/vegetation/TreeImpostorAtlas.cpp
@@ -6,6 +6,7 @@
 #include "TreeSystem.h"
 #include "Mesh.h"
 #include "OctahedralMapping.h"
+#include "core/vulkan/VmaResources.h"
 
 #include <SDL3/SDL.h>
 #include <glm/gtc/matrix_transform.hpp>
@@ -287,18 +288,12 @@ bool TreeImpostorAtlas::createAtlasResources(uint32_t archetypeIndex) {
 }
 
 bool TreeImpostorAtlas::createSampler() {
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setAnisotropyEnable(true)
-        .setMaxAnisotropy(4.0f)
-        .setBorderColor(vk::BorderColor::eFloatTransparentBlack)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear);
-
-    atlasSampler_.emplace(*raiiDevice_, samplerInfo);
+    auto sampler = SamplerFactory::createSamplerLinearClampAnisotropic(*raiiDevice_, 4.0f);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TreeImpostorAtlas: Failed to create sampler");
+        return false;
+    }
+    atlasSampler_ = std::move(*sampler);
     return true;
 }
 

--- a/src/water/FlowMapGenerator.cpp
+++ b/src/water/FlowMapGenerator.cpp
@@ -120,28 +120,13 @@ bool FlowMapGenerator::createImage(uint32_t resolution) {
 }
 
 bool FlowMapGenerator::createSampler() {
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setAnisotropyEnable(VK_TRUE)
-        .setMaxAnisotropy(4.0f)
-        .setBorderColor(vk::BorderColor::eFloatOpaqueBlack)
-        .setUnnormalizedCoordinates(VK_FALSE)
-        .setCompareEnable(VK_FALSE)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f);
-
-    try {
-        flowMapSampler_.emplace(*raiiDevice_, samplerInfo);
-        return true;
-    } catch (const std::exception& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create flow map sampler: %s", e.what());
+    auto sampler = SamplerFactory::createSamplerLinearClampAnisotropic(*raiiDevice_, 4.0f, 0.0f);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create flow map sampler");
         return false;
     }
+    flowMapSampler_ = std::move(*sampler);
+    return true;
 }
 
 void FlowMapGenerator::uploadToGPU() {

--- a/src/water/OceanFFT.cpp
+++ b/src/water/OceanFFT.cpp
@@ -79,28 +79,13 @@ bool OceanFFT::initInternal(const InitInfo& info) {
         };
     }
 
-    // Create sampler for output textures
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eRepeat)  // Tiling ocean
-        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
-        .setMipLodBias(0.0f)
-        .setAnisotropyEnable(VK_TRUE)
-        .setMaxAnisotropy(16.0f)
-        .setCompareEnable(VK_FALSE)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f)
-        .setBorderColor(vk::BorderColor::eFloatOpaqueBlack);
-
-    try {
-        sampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create sampler: %s", e.what());
+    // Create sampler for output textures (tiling ocean with anisotropic filtering)
+    auto sampler = SamplerFactory::createSamplerLinearRepeatAnisotropic(*raiiDevice_, 16.0f, 0.0f);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create sampler");
         return false;
     }
+    sampler_ = std::move(*sampler);
 
     // Create compute pipelines
     if (!createComputePipelines()) {
@@ -177,28 +162,13 @@ bool OceanFFT::initInternal(const InitContext& ctx, const OceanParams& oceanPara
         };
     }
 
-    // Create sampler for output textures
-    auto samplerInfo2 = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eLinear)
-        .setMinFilter(vk::Filter::eLinear)
-        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
-        .setAddressModeU(vk::SamplerAddressMode::eRepeat)  // Tiling ocean
-        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
-        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
-        .setMipLodBias(0.0f)
-        .setAnisotropyEnable(VK_TRUE)
-        .setMaxAnisotropy(16.0f)
-        .setCompareEnable(VK_FALSE)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f)
-        .setBorderColor(vk::BorderColor::eFloatOpaqueBlack);
-
-    try {
-        sampler_.emplace(*raiiDevice_, samplerInfo2);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create sampler: %s", e.what());
+    // Create sampler for output textures (tiling ocean with anisotropic filtering)
+    auto sampler2 = SamplerFactory::createSamplerLinearRepeatAnisotropic(*raiiDevice_, 16.0f, 0.0f);
+    if (!sampler2) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create sampler");
         return false;
     }
+    sampler_ = std::move(*sampler2);
 
     // Create compute pipelines
     if (!createComputePipelines()) {

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -245,25 +245,12 @@ bool WaterTileCull::createComputePipeline() {
     SDL_Log("WaterTileCull compute pipeline created");
 
     // Create depth sampler for tile culling
-    auto samplerInfo = vk::SamplerCreateInfo{}
-        .setMagFilter(vk::Filter::eNearest)
-        .setMinFilter(vk::Filter::eNearest)
-        .setMipmapMode(vk::SamplerMipmapMode::eNearest)
-        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
-        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
-        .setMipLodBias(0.0f)
-        .setAnisotropyEnable(VK_FALSE)
-        .setCompareEnable(VK_FALSE)
-        .setMinLod(0.0f)
-        .setMaxLod(0.0f);
-
-    try {
-        depthSampler_.emplace(*raiiDevice_, samplerInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull depth sampler: %s", e.what());
+    auto sampler = SamplerFactory::createSamplerNearestClamp(*raiiDevice_);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull depth sampler");
         return false;
     }
+    depthSampler_ = std::move(*sampler);
 
     return true;
 }


### PR DESCRIPTION
Migrate direct sampler creation to use centralized factory functions in VmaResources.h for consistency and reduced code duplication.

Changes:
- Add new factory functions: createSamplerLinearClampAnisotropic, createSamplerNearestRepeat, createSamplerLinearRepeatLimitedMip
- Add maxLod parameter to createSamplerLinearRepeatAnisotropic
- Replace direct sampler creation with factory calls in:
  - FroxelSystem, WaterTileCull, TerrainTileCache
  - VirtualTexturePageTable, VirtualTextureCache
  - FlowMapGenerator, OceanFFT, TreeImpostorAtlas
  - TerrainTextures
- Add comments documenting equivalent factory functions in:
  - VulkanHelpers.h (raw VkDevice handles)
  - Texture.cpp (non-RAII code paths)