### PR TITLE
Replace raw pointers with reference wrappers

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -92,7 +92,6 @@ Renderer::~Renderer() {
 bool Renderer::initInternal(const InitInfo& info) {
     INIT_PROFILE_PHASE("Renderer");
 
-    window = info.window;
     resourcePath = info.resourcePath;
     config_ = info.config;
 
@@ -110,14 +109,14 @@ bool Renderer::initInternal(const InitInfo& info) {
             // Only call initDevice if device isn't already initialized
             // (LoadingRenderer may have already completed device init)
             if (!vulkanContext_->isDeviceReady()) {
-                if (!vulkanContext_->initDevice(window)) {
+                if (!vulkanContext_->initDevice(info.window)) {
                     SDL_Log("Failed to complete Vulkan device initialization");
                     return false;
                 }
             }
         } else {
             vulkanContext_ = std::make_unique<VulkanContext>();
-            if (!vulkanContext_->init(window)) {
+            if (!vulkanContext_->init(info.window)) {
                 SDL_Log("Failed to initialize Vulkan context");
                 return false;
             }

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -270,7 +270,6 @@ private:
     // Build render resources snapshot for pipeline stages
     RenderResources buildRenderResources(uint32_t swapchainImageIndex) const;
 
-    SDL_Window* window = nullptr;
     std::string resourcePath;
     Config config_;  // Renderer configuration
 

--- a/src/core/loading/AsyncStartupLoader.cpp
+++ b/src/core/loading/AsyncStartupLoader.cpp
@@ -21,7 +21,6 @@ AsyncStartupLoader::~AsyncStartupLoader() {
 }
 
 bool AsyncStartupLoader::init(const InitInfo& info) {
-    vulkanContext_ = info.vulkanContext;
     loadingRenderer_ = info.loadingRenderer;
     resourcePath_ = info.resourcePath;
 

--- a/src/core/loading/AsyncStartupLoader.h
+++ b/src/core/loading/AsyncStartupLoader.h
@@ -121,7 +121,6 @@ private:
     // Helper to build full path
     std::string buildPath(const std::string& relativePath) const;
 
-    VulkanContext* vulkanContext_ = nullptr;
     LoadingRenderer* loadingRenderer_ = nullptr;
     std::string resourcePath_;
 

--- a/src/physics/PhysicsTerrainTileManager.h
+++ b/src/physics/PhysicsTerrainTileManager.h
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <vector>
 #include <cstdint>
+#include <functional>
+#include <optional>
 #include "PhysicsSystem.h"
 
 class TerrainTileCache;
@@ -56,8 +58,8 @@ private:
     };
     std::vector<TileRequest> calculateRequiredTiles(const glm::vec3& position) const;
 
-    PhysicsWorld* physics_ = nullptr;
-    TerrainTileCache* tileCache_ = nullptr;
+    std::optional<std::reference_wrapper<PhysicsWorld>> physics_;
+    std::optional<std::reference_wrapper<TerrainTileCache>> tileCache_;
     Config config_;
 
     std::unordered_map<uint64_t, PhysicsTileEntry> loadedTiles_;


### PR DESCRIPTION
- PhysicsTerrainTileManager: Convert physics_ and tileCache_ raw pointers to std::optional<std::reference_wrapper<T>> for type-safe non-owning references that are initialized via init()

- AsyncStartupLoader: Remove unused vulkanContext_ member variable (was assigned but never used after assignment)

- Renderer: Remove redundant window member variable since VulkanContext already stores and manages the SDL_Window* reference