### PR TITLE
Replace unique_ptr with make_unique

### DIFF
--- a/src/core/GlobalBufferManager.h
+++ b/src/core/GlobalBufferManager.h
@@ -25,18 +25,23 @@
  */
 class GlobalBufferManager {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     /**
      * Factory: Create and initialize buffer manager.
      * Returns nullptr on failure.
      */
     static std::unique_ptr<GlobalBufferManager> create(VmaAllocator allocator, VkPhysicalDevice physicalDevice,
                                                         uint32_t frameCount, uint32_t maxBones = 128) {
-        auto manager = std::unique_ptr<GlobalBufferManager>(new GlobalBufferManager());
+        auto manager = std::make_unique<GlobalBufferManager>(ConstructToken{});
         if (!manager->initInternal(allocator, physicalDevice, frameCount, maxBones)) {
             return nullptr;
         }
         return manager;
     }
+
+    explicit GlobalBufferManager(ConstructToken) {}
 
     ~GlobalBufferManager() {
         cleanup();
@@ -64,8 +69,6 @@ public:
     uint32_t getMaxBoneMatrices() const { return maxBoneMatrices_; }
 
 private:
-    GlobalBufferManager() = default;
-
     bool initInternal(VmaAllocator allocator, VkPhysicalDevice physicalDevice,
                       uint32_t frameCount, uint32_t maxBones) {
         allocator_ = allocator;

--- a/src/gui/GuiSystem.cpp
+++ b/src/gui/GuiSystem.cpp
@@ -53,15 +53,12 @@ static void checkVkResult(VkResult err) {
     }
 }
 
-// Private constructor
-GuiSystem::GuiSystem() = default;
-
 // Factory
 std::unique_ptr<GuiSystem> GuiSystem::create(SDL_Window* window, VkInstance instance,
                                               VkPhysicalDevice physicalDevice, VkDevice device,
                                               uint32_t graphicsQueueFamily, VkQueue graphicsQueue,
                                               VkRenderPass renderPass, uint32_t imageCount) {
-    auto gui = std::unique_ptr<GuiSystem>(new GuiSystem());
+    auto gui = std::make_unique<GuiSystem>(ConstructToken{});
     if (!gui->initInternal(window, instance, physicalDevice, device, graphicsQueueFamily,
                            graphicsQueue, renderPass, imageCount)) {
         return nullptr;

--- a/src/gui/GuiSystem.h
+++ b/src/gui/GuiSystem.h
@@ -17,6 +17,9 @@ class Camera;
 
 class GuiSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     /**
      * Factory: Create and initialize GUI system.
      * Returns nullptr on failure.
@@ -53,8 +56,9 @@ public:
     PlayerSettings& getPlayerSettings() { return playerSettings; }
     const PlayerSettings& getPlayerSettings() const { return playerSettings; }
 
+    explicit GuiSystem(ConstructToken) {}
+
 private:
-    GuiSystem();  // Private: use factory
     bool initInternal(SDL_Window* window, VkInstance instance, VkPhysicalDevice physicalDevice,
                       VkDevice device, uint32_t graphicsQueueFamily, VkQueue graphicsQueue,
                       VkRenderPass renderPass, uint32_t imageCount);

--- a/src/lighting/ShadowSystem.cpp
+++ b/src/lighting/ShadowSystem.cpp
@@ -13,7 +13,7 @@
 
 // Factory implementations
 std::unique_ptr<ShadowSystem> ShadowSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<ShadowSystem>(new ShadowSystem());
+    auto system = std::make_unique<ShadowSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/lighting/ShadowSystem.h
+++ b/src/lighting/ShadowSystem.h
@@ -28,6 +28,9 @@ struct ShadowPushConstants {
 
 class ShadowSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     // Configuration for shadow system initialization
     struct InitInfo {
         VkDevice device;
@@ -111,9 +114,9 @@ public:
                               const DrawCallback& skinnedDrawCallback,
                               const std::vector<Light>& visibleLights);
 
-private:
-    ShadowSystem() = default;  // Private: use factory
+    explicit ShadowSystem(ConstructToken) {}
 
+private:
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/postprocess/BilateralGridSystem.cpp
+++ b/src/postprocess/BilateralGridSystem.cpp
@@ -31,7 +31,7 @@ struct BilateralBlurUniforms {
 };
 
 std::unique_ptr<BilateralGridSystem> BilateralGridSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<BilateralGridSystem>(new BilateralGridSystem());
+    auto system = std::make_unique<BilateralGridSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/postprocess/BilateralGridSystem.h
+++ b/src/postprocess/BilateralGridSystem.h
@@ -26,6 +26,9 @@
 
 class BilateralGridSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
@@ -89,9 +92,9 @@ public:
     float getMinLogLuminance() const { return MIN_LOG_LUMINANCE; }
     float getMaxLogLuminance() const { return MAX_LOG_LUMINANCE; }
 
-private:
-    BilateralGridSystem() = default;  // Private: use factory
+    explicit BilateralGridSystem(ConstructToken) {}
 
+private:
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/postprocess/BloomSystem.cpp
+++ b/src/postprocess/BloomSystem.cpp
@@ -12,7 +12,7 @@
 #include <SDL3/SDL.h>
 
 std::unique_ptr<BloomSystem> BloomSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<BloomSystem>(new BloomSystem());
+    auto system = std::make_unique<BloomSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/postprocess/BloomSystem.h
+++ b/src/postprocess/BloomSystem.h
@@ -12,6 +12,9 @@
 
 class BloomSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     // Legacy InitInfo - kept for backward compatibility during migration
     struct InitInfo {
         VkDevice device;
@@ -49,9 +52,9 @@ public:
     void setIntensity(float i) { intensity = i; }
     float getIntensity() const { return intensity; }
 
-private:
-    BloomSystem() = default;  // Private: use factory
+    explicit BloomSystem(ConstructToken) {}
 
+private:
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/postprocess/HiZSystem.cpp
+++ b/src/postprocess/HiZSystem.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 
 std::unique_ptr<HiZSystem> HiZSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<HiZSystem>(new HiZSystem());
+    auto system = std::make_unique<HiZSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/postprocess/HiZSystem.h
+++ b/src/postprocess/HiZSystem.h
@@ -64,6 +64,9 @@ struct HiZPyramidPushConstants {
 // Generates a depth pyramid from the depth buffer and uses it to cull objects
 class HiZSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
@@ -141,9 +144,9 @@ public:
     };
     CullingStats getStats() const { return stats; }
 
-private:
-    HiZSystem() = default;  // Private: use factory
+    explicit HiZSystem(ConstructToken) {}
 
+private:
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/postprocess/SSRSystem.cpp
+++ b/src/postprocess/SSRSystem.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 
 std::unique_ptr<SSRSystem> SSRSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<SSRSystem>(new SSRSystem());
+    auto system = std::make_unique<SSRSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/postprocess/SSRSystem.h
+++ b/src/postprocess/SSRSystem.h
@@ -30,6 +30,9 @@
 
 class SSRSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         VkDevice device;
         VkPhysicalDevice physicalDevice;
@@ -118,9 +121,9 @@ public:
     bool isBlurEnabled() const { return blurEnabled; }
     float getBlurRadius() const { return blurRadius; }
 
-private:
-    SSRSystem() = default;  // Private: use factory
+    explicit SSRSystem(ConstructToken) {}
 
+private:
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/vegetation/ImpostorCullSystem.cpp
+++ b/src/vegetation/ImpostorCullSystem.cpp
@@ -11,7 +11,7 @@
 #include <cstring>
 
 std::unique_ptr<ImpostorCullSystem> ImpostorCullSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<ImpostorCullSystem>(new ImpostorCullSystem());
+    auto system = std::make_unique<ImpostorCullSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/vegetation/ImpostorCullSystem.h
+++ b/src/vegetation/ImpostorCullSystem.h
@@ -68,6 +68,9 @@ struct ImpostorOutputData {
  */
 class ImpostorCullSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         const vk::raii::Device* raiiDevice = nullptr;
         VkDevice device;
@@ -174,8 +177,9 @@ public:
     // Initialize static descriptor set bindings (call once after buffers are created)
     void initializeDescriptorSets();
 
+    explicit ImpostorCullSystem(ConstructToken) {}
+
 private:
-    ImpostorCullSystem() = default;
     bool initInternal(const InitInfo& info);
     void cleanup();
 

--- a/src/vegetation/TreeBranchCulling.cpp
+++ b/src/vegetation/TreeBranchCulling.cpp
@@ -9,7 +9,7 @@
 #include <cstring>
 
 std::unique_ptr<TreeBranchCulling> TreeBranchCulling::create(const InitInfo& info) {
-    auto culling = std::unique_ptr<TreeBranchCulling>(new TreeBranchCulling());
+    auto culling = std::make_unique<TreeBranchCulling>(ConstructToken{});
     if (!culling->init(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeBranchCulling.h
+++ b/src/vegetation/TreeBranchCulling.h
@@ -64,6 +64,9 @@ static_assert(sizeof(BranchMeshGroupGPU) == 32, "BranchMeshGroupGPU must be 32 b
 // Reduces per-tree draw calls to per-archetype indirect draws
 class TreeBranchCulling {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         VkDevice device;
         VkPhysicalDevice physicalDevice;
@@ -116,8 +119,9 @@ public:
 
     VkDevice getDevice() const { return device_; }
 
+    explicit TreeBranchCulling(ConstructToken) {}
+
 private:
-    TreeBranchCulling() = default;
     bool init(const InitInfo& info);
 
     bool createCullPipeline();

--- a/src/vegetation/TreeImpostorAtlas.cpp
+++ b/src/vegetation/TreeImpostorAtlas.cpp
@@ -15,7 +15,7 @@
 #include <vulkan/vulkan.hpp>
 
 std::unique_ptr<TreeImpostorAtlas> TreeImpostorAtlas::create(const InitInfo& info) {
-    auto atlas = std::unique_ptr<TreeImpostorAtlas>(new TreeImpostorAtlas());
+    auto atlas = std::make_unique<TreeImpostorAtlas>(ConstructToken{});
     if (!atlas->initInternal(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeImpostorAtlas.h
+++ b/src/vegetation/TreeImpostorAtlas.h
@@ -16,6 +16,9 @@
 
 class TreeImpostorAtlas {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         const vk::raii::Device* raiiDevice;  // vulkan-hpp RAII device
         VkDevice device;
@@ -69,8 +72,9 @@ public:
     VkDescriptorSet getPreviewDescriptorSet(uint32_t archetypeIndex);
     VkDescriptorSet getNormalPreviewDescriptorSet(uint32_t archetypeIndex);
 
+    explicit TreeImpostorAtlas(ConstructToken) {}
+
 private:
-    TreeImpostorAtlas() = default;
     bool initInternal(const InitInfo& info);
 
     // Pipeline and resource creation (implemented in TreeImpostorAtlasCapture.cpp)

--- a/src/vegetation/TreeLODSystem.cpp
+++ b/src/vegetation/TreeLODSystem.cpp
@@ -15,7 +15,7 @@
 #include <limits>
 
 std::unique_ptr<TreeLODSystem> TreeLODSystem::create(const InitInfo& info) {
-    auto system = std::unique_ptr<TreeLODSystem>(new TreeLODSystem());
+    auto system = std::make_unique<TreeLODSystem>(ConstructToken{});
     if (!system->initInternal(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeLODSystem.h
+++ b/src/vegetation/TreeLODSystem.h
@@ -44,6 +44,9 @@ struct ImpostorInstanceGPU {
 
 class TreeLODSystem {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         const vk::raii::Device* raiiDevice;  // vulkan-hpp RAII device
         VkDevice device;
@@ -162,8 +165,9 @@ public:
     };
     const DebugInfo& getDebugInfo() const { return debugInfo_; }
 
+    explicit TreeLODSystem(ConstructToken) {}
+
 private:
-    TreeLODSystem() = default;
     bool initInternal(const InitInfo& info);
     bool createPipeline();
     bool createShadowPipeline();

--- a/src/vegetation/TreeLeafCulling.cpp
+++ b/src/vegetation/TreeLeafCulling.cpp
@@ -11,7 +11,7 @@
 #include <numeric>
 
 std::unique_ptr<TreeLeafCulling> TreeLeafCulling::create(const InitInfo& info) {
-    auto culling = std::unique_ptr<TreeLeafCulling>(new TreeLeafCulling());
+    auto culling = std::make_unique<TreeLeafCulling>(ConstructToken{});
     if (!culling->init(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeLeafCulling.h
+++ b/src/vegetation/TreeLeafCulling.h
@@ -132,6 +132,9 @@ struct TreeRenderDataGPU {
 // Encapsulates all tree leaf culling compute pipelines and buffers
 class TreeLeafCulling {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         const vk::raii::Device* raiiDevice = nullptr;
         VkDevice device;
@@ -200,8 +203,9 @@ public:
 
     VkDevice getDevice() const { return device_; }
 
+    explicit TreeLeafCulling(ConstructToken) {}
+
 private:
-    TreeLeafCulling() = default;
     bool init(const InitInfo& info);
 
     bool createLeafCullPipeline();

--- a/src/vegetation/TreeRenderer.cpp
+++ b/src/vegetation/TreeRenderer.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 
 std::unique_ptr<TreeRenderer> TreeRenderer::create(const InitInfo& info) {
-    auto renderer = std::unique_ptr<TreeRenderer>(new TreeRenderer());
+    auto renderer = std::make_unique<TreeRenderer>(ConstructToken{});
     if (!renderer->initInternal(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeRenderer.h
+++ b/src/vegetation/TreeRenderer.h
@@ -53,6 +53,9 @@ struct TreeBranchShadowInstancedPushConstants {
 
 class TreeRenderer {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         const vk::raii::Device* raiiDevice = nullptr;
         vk::Device device;
@@ -176,8 +179,9 @@ public:
 
     vk::Device getDevice() const { return device_; }
 
+    explicit TreeRenderer(ConstructToken) {}
+
 private:
-    TreeRenderer() = default;
     bool initInternal(const InitInfo& info);
     bool createPipelines(const InitInfo& info);
     bool createDescriptorSetLayout();

--- a/src/vegetation/TreeSpatialIndex.cpp
+++ b/src/vegetation/TreeSpatialIndex.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 std::unique_ptr<TreeSpatialIndex> TreeSpatialIndex::create(const InitInfo& info) {
-    auto index = std::unique_ptr<TreeSpatialIndex>(new TreeSpatialIndex());
+    auto index = std::make_unique<TreeSpatialIndex>(ConstructToken{});
     if (!index->initInternal(info)) {
         return nullptr;
     }

--- a/src/vegetation/TreeSpatialIndex.h
+++ b/src/vegetation/TreeSpatialIndex.h
@@ -45,6 +45,9 @@ struct SortedTreeEntry {
  */
 class TreeSpatialIndex {
 public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+
     struct InitInfo {
         VkDevice device;
         VmaAllocator allocator;
@@ -116,8 +119,9 @@ public:
                !sortedTreeBuffers_.empty() && sortedTreeBuffers_[0] != VK_NULL_HANDLE;
     }
 
+    explicit TreeSpatialIndex(ConstructToken) {}
+
 private:
-    TreeSpatialIndex() = default;
     bool initInternal(const InitInfo& info);
     void cleanup();
 


### PR DESCRIPTION
Modernize factory methods across 15 classes to use std::make_unique instead of std::unique_ptr(new T()). Since constructors are private to enforce factory pattern usage, add a passkey idiom (ConstructToken struct) that allows make_unique to construct objects while keeping the constructors effectively private.

Classes updated:
- TreeImpostorAtlas, SSRSystem, GuiSystem, TreeLeafCulling
- ImpostorCullSystem, HiZSystem, TreeSpatialIndex, TreeRenderer
- BilateralGridSystem, TreeLODSystem, TreeBranchCulling, BloomSystem
- ShadowSystem, GlobalBufferManager, Profiler

Benefits of make_unique:
- Exception safety: avoids potential memory leaks on construction exceptions
- More concise code
- Modern C++ best practice (Scott Meyers' Effective Modern C++ Item 21)