### PR TITLE
Migrate water subsystem to vulkan-hpp RAII patterns

### DIFF
--- a/src/water/FlowMapGenerator.h
+++ b/src/water/FlowMapGenerator.h
@@ -75,7 +75,7 @@ public:
                                 const Config& config);
 
     // Access the generated flow map
-    VkImageView getFlowMapView() const { return flowMapView; }
+    VkImageView getFlowMapView() const { return flowMapView_ ? **flowMapView_ : VK_NULL_HANDLE; }
     VkSampler getFlowMapSampler() const { return flowMapSampler_ ? **flowMapSampler_ : VK_NULL_HANDLE; }
     VkImage getFlowMapImage() const { return flowMapImage; }
 
@@ -119,7 +119,7 @@ private:
 
     VkImage flowMapImage = VK_NULL_HANDLE;
     VmaAllocation flowMapAllocation = VK_NULL_HANDLE;
-    VkImageView flowMapView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> flowMapView_;
     std::optional<vk::raii::Sampler> flowMapSampler_;
 
     // CPU-side flow data

--- a/src/water/FoamBuffer.h
+++ b/src/water/FoamBuffer.h
@@ -92,7 +92,7 @@ public:
                        VkImageView flowMapView, VkSampler flowMapSampler);
 
     // Get foam buffer for sampling in water shader
-    VkImageView getFoamBufferView() const { return foamBufferView[currentBuffer]; }
+    VkImageView getFoamBufferView() const { return foamBufferView_[currentBuffer] ? **foamBufferView_[currentBuffer] : VK_NULL_HANDLE; }
     VkSampler getSampler() const { return sampler_ ? **sampler_ : VK_NULL_HANDLE; }
 
     // Configuration
@@ -155,7 +155,7 @@ private:
     // Double-buffered foam maps (ping-pong for blur)
     // R16F format - single channel foam intensity
     VkImage foamBuffer[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-    VkImageView foamBufferView[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    std::optional<vk::raii::ImageView> foamBufferView_[2];
     VmaAllocation foamAllocation[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
     int currentBuffer = 0;  // Which buffer to read from
 
@@ -166,7 +166,7 @@ private:
     std::optional<vk::raii::Pipeline> computePipeline_;
     std::optional<vk::raii::PipelineLayout> computePipelineLayout_;
     std::optional<vk::raii::DescriptorSetLayout> descriptorSetLayout_;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    std::optional<vk::raii::DescriptorPool> descriptorPool_;
     std::vector<VkDescriptorSet> descriptorSets;
 
     // Phase 16: Wake system

--- a/src/water/OceanFFT.h
+++ b/src/water/OceanFFT.h
@@ -243,7 +243,7 @@ private:
     std::optional<vk::raii::DescriptorSetLayout> displacementDescLayout_;
 
     // Descriptor pool and sets
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    std::optional<vk::raii::DescriptorPool> descriptorPool_;
     std::vector<VkDescriptorSet> spectrumDescSets;
     std::vector<VkDescriptorSet> timeEvolutionDescSets;
     std::vector<VkDescriptorSet> fftDescSets;       // Multiple for ping-pong

--- a/src/water/WaterDisplacement.h
+++ b/src/water/WaterDisplacement.h
@@ -84,7 +84,7 @@ public:
     void recordCompute(VkCommandBuffer cmd, uint32_t frameIndex);
 
     // Get displacement map for sampling in water shader
-    VkImageView getDisplacementMapView() const { return displacementMapView; }
+    VkImageView getDisplacementMapView() const { return displacementMapView_ ? **displacementMapView_ : VK_NULL_HANDLE; }
     VkSampler getSampler() const { return sampler_ ? **sampler_ : VK_NULL_HANDLE; }
 
     // Get descriptor set for water shader binding
@@ -131,12 +131,12 @@ private:
 
     // Displacement map (R16F - single channel height)
     VkImage displacementMap = VK_NULL_HANDLE;
-    VkImageView displacementMapView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> displacementMapView_;
     VmaAllocation displacementAllocation = VK_NULL_HANDLE;
 
     // Previous frame displacement (for temporal blending)
     VkImage prevDisplacementMap = VK_NULL_HANDLE;
-    VkImageView prevDisplacementMapView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> prevDisplacementMapView_;
     VmaAllocation prevDisplacementAllocation = VK_NULL_HANDLE;
 
     // Sampler (RAII-managed)
@@ -146,7 +146,7 @@ private:
     std::optional<vk::raii::Pipeline> computePipeline_;
     std::optional<vk::raii::PipelineLayout> computePipelineLayout_;
     std::optional<vk::raii::DescriptorSetLayout> descriptorSetLayout_;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    std::optional<vk::raii::DescriptorPool> descriptorPool_;
     std::vector<VkDescriptorSet> descriptorSets;
 
     // Particle buffer (SSBO, RAII-managed)

--- a/src/water/WaterGBuffer.h
+++ b/src/water/WaterGBuffer.h
@@ -72,9 +72,9 @@ public:
     VkExtent2D getExtent() const { return gbufferExtent; }
 
     // Get G-buffer textures for sampling in composite pass
-    VkImageView getDataImageView() const { return dataImageView; }
-    VkImageView getNormalImageView() const { return normalImageView; }
-    VkImageView getDepthImageView() const { return depthImageView; }
+    VkImageView getDataImageView() const { return dataImageView_ ? **dataImageView_ : VK_NULL_HANDLE; }
+    VkImageView getNormalImageView() const { return normalImageView_ ? **normalImageView_ : VK_NULL_HANDLE; }
+    VkImageView getDepthImageView() const { return depthImageView_ ? **depthImageView_ : VK_NULL_HANDLE; }
     VkSampler getSampler() const { return sampler_ ? **sampler_ : VK_NULL_HANDLE; }
 
     // Get pipeline resources
@@ -125,15 +125,15 @@ private:
 
     // G-buffer images
     VkImage dataImage = VK_NULL_HANDLE;
-    VkImageView dataImageView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> dataImageView_;
     VmaAllocation dataAllocation = VK_NULL_HANDLE;
 
     VkImage normalImage = VK_NULL_HANDLE;
-    VkImageView normalImageView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> normalImageView_;
     VmaAllocation normalAllocation = VK_NULL_HANDLE;
 
     VkImage depthImage = VK_NULL_HANDLE;
-    VkImageView depthImageView = VK_NULL_HANDLE;
+    std::optional<vk::raii::ImageView> depthImageView_;
     VmaAllocation depthAllocation = VK_NULL_HANDLE;
 
     // Render pass and framebuffer (RAII-managed)

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -51,16 +51,12 @@ bool WaterTileCull::initInternal(const InitInfo& info) {
 }
 
 void WaterTileCull::cleanup() {
-    if (device == VK_NULL_HANDLE) return;
+    if (!raiiDevice_) return;
 
-    vkDeviceWaitIdle(device);
-
-    if (descriptorPool != VK_NULL_HANDLE) {
-        vkDestroyDescriptorPool(device, descriptorPool, nullptr);
-        descriptorPool = VK_NULL_HANDLE;
-    }
+    raiiDevice_->waitIdle();
 
     // RAII wrappers handle cleanup automatically - just reset them
+    descriptorPool_.reset();
     computePipeline_.reset();
     computePipelineLayout_.reset();
     descriptorSetLayout_.reset();
@@ -100,11 +96,8 @@ void WaterTileCull::resize(VkExtent2D newExtent) {
 
         createBuffers();
 
-        // Recreate descriptor sets
-        if (descriptorPool != VK_NULL_HANDLE) {
-            vkDestroyDescriptorPool(device, descriptorPool, nullptr);
-            descriptorPool = VK_NULL_HANDLE;
-        }
+        // Recreate descriptor sets (RAII handles cleanup)
+        descriptorPool_.reset();
         createDescriptorSets();
     }
 
@@ -163,54 +156,47 @@ bool WaterTileCull::createComputePipeline() {
     // 2: Counter buffer (storage)
     // 3: Indirect draw buffer (storage)
 
-    auto makeComputeBinding = [](uint32_t binding, VkDescriptorType type) {
-        VkDescriptorSetLayoutBinding b{};
-        b.binding = binding;
-        b.descriptorType = type;
-        b.descriptorCount = 1;
-        b.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-        return b;
+    auto makeComputeBinding = [](uint32_t binding, vk::DescriptorType type) {
+        return vk::DescriptorSetLayoutBinding{}
+            .setBinding(binding)
+            .setDescriptorType(type)
+            .setDescriptorCount(1)
+            .setStageFlags(vk::ShaderStageFlagBits::eCompute);
     };
 
-    std::array<VkDescriptorSetLayoutBinding, 4> bindings = {
-        makeComputeBinding(0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER),
-        makeComputeBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
-        makeComputeBinding(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER),
-        makeComputeBinding(3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
+    std::array<vk::DescriptorSetLayoutBinding, 4> bindings = {
+        makeComputeBinding(0, vk::DescriptorType::eCombinedImageSampler),
+        makeComputeBinding(1, vk::DescriptorType::eStorageBuffer),
+        makeComputeBinding(2, vk::DescriptorType::eStorageBuffer),
+        makeComputeBinding(3, vk::DescriptorType::eStorageBuffer)
     };
 
-    VkDescriptorSetLayoutCreateInfo layoutInfo{};
-    layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
-    layoutInfo.pBindings = bindings.data();
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
+        .setBindings(bindings);
 
-    VkDescriptorSetLayout rawDescLayout = VK_NULL_HANDLE;
-    if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &rawDescLayout) != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull descriptor set layout");
+    try {
+        descriptorSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull descriptor set layout: %s", e.what());
         return false;
     }
-    descriptorSetLayout_.emplace(*raiiDevice_, rawDescLayout);
 
     // Push constant range
-    VkPushConstantRange pushConstantRange{};
-    pushConstantRange.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pushConstantRange.offset = 0;
-    pushConstantRange.size = sizeof(TileCullPushConstants);
+    auto pushConstantRange = vk::PushConstantRange{}
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute)
+        .setOffset(0)
+        .setSize(sizeof(TileCullPushConstants));
 
-    VkDescriptorSetLayout rawLayout = **descriptorSetLayout_;
-    VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
-    pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pipelineLayoutInfo.setLayoutCount = 1;
-    pipelineLayoutInfo.pSetLayouts = &rawLayout;
-    pipelineLayoutInfo.pushConstantRangeCount = 1;
-    pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}
+        .setSetLayouts(**descriptorSetLayout_)
+        .setPushConstantRanges(pushConstantRange);
 
-    VkPipelineLayout rawPipelineLayout = VK_NULL_HANDLE;
-    if (vkCreatePipelineLayout(device, &pipelineLayoutInfo, nullptr, &rawPipelineLayout) != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull pipeline layout");
+    try {
+        computePipelineLayout_.emplace(*raiiDevice_, pipelineLayoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull pipeline layout: %s", e.what());
         return false;
     }
-    computePipelineLayout_.emplace(*raiiDevice_, rawPipelineLayout);
 
     if (!ComputePipelineBuilder(*raiiDevice_)
             .setShader(shaderPath + "/water_tile_cull.comp.spv")
@@ -234,34 +220,40 @@ bool WaterTileCull::createComputePipeline() {
 }
 
 bool WaterTileCull::createDescriptorSets() {
-    std::array<VkDescriptorPoolSize, 2> poolSizes{};
-    poolSizes[0].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    poolSizes[0].descriptorCount = framesInFlight;
-    poolSizes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    poolSizes[1].descriptorCount = framesInFlight * 3;  // tile, counter, indirect
+    std::array<vk::DescriptorPoolSize, 2> poolSizes = {
+        vk::DescriptorPoolSize{}
+            .setType(vk::DescriptorType::eCombinedImageSampler)
+            .setDescriptorCount(framesInFlight),
+        vk::DescriptorPoolSize{}
+            .setType(vk::DescriptorType::eStorageBuffer)
+            .setDescriptorCount(framesInFlight * 3)  // tile, counter, indirect
+    };
 
-    VkDescriptorPoolCreateInfo poolInfo{};
-    poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = static_cast<uint32_t>(poolSizes.size());
-    poolInfo.pPoolSizes = poolSizes.data();
-    poolInfo.maxSets = framesInFlight;
+    auto poolInfo = vk::DescriptorPoolCreateInfo{}
+        .setPoolSizes(poolSizes)
+        .setMaxSets(framesInFlight);
 
-    if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &descriptorPool) != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull descriptor pool");
+    try {
+        descriptorPool_.emplace(*raiiDevice_, poolInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull descriptor pool: %s", e.what());
         return false;
     }
 
-    std::vector<VkDescriptorSetLayout> layouts(framesInFlight, **descriptorSetLayout_);
+    std::vector<vk::DescriptorSetLayout> layouts(framesInFlight, **descriptorSetLayout_);
 
-    VkDescriptorSetAllocateInfo allocInfo{};
-    allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool;
-    allocInfo.descriptorSetCount = framesInFlight;
-    allocInfo.pSetLayouts = layouts.data();
+    auto allocInfo = vk::DescriptorSetAllocateInfo{}
+        .setDescriptorPool(**descriptorPool_)
+        .setSetLayouts(layouts);
 
-    descriptorSets.resize(framesInFlight);
-    if (vkAllocateDescriptorSets(device, &allocInfo, descriptorSets.data()) != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate tile cull descriptor sets");
+    try {
+        auto allocatedSets = vk::Device(device).allocateDescriptorSets(allocInfo);
+        descriptorSets.resize(framesInFlight);
+        for (uint32_t i = 0; i < framesInFlight; ++i) {
+            descriptorSets[i] = allocatedSets[i];
+        }
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to allocate tile cull descriptor sets: %s", e.what());
         return false;
     }
 

--- a/src/water/WaterTileCull.h
+++ b/src/water/WaterTileCull.h
@@ -160,7 +160,7 @@ private:
     std::optional<vk::raii::Pipeline> computePipeline_;
     std::optional<vk::raii::PipelineLayout> computePipelineLayout_;
     std::optional<vk::raii::DescriptorSetLayout> descriptorSetLayout_;
-    VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+    std::optional<vk::raii::DescriptorPool> descriptorPool_;
     std::vector<VkDescriptorSet> descriptorSets;
 
     // Depth texture sampler for tile culling (RAII-managed)


### PR DESCRIPTION
- WaterTileCull: Convert to RAII descriptor pool, use builder patterns for descriptor set layouts, pipeline layouts, and compute pipelines
- WaterDisplacement: Convert to RAII image views and descriptor pool, use vulkan-hpp builder patterns throughout
- FoamBuffer: Convert to RAII image views and descriptor pool, use ImageBuilder for foam buffer creation
- FlowMapGenerator: Convert to RAII image view, use ImageBuilder
- WaterGBuffer: Convert to RAII image views, render pass, framebuffer, and use builder patterns for all Vulkan structures
- OceanFFT: Convert to RAII descriptor pool, use vulkan-hpp builder patterns for all descriptor set layouts, pipeline layouts, and compute pipelines

Key changes:
- Replace VkDescriptorPool with std::optional<vk::raii::DescriptorPool>
- Replace VkImageView with std::optional<vk::raii::ImageView>
- Replace vkDeviceWaitIdle() with raiiDevice_->waitIdle()
- Replace vkCreateComputePipelines() with raiiDevice_->createComputePipeline()
- Replace manual VkStructure initialization with vulkan-hpp builders
- Use try/catch for Vulkan object creation with proper error logging
- Remove manual vkDestroyShaderModule() calls (RAII handles cleanup)

This eliminates C API usage patterns throughout the water rendering subsystem in favor of type-safe vulkan-hpp RAII wrappers.