### PR TITLE
Optimize queue submit frame time performance

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -76,6 +76,7 @@
 #include <limits>
 #include <algorithm>
 #include <numeric>
+#include <chrono>
 
 std::unique_ptr<Renderer> Renderer::create(const InitInfo& info) {
     std::unique_ptr<Renderer> instance(new Renderer());
@@ -977,10 +978,22 @@ bool Renderer::render(const Camera& camera) {
     // Begin CPU profiling for this frame (must be before any CPU zones)
     systems_->profiler().beginCpuFrame();
 
+    // Reset queue submit diagnostics for this frame
+    auto& qsDiag = systems_->profiler().getQueueSubmitDiagnostics();
+    qsDiag.reset();
+    qsDiag.validationLayersEnabled = vulkanContext_->hasValidationLayers();
+
     // Frame synchronization - use non-blocking check first to avoid unnecessary waits
     // With triple buffering, the fence is often already signaled
     systems_->profiler().beginCpuZone("Wait:FenceSync");
+
+    // Track fence status for diagnostics
+    qsDiag.fenceWasAlreadySignaled = frameSync_.isCurrentFenceSignaled();
+    auto fenceStart = std::chrono::high_resolution_clock::now();
     frameSync_.waitForCurrentFrameIfNeeded();
+    auto fenceEnd = std::chrono::high_resolution_clock::now();
+    qsDiag.fenceWaitTimeMs = std::chrono::duration<float, std::milli>(fenceEnd - fenceStart).count();
+
     systems_->profiler().endCpuZone("Wait:FenceSync");
 
     systems_->profiler().beginCpuZone("Wait:AcquireImage");
@@ -1263,6 +1276,13 @@ bool Renderer::render(const Camera& camera) {
 
     VkCommandBuffer cmd = commandBuffers[frame.frameIndex];
 
+    // Get reference to diagnostics for command counting
+    auto& cmdDiag = systems_->profiler().getQueueSubmitDiagnostics();
+
+    // Begin command capture if requested
+    auto& cmdCapture = systems_->profiler().getCommandCapture();
+    cmdCapture.beginFrame(systems_->profiler().getFrameNumber());
+
     // Begin GPU profiling frame
     systems_->profiler().beginGpuFrame(cmd, frame.frameIndex);
 
@@ -1301,7 +1321,10 @@ bool Renderer::render(const Camera& camera) {
         if (lastSunIntensity > 0.001f && perfToggles.shadowPass) {
             systems_->profiler().beginCpuZone("ShadowRecord");
             systems_->profiler().beginGpuZone(cmd, "ShadowPass");
+            cmdDiag.renderPassCount++;  // Shadow cascade render pass
+            cmdCapture.recordBeginRenderPass("ShadowSystem", "ShadowCascades");
             recordShadowPass(cmd, frame.frameIndex, frame.time, frame.cameraPosition);
+            cmdCapture.recordEndRenderPass("ShadowSystem");
             systems_->profiler().endGpuZone(cmd, "ShadowPass");
             systems_->profiler().endCpuZone("ShadowRecord");
         }
@@ -1318,16 +1341,20 @@ bool Renderer::render(const Camera& camera) {
             systems_->waterGBuffer().getPipeline() != VK_NULL_HANDLE &&
             systems_->waterTileCull().wasWaterVisibleLastFrame(frame.frameIndex)) {
             systems_->profiler().beginGpuZone(cmd, "WaterGBuffer");
+            cmdDiag.renderPassCount++;  // Water G-buffer pass
             systems_->waterGBuffer().beginRenderPass(cmd);
 
             // Bind G-buffer pipeline and descriptor set
             vkCmd.bindPipeline(vk::PipelineBindPoint::eGraphics, systems_->waterGBuffer().getPipeline());
+            cmdDiag.pipelineBindCount++;
             vk::DescriptorSet gbufferDescSet = systems_->waterGBuffer().getDescriptorSet(frame.frameIndex);
             vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
                                      systems_->waterGBuffer().getPipelineLayout(), 0, gbufferDescSet, {});
+            cmdDiag.descriptorSetBindCount++;
 
             // Draw water mesh
             systems_->water().recordMeshDraw(cmd);
+            cmdDiag.drawCallCount++;
 
             systems_->waterGBuffer().endRenderPass(cmd);
             systems_->profiler().endGpuZone(cmd, "WaterGBuffer");
@@ -1338,13 +1365,17 @@ bool Renderer::render(const Camera& camera) {
         // contains granular HDR:* sub-zones. Nesting would confuse the profiler.
         if (hdrPassEnabled) {
             systems_->profiler().beginCpuZone("RenderPassRecord");
+            cmdDiag.renderPassCount++;  // HDR main render pass
+            cmdCapture.recordBeginRenderPass("HDRPass", "MainScene");
             recordHDRPass(cmd, frame.frameIndex, frame.time);
+            cmdCapture.recordEndRenderPass("HDRPass");
             systems_->profiler().endCpuZone("RenderPassRecord");
 
             // Screen-Space Reflections compute pass (Phase 10)
             // Computes SSR for next frame's water - uses current scene for temporal stability
             if (perfToggles.ssr && systems_->ssr().isEnabled()) {
                 systems_->profiler().beginGpuZone(cmd, "SSR");
+                cmdDiag.dispatchCount++;  // SSR compute
                 systems_->ssr().recordCompute(cmd, frame.frameIndex,
                                         systems_->postProcess().getHDRColorView(),
                                         systems_->postProcess().getHDRDepthView(),
@@ -1357,6 +1388,7 @@ bool Renderer::render(const Camera& camera) {
             // Determines which screen tiles contain water for optimized rendering
             if (perfToggles.waterTileCull && systems_->waterTileCull().isEnabled()) {
                 systems_->profiler().beginGpuZone(cmd, "WaterTileCull");
+                cmdDiag.dispatchCount++;  // Water tile cull compute
                 glm::mat4 viewProj = frame.projection * frame.view;
                 systems_->waterTileCull().recordTileCull(cmd, frame.frameIndex,
                                               viewProj, frame.cameraPosition,
@@ -1368,16 +1400,19 @@ bool Renderer::render(const Camera& camera) {
 
         // Hi-Z pyramid and Bloom via pipeline post stage
         if (renderPipeline.postStage.hiZRecordFn) {
+            cmdDiag.dispatchCount++;  // Hi-Z compute
             renderPipeline.postStage.hiZRecordFn(ctx);
         }
         // Only run bloom passes if bloom is enabled (skip for performance)
         if (systems_->postProcess().isBloomEnabled() && renderPipeline.postStage.bloomRecordFn) {
+            cmdDiag.dispatchCount += 2;  // Bloom downsample + upsample
             renderPipeline.postStage.bloomRecordFn(ctx);
         }
 
         // Bilateral grid for local tone mapping (if enabled)
         if (systems_->postProcess().isLocalToneMapEnabled()) {
             systems_->profiler().beginGpuZone(cmd, "BilateralGrid");
+            cmdDiag.dispatchCount++;  // Bilateral grid compute
             systems_->bilateralGrid().recordBilateralGrid(cmd, frame.frameIndex,
                                                            systems_->postProcess().getHDRColorView());
             systems_->profiler().endGpuZone(cmd, "BilateralGrid");
@@ -1386,12 +1421,17 @@ bool Renderer::render(const Camera& camera) {
         // Post-process pass (with optional GUI overlay callback)
         // Note: This is not in postStage because it needs framebuffer and guiRenderCallback
         systems_->profiler().beginGpuZone(cmd, "PostProcess");
+        cmdDiag.renderPassCount++;  // Post-process render pass
+        cmdDiag.drawCallCount++;    // Full-screen quad
         systems_->postProcess().recordPostProcess(cmd, frame.frameIndex, *framebuffers_[imageIndex], frame.deltaTime, guiRenderCallback);
         systems_->profiler().endGpuZone(cmd, "PostProcess");
     }
 
     // End GPU profiling frame
     systems_->profiler().endGpuFrame(cmd, frame.frameIndex);
+
+    // End command capture
+    cmdCapture.endFrame();
 
     vkCmd.end();
 
@@ -1411,7 +1451,12 @@ bool Renderer::render(const Camera& camera) {
         .setSignalSemaphores(signalSemaphores);
 
     try {
+        // Track queue submit time for diagnostics
+        auto submitStart = std::chrono::high_resolution_clock::now();
         vk::Queue(graphicsQueue).submit(submitInfo, frameSync_.currentFence());
+        auto submitEnd = std::chrono::high_resolution_clock::now();
+        systems_->profiler().getQueueSubmitDiagnostics().queueSubmitTimeMs =
+            std::chrono::duration<float, std::milli>(submitEnd - submitStart).count();
     } catch (const vk::DeviceLostError&) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Device lost during queue submit");
         systems_->profiler().endCpuZone("QueueSubmit");

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -3,6 +3,7 @@
 #include <vulkan/vulkan_raii.hpp>
 #include <SDL3/SDL_vulkan.h>
 #include <SDL3/SDL_log.h>
+#include <cstdlib>
 
 // Required for dynamic dispatch loader - only define in one .cpp file
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
@@ -92,8 +93,22 @@ void VulkanContext::shutdown() {
 
 bool VulkanContext::createInstance() {
     vkb::InstanceBuilder builder;
+
+    // Disable validation layers in release builds for performance
+    // Validation layers add significant overhead to vkQueueSubmit
+#ifdef NDEBUG
+    constexpr bool enableValidation = false;
+#else
+    // Can be overridden via environment variable for profiling debug builds
+    const bool enableValidation = (std::getenv("DISABLE_VULKAN_VALIDATION") == nullptr);
+#endif
+
+    if (!enableValidation) {
+        SDL_Log("Vulkan validation layers disabled");
+    }
+
     auto instRet = builder.set_app_name("Vulkan Game")
-        .request_validation_layers(true)
+        .request_validation_layers(enableValidation)
         .use_default_debug_messenger()
         .require_api_version(1, 2, 0)
         .build();

--- a/src/core/vulkan/VulkanContext.h
+++ b/src/core/vulkan/VulkanContext.h
@@ -82,6 +82,9 @@ public:
 
     const vkb::Device& getVkbDevice() const { return vkbDevice; }
 
+    // Check if validation layers are enabled (useful for diagnostics)
+    bool hasValidationLayers() const { return vkbInstance.debug_messenger != VK_NULL_HANDLE; }
+
     // Check if instance phase is complete (for two-phase init)
     bool isInstanceReady() const { return instanceReady; }
 

--- a/src/debug/CommandCapture.h
+++ b/src/debug/CommandCapture.h
@@ -1,0 +1,337 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <string>
+#include <vector>
+#include <chrono>
+
+/**
+ * CommandCapture - Records detailed command buffer operations for debugging.
+ *
+ * Provides frame-by-frame capture of all recorded commands with timing.
+ * Can operate in continuous mode (every frame) or single-shot capture.
+ *
+ * Usage:
+ *   // At frame start:
+ *   capture.beginFrame();
+ *
+ *   // When recording commands:
+ *   capture.recordDraw("TerrainSystem", drawCount, instanceCount);
+ *   capture.recordDispatch("GrassCull", groupsX, groupsY, groupsZ);
+ *   capture.recordBarrier("ShadowToRead", srcStage, dstStage);
+ *
+ *   // At frame end:
+ *   capture.endFrame();
+ *
+ *   // Query results:
+ *   const auto& frame = capture.getLastCapture();
+ */
+
+enum class CommandType {
+    Draw,
+    DrawIndexed,
+    DrawIndirect,
+    DrawIndexedIndirect,
+    Dispatch,
+    DispatchIndirect,
+    BeginRenderPass,
+    EndRenderPass,
+    BindPipeline,
+    BindDescriptorSet,
+    PushConstants,
+    PipelineBarrier,
+    CopyBuffer,
+    CopyImage,
+    BlitImage,
+    ClearImage,
+    Other
+};
+
+inline const char* commandTypeName(CommandType type) {
+    switch (type) {
+        case CommandType::Draw: return "Draw";
+        case CommandType::DrawIndexed: return "DrawIndexed";
+        case CommandType::DrawIndirect: return "DrawIndirect";
+        case CommandType::DrawIndexedIndirect: return "DrawIndexedIndirect";
+        case CommandType::Dispatch: return "Dispatch";
+        case CommandType::DispatchIndirect: return "DispatchIndirect";
+        case CommandType::BeginRenderPass: return "BeginRenderPass";
+        case CommandType::EndRenderPass: return "EndRenderPass";
+        case CommandType::BindPipeline: return "BindPipeline";
+        case CommandType::BindDescriptorSet: return "BindDescriptorSet";
+        case CommandType::PushConstants: return "PushConstants";
+        case CommandType::PipelineBarrier: return "PipelineBarrier";
+        case CommandType::CopyBuffer: return "CopyBuffer";
+        case CommandType::CopyImage: return "CopyImage";
+        case CommandType::BlitImage: return "BlitImage";
+        case CommandType::ClearImage: return "ClearImage";
+        case CommandType::Other: return "Other";
+    }
+    return "Unknown";
+}
+
+struct CapturedCommand {
+    CommandType type;
+    std::string source;           // Which system recorded this (e.g., "TerrainSystem")
+    std::string details;          // Additional info (e.g., "vertices=1024, instances=50")
+    float timestampMs = 0.0f;     // Time since frame start when recorded
+
+    // For draw commands
+    uint32_t vertexCount = 0;
+    uint32_t instanceCount = 0;
+    uint32_t indexCount = 0;
+
+    // For dispatch commands
+    uint32_t groupCountX = 0;
+    uint32_t groupCountY = 0;
+    uint32_t groupCountZ = 0;
+
+    // For pipeline binds
+    VkPipelineBindPoint bindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+};
+
+struct CapturedFrame {
+    uint64_t frameNumber = 0;
+    float totalTimeMs = 0.0f;
+    std::vector<CapturedCommand> commands;
+
+    // Summary stats
+    uint32_t drawCount = 0;
+    uint32_t dispatchCount = 0;
+    uint32_t renderPassCount = 0;
+    uint32_t pipelineBindCount = 0;
+    uint32_t descriptorBindCount = 0;
+    uint32_t barrierCount = 0;
+
+    void clear() {
+        commands.clear();
+        drawCount = dispatchCount = renderPassCount = 0;
+        pipelineBindCount = descriptorBindCount = barrierCount = 0;
+    }
+
+    std::string getSummary() const {
+        std::string result;
+        result += "Frame " + std::to_string(frameNumber) + ": ";
+        result += std::to_string(commands.size()) + " commands, ";
+        result += std::to_string(drawCount) + " draws, ";
+        result += std::to_string(dispatchCount) + " dispatches, ";
+        result += std::to_string(renderPassCount) + " render passes\n";
+        return result;
+    }
+};
+
+class CommandCapture {
+public:
+    CommandCapture() = default;
+
+    // === Capture Control ===
+
+    // Enable/disable continuous capture (every frame)
+    void setContinuousCapture(bool enabled) { continuousCapture_ = enabled; }
+    bool isContinuousCapture() const { return continuousCapture_; }
+
+    // Request a single frame capture (auto-disables after capture)
+    void requestSingleCapture() { singleCaptureRequested_ = true; }
+
+    // Check if currently capturing
+    bool isCapturing() const { return capturing_; }
+
+    // === Frame Recording ===
+
+    void beginFrame(uint64_t frameNumber) {
+        if (!continuousCapture_ && !singleCaptureRequested_) {
+            capturing_ = false;
+            return;
+        }
+
+        capturing_ = true;
+        currentFrame_.clear();
+        currentFrame_.frameNumber = frameNumber;
+        frameStartTime_ = std::chrono::high_resolution_clock::now();
+    }
+
+    void endFrame() {
+        if (!capturing_) return;
+
+        auto endTime = std::chrono::high_resolution_clock::now();
+        currentFrame_.totalTimeMs =
+            std::chrono::duration<float, std::milli>(endTime - frameStartTime_).count();
+
+        lastCapture_ = currentFrame_;
+        hasCapture_ = true;
+
+        if (singleCaptureRequested_) {
+            singleCaptureRequested_ = false;
+        }
+
+        capturing_ = false;
+    }
+
+    // === Command Recording ===
+
+    void recordDraw(const char* source, uint32_t vertexCount, uint32_t instanceCount = 1) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::Draw;
+        cmd.source = source;
+        cmd.vertexCount = vertexCount;
+        cmd.instanceCount = instanceCount;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = "vertices=" + std::to_string(vertexCount) +
+                      " instances=" + std::to_string(instanceCount);
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.drawCount++;
+    }
+
+    void recordDrawIndexed(const char* source, uint32_t indexCount, uint32_t instanceCount = 1) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::DrawIndexed;
+        cmd.source = source;
+        cmd.indexCount = indexCount;
+        cmd.instanceCount = instanceCount;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = "indices=" + std::to_string(indexCount) +
+                      " instances=" + std::to_string(instanceCount);
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.drawCount++;
+    }
+
+    void recordDrawIndirect(const char* source, uint32_t drawCount) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::DrawIndirect;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = "drawCount=" + std::to_string(drawCount);
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.drawCount += drawCount;
+    }
+
+    void recordDispatch(const char* source, uint32_t groupX, uint32_t groupY, uint32_t groupZ) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::Dispatch;
+        cmd.source = source;
+        cmd.groupCountX = groupX;
+        cmd.groupCountY = groupY;
+        cmd.groupCountZ = groupZ;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = "groups=(" + std::to_string(groupX) + "," +
+                      std::to_string(groupY) + "," + std::to_string(groupZ) + ")";
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.dispatchCount++;
+    }
+
+    void recordBeginRenderPass(const char* source, const char* passName = nullptr) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::BeginRenderPass;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        if (passName) cmd.details = passName;
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.renderPassCount++;
+    }
+
+    void recordEndRenderPass(const char* source) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::EndRenderPass;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        currentFrame_.commands.push_back(std::move(cmd));
+    }
+
+    void recordBindPipeline(const char* source, VkPipelineBindPoint bindPoint) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::BindPipeline;
+        cmd.source = source;
+        cmd.bindPoint = bindPoint;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = (bindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS) ? "Graphics" : "Compute";
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.pipelineBindCount++;
+    }
+
+    void recordBindDescriptorSet(const char* source, uint32_t setIndex) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::BindDescriptorSet;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = "set=" + std::to_string(setIndex);
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.descriptorBindCount++;
+    }
+
+    void recordPipelineBarrier(const char* source, const char* description = nullptr) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::PipelineBarrier;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        if (description) cmd.details = description;
+        currentFrame_.commands.push_back(std::move(cmd));
+        currentFrame_.barrierCount++;
+    }
+
+    void recordOther(const char* source, const char* description) {
+        if (!capturing_) return;
+        CapturedCommand cmd;
+        cmd.type = CommandType::Other;
+        cmd.source = source;
+        cmd.timestampMs = getTimeSinceFrameStart();
+        cmd.details = description;
+        currentFrame_.commands.push_back(std::move(cmd));
+    }
+
+    // === Results ===
+
+    bool hasCapture() const { return hasCapture_; }
+    const CapturedFrame& getLastCapture() const { return lastCapture_; }
+
+    // Generate a detailed report for the last captured frame
+    std::string generateReport() const {
+        if (!hasCapture_) return "No capture available\n";
+
+        std::string report;
+        report += "=== Command Capture Report ===\n";
+        report += lastCapture_.getSummary();
+        report += "\n";
+
+        std::string currentSource;
+        for (const auto& cmd : lastCapture_.commands) {
+            // Group by source
+            if (cmd.source != currentSource) {
+                currentSource = cmd.source;
+                report += "\n[" + currentSource + "]\n";
+            }
+
+            report += "  ";
+            report += commandTypeName(cmd.type);
+            if (!cmd.details.empty()) {
+                report += " (" + cmd.details + ")";
+            }
+            report += " @" + std::to_string(cmd.timestampMs) + "ms\n";
+        }
+
+        return report;
+    }
+
+private:
+    float getTimeSinceFrameStart() const {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration<float, std::milli>(now - frameStartTime_).count();
+    }
+
+    bool continuousCapture_ = false;
+    bool singleCaptureRequested_ = false;
+    bool capturing_ = false;
+    bool hasCapture_ = false;
+
+    CapturedFrame currentFrame_;
+    CapturedFrame lastCapture_;
+    std::chrono::high_resolution_clock::time_point frameStartTime_;
+};

--- a/src/debug/Profiler.h
+++ b/src/debug/Profiler.h
@@ -4,6 +4,8 @@
 #include "CpuProfiler.h"
 #include "InitProfiler.h"
 #include "Flamegraph.h"
+#include "QueueSubmitDiagnostics.h"
+#include "CommandCapture.h"
 #include "interfaces/IProfilerControl.h"
 #include <memory>
 #include <optional>
@@ -338,9 +340,23 @@ public:
     const GpuFlamegraphHistory& getGpuFlamegraphHistory() const { return gpuFlamegraphHistory_; }
     const FlamegraphCapture& getInitFlamegraph() const { return initFlamegraph_; }
 
+    // Queue submit diagnostics access
+    QueueSubmitDiagnostics& getQueueSubmitDiagnostics() { return queueSubmitDiag_; }
+    const QueueSubmitDiagnostics& getQueueSubmitDiagnostics() const { return queueSubmitDiag_; }
+
+    // Command capture access
+    CommandCapture& getCommandCapture() { return commandCapture_; }
+    const CommandCapture& getCommandCapture() const { return commandCapture_; }
+
 private:
     std::optional<GpuProfiler> gpuProfiler_;
     CpuProfiler cpuProfiler;
+
+    // Queue submit diagnostics
+    QueueSubmitDiagnostics queueSubmitDiag_;
+
+    // Command capture for detailed per-frame analysis
+    CommandCapture commandCapture_;
 
     // Flamegraph capture storage
     CpuFlamegraphHistory cpuFlamegraphHistory_;

--- a/src/debug/QueueSubmitDiagnostics.h
+++ b/src/debug/QueueSubmitDiagnostics.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <cstdint>
+#include <string>
+
+/**
+ * QueueSubmitDiagnostics - Tracks metrics to diagnose high queue submit times.
+ *
+ * Common causes of high vkQueueSubmit CPU time:
+ * 1. Validation layers enabled (adds significant overhead)
+ * 2. GPU not finished with previous frame (implicit wait in driver)
+ * 3. Large command buffer (driver validation/processing)
+ * 4. Many pipeline/descriptor bindings (driver state tracking)
+ * 5. Resource hazards requiring driver-side synchronization
+ */
+struct QueueSubmitDiagnostics {
+    // === Frame Timing ===
+    // Was the fence already signaled before we waited?
+    // If false, CPU was blocked waiting for GPU = GPU-bound
+    bool fenceWasAlreadySignaled = false;
+
+    // Time spent waiting for fence (ms)
+    float fenceWaitTimeMs = 0.0f;
+
+    // Time spent in vkQueueSubmit call itself (ms)
+    float queueSubmitTimeMs = 0.0f;
+
+    // === Command Buffer Stats ===
+    uint32_t drawCallCount = 0;
+    uint32_t dispatchCount = 0;           // Compute dispatches
+    uint32_t pipelineBindCount = 0;
+    uint32_t descriptorSetBindCount = 0;
+    uint32_t pushConstantCount = 0;
+    uint32_t renderPassCount = 0;
+    uint32_t pipelineBarrierCount = 0;
+
+    // === Validation Layer Status ===
+    bool validationLayersEnabled = false;
+
+    // === Derived Metrics ===
+    uint32_t totalCommandCount() const {
+        return drawCallCount + dispatchCount + pipelineBindCount +
+               descriptorSetBindCount + pushConstantCount +
+               renderPassCount + pipelineBarrierCount;
+    }
+
+    // Reset for new frame
+    void reset() {
+        fenceWasAlreadySignaled = false;
+        fenceWaitTimeMs = 0.0f;
+        queueSubmitTimeMs = 0.0f;
+        drawCallCount = 0;
+        dispatchCount = 0;
+        pipelineBindCount = 0;
+        descriptorSetBindCount = 0;
+        pushConstantCount = 0;
+        renderPassCount = 0;
+        pipelineBarrierCount = 0;
+        // validationLayersEnabled persists
+    }
+
+    // Get diagnostic summary string
+    std::string getSummary() const {
+        std::string result;
+        result.reserve(256);
+
+        // Fence status
+        if (fenceWasAlreadySignaled) {
+            result += "Fence: signaled (GPU idle)\n";
+        } else {
+            result += "Fence: waited " + std::to_string(fenceWaitTimeMs) + "ms (GPU-bound)\n";
+        }
+
+        // Submit time
+        result += "Submit: " + std::to_string(queueSubmitTimeMs) + "ms\n";
+
+        // Command counts
+        result += "Draws: " + std::to_string(drawCallCount);
+        result += " Dispatches: " + std::to_string(dispatchCount);
+        result += " Binds: " + std::to_string(pipelineBindCount + descriptorSetBindCount);
+        result += " Total: " + std::to_string(totalCommandCount()) + "\n";
+
+        // Warnings
+        if (validationLayersEnabled) {
+            result += "WARNING: Validation layers enabled!\n";
+        }
+        if (queueSubmitTimeMs > 1.0f && !validationLayersEnabled) {
+            result += "WARNING: High submit time without validation - check driver?\n";
+        }
+
+        return result;
+    }
+};
+
+/**
+ * CommandCounter - RAII wrapper to track Vulkan commands during recording.
+ *
+ * Wraps a VkCommandBuffer and counts commands as they're recorded.
+ * Use this instead of raw command buffer when you want diagnostics.
+ */
+class CommandCounter {
+public:
+    explicit CommandCounter(QueueSubmitDiagnostics& diag) : diag_(diag) {}
+
+    // Call these after the corresponding Vulkan commands
+    void recordDraw() { diag_.drawCallCount++; }
+    void recordDrawIndexed() { diag_.drawCallCount++; }
+    void recordDrawIndirect() { diag_.drawCallCount++; }
+    void recordDrawIndexedIndirect() { diag_.drawCallCount++; }
+    void recordDispatch() { diag_.dispatchCount++; }
+    void recordDispatchIndirect() { diag_.dispatchCount++; }
+    void recordBindPipeline() { diag_.pipelineBindCount++; }
+    void recordBindDescriptorSets() { diag_.descriptorSetBindCount++; }
+    void recordPushConstants() { diag_.pushConstantCount++; }
+    void recordBeginRenderPass() { diag_.renderPassCount++; }
+    void recordPipelineBarrier() { diag_.pipelineBarrierCount++; }
+
+    // Bulk increment for systems that batch commands
+    void recordDrawCalls(uint32_t count) { diag_.drawCallCount += count; }
+    void recordDispatches(uint32_t count) { diag_.dispatchCount += count; }
+
+private:
+    QueueSubmitDiagnostics& diag_;
+};


### PR DESCRIPTION
This adds diagnostic tools to help identify causes of high vkQueueSubmit CPU time:

Queue Submit Diagnostics (QueueSubmitDiagnostics.h):
- Tracks fence status before submit (was GPU already done?)
- Measures queue submit time in milliseconds
- Counts draw calls, dispatches, pipeline/descriptor binds
- Detects if validation layers are enabled (common perf issue)
- Shows warning in GUI when validation layers active

Command Capture (CommandCapture.h):
- Records detailed command buffer operations per frame
- Supports single-shot capture or continuous mode
- Groups commands by source system (e.g., ShadowSystem, HDRPass)
- Generates copyable text reports for debugging
- Color-coded display in profiler GUI (draws=green, compute=orange, barriers=red)

Conditional Validation Layers:
- Automatically disabled in release builds (NDEBUG)
- Can be disabled in debug via DISABLE_VULKAN_VALIDATION env var
- Logs when validation layers are disabled

All diagnostics integrated into the existing profiler GUI under collapsible "QUEUE SUBMIT DIAGNOSTICS" section.