### PR TITLE
Replace raw pointers with reference wrappers

### DIFF
--- a/src/core/LoadingRenderer.h
+++ b/src/core/LoadingRenderer.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <memory>
 #include <optional>
+#include <functional>
 
 class VulkanContext;
 
@@ -86,7 +87,7 @@ private:
         float _pad;
     };
 
-    VulkanContext* ctx_ = nullptr;  // Borrowed, not owned
+    std::optional<std::reference_wrapper<VulkanContext>> ctx_;  // Borrowed, not owned
     std::string shaderPath_;
 
     // Render resources (all managed with RAII via vulkan-hpp)

--- a/src/core/loading/AsyncStartupLoader.cpp
+++ b/src/core/loading/AsyncStartupLoader.cpp
@@ -21,7 +21,9 @@ AsyncStartupLoader::~AsyncStartupLoader() {
 }
 
 bool AsyncStartupLoader::init(const InitInfo& info) {
-    loadingRenderer_ = info.loadingRenderer;
+    if (info.loadingRenderer) {
+        loadingRenderer_.emplace(*info.loadingRenderer);
+    }
     resourcePath_ = info.resourcePath;
 
     jobQueue_ = LoadJobQueue::create(info.workerCount);
@@ -184,8 +186,8 @@ void AsyncStartupLoader::runLoadingLoop() {
         // Render loading screen frame
         if (loadingRenderer_) {
             LoadProgress progress = getProgress();
-            loadingRenderer_->setProgress(progress.getProgress());
-            loadingRenderer_->render();
+            loadingRenderer_->get().setProgress(progress.getProgress());
+            loadingRenderer_->get().render();
         }
 
         // Keep window responsive

--- a/src/core/loading/AsyncStartupLoader.h
+++ b/src/core/loading/AsyncStartupLoader.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <functional>
 #include <string>
+#include <optional>
 
 class VulkanContext;
 class LoadingRenderer;
@@ -121,7 +122,7 @@ private:
     // Helper to build full path
     std::string buildPath(const std::string& relativePath) const;
 
-    LoadingRenderer* loadingRenderer_ = nullptr;
+    std::optional<std::reference_wrapper<LoadingRenderer>> loadingRenderer_;
     std::string resourcePath_;
 
     std::unique_ptr<LoadJobQueue> jobQueue_;

--- a/src/core/vulkan/AsyncTransferManager.cpp
+++ b/src/core/vulkan/AsyncTransferManager.cpp
@@ -11,7 +11,7 @@ bool AsyncTransferManager::initialize(VulkanContext& context) {
         return true;
     }
 
-    context_ = &context;
+    context_.emplace(context);
     device_ = context.getVkDevice();
     transferQueue_ = context.getVkTransferQueue();
     transferQueueFamily_ = context.getTransferQueueFamily();
@@ -151,7 +151,7 @@ TransferHandle AsyncTransferManager::submitBufferTransfer(
     cmd.end();
 
     // Create fence for transfer completion
-    vk::raii::Fence fence(context_->getRaiiDevice(),
+    vk::raii::Fence fence(context_->get().getRaiiDevice(),
         vk::FenceCreateInfo{});
 
     // Submit to transfer queue
@@ -300,7 +300,7 @@ TransferHandle AsyncTransferManager::submitImageTransfer(
     cmd.end();
 
     // Create fence for transfer completion
-    vk::raii::Fence fence(context_->getRaiiDevice(),
+    vk::raii::Fence fence(context_->get().getRaiiDevice(),
         vk::FenceCreateInfo{});
 
     // Submit to transfer queue

--- a/src/core/vulkan/AsyncTransferManager.h
+++ b/src/core/vulkan/AsyncTransferManager.h
@@ -145,7 +145,7 @@ private:
     // Return staging buffer to pool for reuse
     void releaseStagingBuffer(VmaBuffer buffer);
 
-    VulkanContext* context_ = nullptr;
+    std::optional<std::reference_wrapper<VulkanContext>> context_;
     vk::Device device_;
     vk::Queue transferQueue_;
     uint32_t transferQueueFamily_ = 0;

--- a/src/debug/RoadRiverVisualization.cpp
+++ b/src/debug/RoadRiverVisualization.cpp
@@ -28,11 +28,11 @@ void RoadRiverVisualization::addToDebugLines(DebugLineSystem& debugLines) {
 void RoadRiverVisualization::rebuildCache() {
     cachedLineVertices_.clear();
 
-    if (config_.showRivers && waterData_ != nullptr) {
+    if (config_.showRivers && waterData_) {
         buildRiverCones();
     }
 
-    if (config_.showRoads && roadNetwork_ != nullptr) {
+    if (config_.showRoads && roadNetwork_) {
         buildRoadCones();
     }
 
@@ -83,7 +83,7 @@ void RoadRiverVisualization::buildRiverCones() {
     const float coneLength = config_.coneLength;
     const float heightOffset = config_.heightAboveGround;
 
-    for (const auto& river : waterData_->rivers) {
+    for (const auto& river : waterData_->get().rivers) {
         if (river.controlPoints.size() < 2) continue;
 
         // Walk along the river spline and place cones at regular intervals
@@ -133,9 +133,9 @@ void RoadRiverVisualization::buildRoadCones() {
     const float heightOffset = config_.heightAboveGround;
 
     // Road coordinates are in 0-terrainSize space, need to convert to centered world space
-    const float halfTerrain = roadNetwork_->terrainSize * 0.5f;
+    const float halfTerrain = roadNetwork_->get().terrainSize * 0.5f;
 
-    for (const auto& road : roadNetwork_->roads) {
+    for (const auto& road : roadNetwork_->get().roads) {
         if (road.controlPoints.size() < 2) continue;
 
         // Walk along the road spline and place bidirectional cones
@@ -183,12 +183,12 @@ void RoadRiverVisualization::buildRoadCones() {
 }
 
 float RoadRiverVisualization::getTerrainHeight(float x, float z) const {
-    if (tileCache_ == nullptr) {
+    if (!tileCache_) {
         return 0.0f;
     }
 
     float height;
-    if (!tileCache_->getHeightAt(x, z, height)) {
+    if (!tileCache_->get().getHeightAt(x, z, height)) {
         return 0.0f;
     }
 

--- a/src/debug/RoadRiverVisualization.h
+++ b/src/debug/RoadRiverVisualization.h
@@ -6,6 +6,8 @@
 
 #include <glm/glm.hpp>
 #include <vector>
+#include <optional>
+#include <functional>
 
 class DebugLineSystem;
 class TerrainTileCache;
@@ -42,9 +44,21 @@ public:
     const RoadRiverVisConfig& getConfig() const { return config_; }
 
     // Set data sources (marks cache dirty)
-    void setWaterData(const WaterPlacementData* waterData) { waterData_ = waterData; dirty_ = true; }
-    void setRoadNetwork(const RoadNetwork* roadNetwork) { roadNetwork_ = roadNetwork; dirty_ = true; }
-    void setTerrainTileCache(const TerrainTileCache* tileCache) { tileCache_ = tileCache; dirty_ = true; }
+    void setWaterData(const WaterPlacementData* waterData) {
+        if (waterData) waterData_.emplace(*waterData);
+        else waterData_.reset();
+        dirty_ = true;
+    }
+    void setRoadNetwork(const RoadNetwork* roadNetwork) {
+        if (roadNetwork) roadNetwork_.emplace(*roadNetwork);
+        else roadNetwork_.reset();
+        dirty_ = true;
+    }
+    void setTerrainTileCache(const TerrainTileCache* tileCache) {
+        if (tileCache) tileCache_.emplace(*tileCache);
+        else tileCache_.reset();
+        dirty_ = true;
+    }
 
     // Force rebuild of cached geometry
     void invalidateCache() { dirty_ = true; }
@@ -73,9 +87,9 @@ private:
     float getTerrainHeight(float x, float z) const;
 
     RoadRiverVisConfig config_;
-    const WaterPlacementData* waterData_ = nullptr;
-    const RoadNetwork* roadNetwork_ = nullptr;
-    const TerrainTileCache* tileCache_ = nullptr;
+    std::optional<std::reference_wrapper<const WaterPlacementData>> waterData_;
+    std::optional<std::reference_wrapper<const RoadNetwork>> roadNetwork_;
+    std::optional<std::reference_wrapper<const TerrainTileCache>> tileCache_;
 
     // Cached line vertices (pairs for each line segment)
     std::vector<CachedVertex> cachedLineVertices_;

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -132,7 +132,11 @@ void Camera::setThirdPersonTarget(const glm::vec3& target) {
 }
 
 void Camera::setThirdPersonTargetNode(SceneNode* targetNode) {
-    thirdPersonTargetNode_ = targetNode;
+    if (targetNode) {
+        thirdPersonTargetNode_.emplace(*targetNode);
+    } else {
+        thirdPersonTargetNode_.reset();
+    }
 }
 
 void Camera::orbitYaw(float delta) {
@@ -159,7 +163,7 @@ void Camera::updateThirdPerson(float deltaTime) {
 
     // If following a scene node, get its world position
     if (thirdPersonTargetNode_) {
-        thirdPersonTarget_ = thirdPersonTargetNode_->getWorldPosition();
+        thirdPersonTarget_ = thirdPersonTargetNode_->get().getWorldPosition();
     }
 
     // Exponential smoothing formula: smoothed += (target - smoothed) * (1 - exp(-speed * deltaTime))

--- a/src/scene/Camera.h
+++ b/src/scene/Camera.h
@@ -3,6 +3,8 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <optional>
+#include <functional>
 #include "SceneNode.h"
 
 /**
@@ -127,7 +129,7 @@ private:
 
     // Third-person camera settings
     glm::vec3 thirdPersonTarget_;
-    SceneNode* thirdPersonTargetNode_ = nullptr;  // Optional: follow a scene node
+    std::optional<std::reference_wrapper<SceneNode>> thirdPersonTargetNode_;  // Optional: follow a scene node
     float thirdPersonDistance_;
     float thirdPersonMinDistance_;
     float thirdPersonMaxDistance_;

--- a/src/scene/SceneBuilder.cpp
+++ b/src/scene/SceneBuilder.cpp
@@ -21,12 +21,12 @@ bool SceneBuilder::initInternal(const InitInfo& info) {
     storedAllocator = info.allocator;
     storedDevice = info.device;
     sceneOrigin = info.sceneOrigin;
-    assetRegistry_ = info.assetRegistry;
 
-    if (!assetRegistry_) {
+    if (!info.assetRegistry) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SceneBuilder: AssetRegistry is required");
         return false;
     }
+    assetRegistry_.emplace(*info.assetRegistry);
 
     if (!createMeshes(info)) return false;
     if (!loadTextures(info)) return false;
@@ -214,14 +214,14 @@ bool SceneBuilder::loadTextures(const InitInfo& info) {
 
     // Crate textures
     std::string texturePath = info.resourcePath + "/assets/textures/crates/crate1/crate1_diffuse.png";
-    crateTexture_ = assetRegistry_->loadTexture(texturePath, srgbConfig);
+    crateTexture_ = assetRegistry_->get().loadTexture(texturePath, srgbConfig);
     if (!crateTexture_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load texture: %s", texturePath.c_str());
         return false;
     }
 
     std::string crateNormalPath = info.resourcePath + "/assets/textures/crates/crate1/crate1_normal.png";
-    crateNormal_ = assetRegistry_->loadTexture(crateNormalPath, linearConfig);
+    crateNormal_ = assetRegistry_->get().loadTexture(crateNormalPath, linearConfig);
     if (!crateNormal_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load crate normal map: %s", crateNormalPath.c_str());
         return false;
@@ -229,14 +229,14 @@ bool SceneBuilder::loadTextures(const InitInfo& info) {
 
     // Ground/grass textures
     std::string grassTexturePath = info.resourcePath + "/assets/textures/grass/grass/grass01.jpg";
-    groundTexture_ = assetRegistry_->loadTexture(grassTexturePath, srgbConfig);
+    groundTexture_ = assetRegistry_->get().loadTexture(grassTexturePath, srgbConfig);
     if (!groundTexture_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load grass texture: %s", grassTexturePath.c_str());
         return false;
     }
 
     std::string grassNormalPath = info.resourcePath + "/assets/textures/grass/grass/grass01_n.jpg";
-    groundNormal_ = assetRegistry_->loadTexture(grassNormalPath, linearConfig);
+    groundNormal_ = assetRegistry_->get().loadTexture(grassNormalPath, linearConfig);
     if (!groundNormal_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load grass normal map: %s", grassNormalPath.c_str());
         return false;
@@ -244,28 +244,28 @@ bool SceneBuilder::loadTextures(const InitInfo& info) {
 
     // Metal textures
     std::string metalTexturePath = info.resourcePath + "/assets/textures/industrial/metal_1.jpg";
-    metalTexture_ = assetRegistry_->loadTexture(metalTexturePath, srgbConfig);
+    metalTexture_ = assetRegistry_->get().loadTexture(metalTexturePath, srgbConfig);
     if (!metalTexture_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load metal texture: %s", metalTexturePath.c_str());
         return false;
     }
 
     std::string metalNormalPath = info.resourcePath + "/assets/textures/industrial/metal_1_norm.jpg";
-    metalNormal_ = assetRegistry_->loadTexture(metalNormalPath, linearConfig);
+    metalNormal_ = assetRegistry_->get().loadTexture(metalNormalPath, linearConfig);
     if (!metalNormal_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to load metal normal map: %s", metalNormalPath.c_str());
         return false;
     }
 
     // Create default black emissive map for objects without emissive textures
-    defaultEmissive_ = assetRegistry_->createSolidColorTexture(0, 0, 0, 255, "default_emissive");
+    defaultEmissive_ = assetRegistry_->get().createSolidColorTexture(0, 0, 0, 255, "default_emissive");
     if (!defaultEmissive_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create default emissive map");
         return false;
     }
 
     // Create white texture for vertex-colored objects (like glTF characters)
-    whiteTexture_ = assetRegistry_->createSolidColorTexture(255, 255, 255, 255, "white");
+    whiteTexture_ = assetRegistry_->get().createSolidColorTexture(255, 255, 255, 255, "white");
     if (!whiteTexture_) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create white texture");
         return false;

--- a/src/scene/SceneBuilder.h
+++ b/src/scene/SceneBuilder.h
@@ -141,7 +141,7 @@ private:
     VkDevice storedDevice = VK_NULL_HANDLE;
 
     // Asset registry for centralized resource management
-    AssetRegistry* assetRegistry_ = nullptr;
+    std::optional<std::reference_wrapper<AssetRegistry>> assetRegistry_;
 
     // Meshes (static RAII-managed)
     std::unique_ptr<Mesh> cubeMesh;


### PR DESCRIPTION
Convert raw pointer member variables used for non-owning references to use std::optional<std::reference_wrapper<T>> for type safety and clearer semantics:

- LoadingRenderer::ctx_ - VulkanContext reference (required after init)
- AsyncStartupLoader::loadingRenderer_ - optional LoadingRenderer
- AsyncTransferManager::context_ - VulkanContext reference (required)
- SceneBuilder::assetRegistry_ - AssetRegistry reference (required)
- RoadRiverVisualization data sources - optional const references
- Camera::thirdPersonTargetNode_ - optional SceneNode for third-person

This improves code clarity by distinguishing between:
- Required references that must be valid (reference_wrapper)
- Optional references that may be unset (optional<reference_wrapper>)

The setter APIs are preserved for backward compatibility where nullable pointers are accepted (e.g., RoadRiverVisualization setters).