### PR TITLE
Review Vulkan API usage across codebase

### DIFF
--- a/src/core/pipeline/PipelineCache.h
+++ b/src/core/pipeline/PipelineCache.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <vulkan/vulkan.h>
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <string>
+#include <optional>
 
 /**
  * PipelineCache - Manages Vulkan pipeline cache with disk persistence
@@ -11,14 +13,14 @@
  *
  * Usage:
  *   PipelineCache cache;
- *   cache.init(device, "pipeline_cache.bin");
+ *   cache.init(raiiDevice, "pipeline_cache.bin");
  *   // Use cache.getCache() when creating pipelines
  *   cache.shutdown(); // Saves cache to disk
  */
 class PipelineCache {
 public:
     PipelineCache() = default;
-    ~PipelineCache() = default;
+    ~PipelineCache();
 
     // Non-copyable
     PipelineCache(const PipelineCache&) = delete;
@@ -26,11 +28,11 @@ public:
 
     /**
      * Initialize the pipeline cache
-     * @param device The Vulkan device
+     * @param raiiDevice The Vulkan RAII device
      * @param cacheFilePath Path to the cache file (loaded if exists)
      * @return true on success
      */
-    bool init(VkDevice device, const std::string& cacheFilePath = "pipeline_cache.bin");
+    bool init(const vk::raii::Device& raiiDevice, const std::string& cacheFilePath = "pipeline_cache.bin");
 
     /**
      * Shutdown and save cache to disk
@@ -40,7 +42,7 @@ public:
     /**
      * Get the pipeline cache handle for use in pipeline creation
      */
-    VkPipelineCache getCache() const { return pipelineCache; }
+    VkPipelineCache getCache() const { return pipelineCache_ ? **pipelineCache_ : VK_NULL_HANDLE; }
 
     /**
      * Save the current cache state to disk
@@ -52,7 +54,7 @@ public:
 private:
     bool loadFromFile();
 
-    VkDevice device = VK_NULL_HANDLE;
-    VkPipelineCache pipelineCache = VK_NULL_HANDLE;
-    std::string cacheFilePath;
+    const vk::raii::Device* device_ = nullptr;
+    std::optional<vk::raii::PipelineCache> pipelineCache_;
+    std::string cacheFilePath_;
 };

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -293,5 +293,5 @@ uint32_t VulkanContext::getTransferQueueFamily() const {
 }
 
 bool VulkanContext::createPipelineCache() {
-    return pipelineCache.init(device, "pipeline_cache.bin");
+    return pipelineCache.init(*raiiDevice_, "pipeline_cache.bin");
 }

--- a/src/lighting/ShadowSystem.h
+++ b/src/lighting/ShadowSystem.h
@@ -34,6 +34,7 @@ public:
 
     // Configuration for shadow system initialization
     struct InitInfo {
+        const vk::raii::Device* raiiDevice = nullptr;  // For RAII resource creation
         VkDevice device;
         VkPhysicalDevice physicalDevice;
         VmaAllocator allocator;
@@ -87,8 +88,8 @@ public:
     void bindSkinnedShadowPipeline(VkCommandBuffer cmd, VkDescriptorSet descriptorSet);
 
     // CSM resource accessors (for binding in main shader)
-    VkImageView getShadowImageView() const { return csmResources.arrayView; }
-    VkSampler getShadowSampler() const { return csmResources.sampler; }
+    VkImageView getShadowImageView() const { return csmResources.getArrayView(); }
+    VkSampler getShadowSampler() const { return csmResources.getSampler(); }
     VkRenderPass getShadowRenderPass() const { return shadowRenderPass; }
     VkPipeline getShadowPipeline() const { return shadowPipeline; }
     VkPipelineLayout getShadowPipelineLayout() const { return shadowPipelineLayout; }
@@ -103,13 +104,13 @@ public:
     // Dynamic shadow resource accessors (for binding in main shader)
     // Bounds-checked accessors to prevent O3 UB from OOB access
     VkImageView getPointShadowArrayView(uint32_t frameIndex) const {
-        return frameIndex < pointShadowResources.size() ? pointShadowResources[frameIndex].arrayView : VK_NULL_HANDLE;
+        return frameIndex < pointShadowResources.size() ? pointShadowResources[frameIndex].getArrayView() : VK_NULL_HANDLE;
     }
-    VkSampler getPointShadowSampler() const { return pointShadowResources.empty() ? VK_NULL_HANDLE : pointShadowResources[0].sampler; }
+    VkSampler getPointShadowSampler() const { return pointShadowResources.empty() ? VK_NULL_HANDLE : pointShadowResources[0].getSampler(); }
     VkImageView getSpotShadowArrayView(uint32_t frameIndex) const {
-        return frameIndex < spotShadowResources.size() ? spotShadowResources[frameIndex].arrayView : VK_NULL_HANDLE;
+        return frameIndex < spotShadowResources.size() ? spotShadowResources[frameIndex].getArrayView() : VK_NULL_HANDLE;
     }
-    VkSampler getSpotShadowSampler() const { return spotShadowResources.empty() ? VK_NULL_HANDLE : spotShadowResources[0].sampler; }
+    VkSampler getSpotShadowSampler() const { return spotShadowResources.empty() ? VK_NULL_HANDLE : spotShadowResources[0].getSampler(); }
 
     // Dynamic shadow rendering (placeholder for future implementation)
     void renderDynamicShadows(VkCommandBuffer cmd, uint32_t frameIndex,
@@ -164,6 +165,7 @@ private:
     glm::mat4 calculateCascadeMatrix(const glm::vec3& lightDir, const Camera& camera, float nearSplit, float farSplit);
 
     // Vulkan handles (not owned)
+    const vk::raii::Device* raiiDevice = nullptr;
     VkDevice device = VK_NULL_HANDLE;
     VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;


### PR DESCRIPTION
- VulkanHelpers.h: Convert DepthResources and DepthArrayResources to use VmaImage, vk::raii::ImageView, and vk::raii::Sampler instead of raw handles
- VulkanHelpers.h: Update createDepthResources, createDepthImageAndView, and createDepthArrayResources to use RAII patterns with SamplerFactory
- PipelineCache: Migrate to vk::raii::PipelineCache with RAII cleanup
- Renderer.cpp: Update depth resource creation to use new RAII API
- ShadowSystem: Add raiiDevice pointer for RAII resource creation, update CSM and dynamic shadow resources to use new RAII depth array API

This continues the vulkan-hpp migration by replacing manual vkCreate/vkDestroy patterns with RAII wrappers for automatic resource management.