### PR TITLE
Continue Vulkan-hpp RAII migration for remaining files

### DIFF
--- a/src/core/ImageBuilder.h
+++ b/src/core/ImageBuilder.h
@@ -272,8 +272,11 @@ public:
                 .setBaseArrayLayer(0)
                 .setLayerCount(imageInfo_.arrayLayers));
 
-        if (vkCreateImageView(device, reinterpret_cast<const VkImageViewCreateInfo*>(&viewInfo), nullptr, &outView) != VK_SUCCESS) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ImageBuilder: Failed to create image view");
+        try {
+            vk::Device vkDevice(device);
+            outView = static_cast<VkImageView>(vkDevice.createImageView(viewInfo));
+        } catch (const vk::SystemError& e) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ImageBuilder: Failed to create image view: %s", e.what());
             outImage.reset();
             return false;
         }

--- a/src/postprocess/BilateralGridSystem.cpp
+++ b/src/postprocess/BilateralGridSystem.cpp
@@ -433,11 +433,10 @@ void BilateralGridSystem::recordClearGrid(VkCommandBuffer cmd) {
         .setImage(gridImages[0])
         .setSubresourceRange(subresourceRange);
 
-    vkCmdPipelineBarrier(cmd,
-                        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                        VK_PIPELINE_STAGE_TRANSFER_BIT,
-                        0, 0, nullptr, 0, nullptr, 1,
-                        reinterpret_cast<const VkImageMemoryBarrier*>(&barrier));
+    vk::CommandBuffer vkCmdBarrier(cmd);
+    vkCmdBarrier.pipelineBarrier(
+        vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
+        {}, {}, {}, barrier);
 
     // Clear to zero
     vk::CommandBuffer vkCmd(cmd);
@@ -475,12 +474,9 @@ void BilateralGridSystem::recordClearGrid(VkCommandBuffer cmd) {
         .setSubresourceRange(subresourceRange);
 
     // Single barrier call for both transitions (TRANSFER covers TOP_OF_PIPE)
-    vkCmdPipelineBarrier(cmd,
-                        VK_PIPELINE_STAGE_TRANSFER_BIT,
-                        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                        0, 0, nullptr, 0, nullptr,
-                        static_cast<uint32_t>(barriers.size()),
-                        reinterpret_cast<const VkImageMemoryBarrier*>(barriers.data()));
+    vkCmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eComputeShader,
+        {}, {}, {}, barriers);
 }
 
 void BilateralGridSystem::recordBilateralGrid(VkCommandBuffer cmd, uint32_t frameIndex,


### PR DESCRIPTION
Replace raw Vulkan C API calls with vulkan-hpp equivalents:
- Convert vkCreateImageView to device.createImageView() with try-catch
- Convert vkDestroyImageView to device.destroyImageView()
- Convert vkCmdPipelineBarrier to vkCmd.pipelineBarrier() with builders
- Convert VkMemoryBarrier structs to vk::MemoryBarrier builders
- Convert VkImageMemoryBarrier structs to vk::ImageMemoryBarrier builders

Files migrated:
- BufferUtils.cpp: Image view creation/destruction in DoubleBufferedImageBuilder
- ImageBuilder.h: Raw device image view creation
- Texture.cpp: Multiple image view and sampler creation, pipeline barriers
- LoadJobFactory.cpp: Image view creation in StagedResourceUploader and AsyncTextureUploader
- SSRSystem.cpp: Image view creation/destruction, device wait
- BilateralGridSystem.cpp: Pipeline barrier for image transitions
- TerrainTextures.cpp: Image view creation/destruction in destructor and move ops
- VolumetricSnowSystem.cpp: Cascade image view creation/destruction
- VirtualTextureCache.cpp: Cache image view creation/destruction
- VirtualTexturePageTable.cpp: Page table image view creation/destruction
- TreeBranchCulling.cpp: Memory barriers for compute/graphics sync
- TreeLeafCulling.cpp: Multiple memory barriers for multi-pass culling

This continues the vulkan-hpp RAII migration, eliminating remaining raw vkCreate*, vkDestroy*, and vkCmdPipelineBarrier calls from the codebase.