### PR TITLE
Refactor SceneObjectCollection to SceneMaterial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,8 @@ set(SOURCES
     src/scene/Application.cpp
     src/scene/SceneBuilder.cpp
     src/scene/SceneManager.cpp
-    src/scene/SceneObjectCollection.cpp
+    src/scene/SceneMaterial.cpp
+    src/scene/SceneCollection.cpp
     src/scene/Camera.cpp
     src/scene/InputSystem.cpp
     # Core

--- a/src/core/RendererSystems.cpp
+++ b/src/core/RendererSystems.cpp
@@ -21,6 +21,7 @@
 #include "SnowMaskSystem.h"
 #include "VolumetricSnowSystem.h"
 #include "RockSystem.h"
+#include "scene/SceneMaterial.h"
 #include "TreeSystem.h"
 #include "TreeRenderer.h"
 #include "TreeLODSystem.h"
@@ -237,7 +238,15 @@ void RendererSystems::setCatmullClark(std::unique_ptr<CatmullClarkSystem> system
 }
 
 void RendererSystems::setRock(std::unique_ptr<RockSystem> system) {
+    // Unregister old material if exists
+    if (rockSystem_) {
+        sceneCollection_.unregisterMaterial(&rockSystem_->getMaterial());
+    }
     rockSystem_ = std::move(system);
+    // Register new material
+    if (rockSystem_) {
+        sceneCollection_.registerMaterial(&rockSystem_->getMaterial());
+    }
 }
 
 void RendererSystems::setTree(std::unique_ptr<TreeSystem> system) {
@@ -257,7 +266,15 @@ void RendererSystems::setImpostorCull(std::unique_ptr<ImpostorCullSystem> system
 }
 
 void RendererSystems::setDetritus(std::unique_ptr<DetritusSystem> system) {
+    // Unregister old material if exists
+    if (detritusSystem_) {
+        sceneCollection_.unregisterMaterial(&detritusSystem_->getMaterial());
+    }
     detritusSystem_ = std::move(system);
+    // Register new material
+    if (detritusSystem_) {
+        sceneCollection_.registerMaterial(&detritusSystem_->getMaterial());
+    }
 }
 
 void RendererSystems::setScene(std::unique_ptr<SceneManager> system) {

--- a/src/core/RendererSystems.h
+++ b/src/core/RendererSystems.h
@@ -10,6 +10,7 @@
 #include "VegetationSystemGroup.h"
 #include "WaterSystemGroup.h"
 #include "SnowSystemGroup.h"
+#include "scene/SceneCollection.h"
 
 // Forward declarations for control subsystems (only those that coordinate multiple systems)
 class EnvironmentControlSubsystem;
@@ -240,6 +241,10 @@ public:
     const DetritusSystem* detritus() const { return detritusSystem_.get(); }
     void setDetritus(std::unique_ptr<DetritusSystem> system);
 
+    // Scene collection for unified material iteration (used by shadow pass)
+    SceneCollection& sceneCollection() { return sceneCollection_; }
+    const SceneCollection& sceneCollection() const { return sceneCollection_; }
+
     // Culling and optimization
     HiZSystem& hiZ() { return *hiZSystem_; }
     const HiZSystem& hiZ() const { return *hiZSystem_; }
@@ -439,6 +444,9 @@ private:
     std::unique_ptr<TreeLODSystem> treeLODSystem_;
     std::unique_ptr<ImpostorCullSystem> impostorCullSystem_;
     std::unique_ptr<DetritusSystem> detritusSystem_;
+
+    // Scene collection for unified material iteration
+    SceneCollection sceneCollection_;
 
     // Tier 2 - Culling
     std::unique_ptr<HiZSystem> hiZSystem_;

--- a/src/scene/SceneCollection.cpp
+++ b/src/scene/SceneCollection.cpp
@@ -1,0 +1,47 @@
+#include "SceneCollection.h"
+#include "SceneMaterial.h"
+#include <algorithm>
+
+void SceneCollection::registerMaterial(SceneMaterial* material) {
+    if (material == nullptr) return;
+
+    // Avoid duplicates
+    auto it = std::find(materials_.begin(), materials_.end(), material);
+    if (it == materials_.end()) {
+        materials_.push_back(material);
+    }
+}
+
+void SceneCollection::unregisterMaterial(SceneMaterial* material) {
+    auto it = std::find(materials_.begin(), materials_.end(), material);
+    if (it != materials_.end()) {
+        materials_.erase(it);
+    }
+}
+
+void SceneCollection::clear() {
+    materials_.clear();
+}
+
+std::vector<Renderable> SceneCollection::collectAllSceneObjects() const {
+    std::vector<Renderable> allObjects;
+
+    // Estimate total size for reservation
+    size_t totalSize = 0;
+    for (const auto* material : materials_) {
+        if (material && material->hasContent()) {
+            totalSize += material->getSceneObjects().size();
+        }
+    }
+    allObjects.reserve(totalSize);
+
+    // Collect from all materials
+    for (const auto* material : materials_) {
+        if (material && material->hasContent()) {
+            const auto& objects = material->getSceneObjects();
+            allObjects.insert(allObjects.end(), objects.begin(), objects.end());
+        }
+    }
+
+    return allObjects;
+}

--- a/src/scene/SceneCollection.h
+++ b/src/scene/SceneCollection.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <vector>
+#include "RenderableBuilder.h"
+
+class SceneMaterial;
+
+/**
+ * SceneCollection - Registry for unified iteration over all scene materials
+ *
+ * Holds non-owning references to SceneMaterial instances (e.g., rock, detritus)
+ * and provides a unified way to collect all scene objects for rendering passes
+ * like shadow mapping.
+ *
+ * Usage:
+ *   SceneCollection collection;
+ *   collection.registerMaterial(&rockMaterial);
+ *   collection.registerMaterial(&detritusMaterial);
+ *
+ *   // Shadow pass: iterate all shadow-casting objects
+ *   for (const auto& obj : collection.collectAllSceneObjects()) {
+ *       if (obj.castsShadow) { ... }
+ *   }
+ */
+class SceneCollection {
+public:
+    SceneCollection() = default;
+    ~SceneCollection() = default;
+
+    // Non-copyable but movable
+    SceneCollection(const SceneCollection&) = delete;
+    SceneCollection& operator=(const SceneCollection&) = delete;
+    SceneCollection(SceneCollection&&) = default;
+    SceneCollection& operator=(SceneCollection&&) = default;
+
+    /**
+     * Register a material to be included in scene iteration
+     * @param material Non-owning pointer to SceneMaterial (must outlive this collection)
+     */
+    void registerMaterial(SceneMaterial* material);
+
+    /**
+     * Unregister a material from the collection
+     */
+    void unregisterMaterial(SceneMaterial* material);
+
+    /**
+     * Clear all registered materials
+     */
+    void clear();
+
+    /**
+     * Collect all scene objects from all registered materials
+     * Returns a vector combining renderables from all materials
+     */
+    std::vector<Renderable> collectAllSceneObjects() const;
+
+    /**
+     * Get read-only access to registered materials
+     */
+    const std::vector<SceneMaterial*>& getMaterials() const { return materials_; }
+
+    /**
+     * Get the number of registered materials
+     */
+    size_t getMaterialCount() const { return materials_.size(); }
+
+private:
+    std::vector<SceneMaterial*> materials_;
+};

--- a/src/scene/SceneMaterial.cpp
+++ b/src/scene/SceneMaterial.cpp
@@ -1,18 +1,18 @@
-#include "SceneObjectCollection.h"
+#include "SceneMaterial.h"
 #include <SDL3/SDL_log.h>
 
-SceneObjectCollection::~SceneObjectCollection() {
+SceneMaterial::~SceneMaterial() {
     cleanup();
 }
 
-void SceneObjectCollection::init(const InitInfo& info, const MaterialProperties& matProps) {
+void SceneMaterial::init(const InitInfo& info, const MaterialProperties& matProps) {
     storedAllocator_ = info.allocator;
     storedDevice_ = info.device;
     materialProps_ = matProps;
     initialized_ = true;
 }
 
-void SceneObjectCollection::setMeshes(std::vector<Mesh>&& meshes) {
+void SceneMaterial::setMeshes(std::vector<Mesh>&& meshes) {
     // Clean up existing meshes first
     for (auto& mesh : meshes_) {
         mesh.releaseGPUResources();
@@ -20,28 +20,28 @@ void SceneObjectCollection::setMeshes(std::vector<Mesh>&& meshes) {
     meshes_ = std::move(meshes);
 }
 
-void SceneObjectCollection::setDiffuseTexture(std::unique_ptr<Texture> texture) {
+void SceneMaterial::setDiffuseTexture(std::unique_ptr<Texture> texture) {
     diffuseTexture_ = std::move(texture);
 }
 
-void SceneObjectCollection::setNormalTexture(std::unique_ptr<Texture> texture) {
+void SceneMaterial::setNormalTexture(std::unique_ptr<Texture> texture) {
     normalTexture_ = std::move(texture);
 }
 
-void SceneObjectCollection::addInstance(const SceneObjectInstance& instance) {
+void SceneMaterial::addInstance(const SceneObjectInstance& instance) {
     instances_.push_back(instance);
 }
 
-void SceneObjectCollection::setInstances(std::vector<SceneObjectInstance>&& instances) {
+void SceneMaterial::setInstances(std::vector<SceneObjectInstance>&& instances) {
     instances_ = std::move(instances);
 }
 
-void SceneObjectCollection::clearInstances() {
+void SceneMaterial::clearInstances() {
     instances_.clear();
     sceneObjects_.clear();
 }
 
-void SceneObjectCollection::rebuildSceneObjects(
+void SceneMaterial::rebuildSceneObjects(
     std::function<glm::mat4(const SceneObjectInstance&, const glm::mat4&)> transformModifier) {
 
     sceneObjects_.clear();
@@ -50,7 +50,7 @@ void SceneObjectCollection::rebuildSceneObjects(
     for (const auto& instance : instances_) {
         if (instance.meshVariation >= meshes_.size()) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                "SceneObjectCollection: Instance mesh variation %u out of range (have %zu meshes)",
+                "SceneMaterial: Instance mesh variation %u out of range (have %zu meshes)",
                 instance.meshVariation, meshes_.size());
             continue;
         }
@@ -73,7 +73,7 @@ void SceneObjectCollection::rebuildSceneObjects(
     }
 }
 
-void SceneObjectCollection::cleanup() {
+void SceneMaterial::cleanup() {
     if (storedDevice_ == VK_NULL_HANDLE) return;
 
     // Release RAII-managed textures

--- a/src/scene/SceneMaterial.h
+++ b/src/scene/SceneMaterial.h
@@ -15,18 +15,19 @@
 #include "RenderableBuilder.h"
 
 /**
- * SceneObjectCollection - Composition-based container for instanced scene objects
+ * SceneMaterial - Represents a material with textures, properties, mesh variations, and instances
  *
- * Manages the common lifecycle of:
- * - Multiple mesh variations
+ * Manages the complete rendering data for a material type:
+ * - Multiple mesh variations (e.g., different rock shapes)
  * - Diffuse and normal textures
  * - Instance transforms (position, rotation, scale, mesh variation)
  * - Renderable generation for the rendering pipeline
+ * - Material properties (roughness, metallic, shadow casting)
  *
  * This class uses composition rather than inheritance. Systems like RockSystem
- * and DetritusSystem own a SceneObjectCollection and delegate common operations to it.
+ * and DetritusSystem own a SceneMaterial and delegate common operations to it.
  */
-class SceneObjectCollection {
+class SceneMaterial {
 public:
     struct InitInfo {
         VkDevice device;
@@ -47,14 +48,14 @@ public:
         static MaterialProperties defaults() { return {0.7f, 0.0f, true}; }
     };
 
-    SceneObjectCollection() = default;
-    ~SceneObjectCollection();
+    SceneMaterial() = default;
+    ~SceneMaterial();
 
     // Non-copyable, non-movable (owns GPU resources)
-    SceneObjectCollection(const SceneObjectCollection&) = delete;
-    SceneObjectCollection& operator=(const SceneObjectCollection&) = delete;
-    SceneObjectCollection(SceneObjectCollection&&) = delete;
-    SceneObjectCollection& operator=(SceneObjectCollection&&) = delete;
+    SceneMaterial(const SceneMaterial&) = delete;
+    SceneMaterial& operator=(const SceneMaterial&) = delete;
+    SceneMaterial(SceneMaterial&&) = delete;
+    SceneMaterial& operator=(SceneMaterial&&) = delete;
 
     /**
      * Initialize with Vulkan context for resource management
@@ -62,7 +63,7 @@ public:
     void init(const InitInfo& info, const MaterialProperties& matProps = MaterialProperties::defaults());
 
     /**
-     * Set the meshes for this collection (transfers ownership)
+     * Set the meshes for this material (transfers ownership)
      * Caller should have already uploaded meshes to GPU
      */
     void setMeshes(std::vector<Mesh>&& meshes);
@@ -78,7 +79,7 @@ public:
     void setNormalTexture(std::unique_ptr<Texture> texture);
 
     /**
-     * Add an instance to the collection
+     * Add an instance to the material
      */
     void addInstance(const SceneObjectInstance& instance);
 

--- a/src/vegetation/DetritusSystem.cpp
+++ b/src/vegetation/DetritusSystem.cpp
@@ -20,23 +20,23 @@ DetritusSystem::~DetritusSystem() {
 bool DetritusSystem::initInternal(const InitInfo& info, const DetritusConfig& cfg) {
     config_ = cfg;
 
-    // Initialize the collection with Vulkan context
-    SceneObjectCollection::InitInfo collectionInfo;
-    collectionInfo.device = info.device;
-    collectionInfo.allocator = info.allocator;
-    collectionInfo.commandPool = info.commandPool;
-    collectionInfo.graphicsQueue = info.graphicsQueue;
-    collectionInfo.physicalDevice = info.physicalDevice;
-    collectionInfo.resourcePath = info.resourcePath;
-    collectionInfo.getTerrainHeight = info.getTerrainHeight;
-    collectionInfo.terrainSize = info.terrainSize;
+    // Initialize the material with Vulkan context
+    SceneMaterial::InitInfo materialInfo;
+    materialInfo.device = info.device;
+    materialInfo.allocator = info.allocator;
+    materialInfo.commandPool = info.commandPool;
+    materialInfo.graphicsQueue = info.graphicsQueue;
+    materialInfo.physicalDevice = info.physicalDevice;
+    materialInfo.resourcePath = info.resourcePath;
+    materialInfo.getTerrainHeight = info.getTerrainHeight;
+    materialInfo.terrainSize = info.terrainSize;
 
-    SceneObjectCollection::MaterialProperties matProps;
+    SceneMaterial::MaterialProperties matProps;
     matProps.roughness = config_.materialRoughness;
     matProps.metallic = config_.materialMetallic;
     matProps.castsShadow = true;
 
-    collection_.init(collectionInfo, matProps);
+    material_.init(materialInfo, matProps);
 
     if (!loadTextures(info)) {
         SDL_Log("DetritusSystem: Failed to load textures");
@@ -52,13 +52,13 @@ bool DetritusSystem::initInternal(const InitInfo& info, const DetritusConfig& cf
     createSceneObjects();
 
     SDL_Log("DetritusSystem: Initialized with %zu pieces (%zu mesh variations)",
-            collection_.getInstanceCount(), collection_.getMeshVariationCount());
+            material_.getInstanceCount(), material_.getMeshVariationCount());
 
     return true;
 }
 
 void DetritusSystem::cleanup() {
-    collection_.cleanup();
+    material_.cleanup();
 }
 
 bool DetritusSystem::loadTextures(const InitInfo& info) {
@@ -70,7 +70,7 @@ bool DetritusSystem::loadTextures(const InitInfo& info) {
         SDL_Log("DetritusSystem: Failed to load bark texture: %s", texturePath.c_str());
         return false;
     }
-    collection_.setDiffuseTexture(std::move(barkTexture));
+    material_.setDiffuseTexture(std::move(barkTexture));
 
     std::string normalPath = info.resourcePath + "/textures/bark/oak_normal_1k.jpg";
     auto barkNormalMap = Texture::loadFromFile(normalPath, info.allocator, info.device, info.commandPool,
@@ -79,7 +79,7 @@ bool DetritusSystem::loadTextures(const InitInfo& info) {
         SDL_Log("DetritusSystem: Failed to load bark normal map: %s", normalPath.c_str());
         return false;
     }
-    collection_.setNormalTexture(std::move(barkNormalMap));
+    material_.setNormalTexture(std::move(barkNormalMap));
 
     return true;
 }
@@ -147,7 +147,7 @@ bool DetritusSystem::createBranchMeshes(const InitInfo& info) {
                 meshIdx, radius, length, forkAngle, gnarliness);
     }
 
-    collection_.setMeshes(std::move(meshes));
+    material_.setMeshes(std::move(meshes));
     return true;
 }
 
@@ -228,7 +228,7 @@ void DetritusSystem::generatePlacements(const InitInfo& info) {
         }
     }
 
-    collection_.setInstances(std::move(instances));
+    material_.setInstances(std::move(instances));
     SDL_Log("DetritusSystem: Placed %d pieces near %d trees (max %d)",
             placed, numTrees, maxTotalDetritus);
 }
@@ -236,5 +236,5 @@ void DetritusSystem::generatePlacements(const InitInfo& info) {
 void DetritusSystem::createSceneObjects() {
     // No transform modification needed - the rotation already includes
     // pitch to lay branches flat on the ground
-    collection_.rebuildSceneObjects();
+    material_.rebuildSceneObjects();
 }

--- a/src/vegetation/DetritusSystem.h
+++ b/src/vegetation/DetritusSystem.h
@@ -12,7 +12,7 @@
 #include "Mesh.h"
 #include "Texture.h"
 #include "RenderableBuilder.h"
-#include "scene/SceneObjectCollection.h"
+#include "scene/SceneMaterial.h"
 #include "scene/SceneObjectInstance.h"
 #include "scene/DeterministicRandom.h"
 #include <optional>
@@ -63,22 +63,26 @@ public:
     DetritusSystem& operator=(DetritusSystem&&) = delete;
 
     // Get scene objects for rendering (integrated with existing pipeline)
-    const std::vector<Renderable>& getSceneObjects() const { return collection_.getSceneObjects(); }
-    std::vector<Renderable>& getSceneObjects() { return collection_.getSceneObjects(); }
+    const std::vector<Renderable>& getSceneObjects() const { return material_.getSceneObjects(); }
+    std::vector<Renderable>& getSceneObjects() { return material_.getSceneObjects(); }
+
+    // Access the underlying material for unified scene collection
+    SceneMaterial& getMaterial() { return material_; }
+    const SceneMaterial& getMaterial() const { return material_; }
 
     // Access to textures for descriptor set binding
-    Texture& getBarkTexture() { return *collection_.getDiffuseTexture(); }
-    Texture& getBarkNormalMap() { return *collection_.getNormalTexture(); }
+    Texture& getBarkTexture() { return *material_.getDiffuseTexture(); }
+    Texture& getBarkNormalMap() { return *material_.getNormalTexture(); }
 
     // Get count for statistics
-    size_t getDetritusCount() const { return collection_.getInstanceCount(); }
-    size_t getMeshVariationCount() const { return collection_.getMeshVariationCount(); }
+    size_t getDetritusCount() const { return material_.getInstanceCount(); }
+    size_t getMeshVariationCount() const { return material_.getMeshVariationCount(); }
 
     // Get instances for physics integration (returns unified SceneObjectInstance)
-    const std::vector<SceneObjectInstance>& getInstances() const { return collection_.getInstances(); }
+    const std::vector<SceneObjectInstance>& getInstances() const { return material_.getInstances(); }
 
     // Get meshes for physics collision shapes
-    const std::vector<Mesh>& getMeshes() const { return collection_.getMeshes(); }
+    const std::vector<Mesh>& getMeshes() const { return material_.getMeshes(); }
 
 private:
     DetritusSystem() = default;  // Private: use factory
@@ -93,6 +97,6 @@ private:
     DetritusConfig config_;
     BranchGenerator generator_;
 
-    // Scene object collection (composition pattern)
-    SceneObjectCollection collection_;
+    // Scene material (composition pattern)
+    SceneMaterial material_;
 };

--- a/src/vegetation/RockSystem.h
+++ b/src/vegetation/RockSystem.h
@@ -11,7 +11,7 @@
 #include "Mesh.h"
 #include "Texture.h"
 #include "RenderableBuilder.h"
-#include "scene/SceneObjectCollection.h"
+#include "scene/SceneMaterial.h"
 #include "scene/SceneObjectInstance.h"
 #include "scene/DeterministicRandom.h"
 #include <optional>
@@ -60,22 +60,26 @@ public:
     RockSystem& operator=(RockSystem&&) = delete;
 
     // Get scene objects for rendering (integrated with existing pipeline)
-    const std::vector<Renderable>& getSceneObjects() const { return collection_.getSceneObjects(); }
-    std::vector<Renderable>& getSceneObjects() { return collection_.getSceneObjects(); }
+    const std::vector<Renderable>& getSceneObjects() const { return material_.getSceneObjects(); }
+    std::vector<Renderable>& getSceneObjects() { return material_.getSceneObjects(); }
+
+    // Access the underlying material for unified scene collection
+    SceneMaterial& getMaterial() { return material_; }
+    const SceneMaterial& getMaterial() const { return material_; }
 
     // Access to textures for descriptor set binding
-    Texture& getRockTexture() { return *collection_.getDiffuseTexture(); }
-    Texture& getRockNormalMap() { return *collection_.getNormalTexture(); }
+    Texture& getRockTexture() { return *material_.getDiffuseTexture(); }
+    Texture& getRockNormalMap() { return *material_.getNormalTexture(); }
 
     // Get rock count for statistics
-    size_t getRockCount() const { return collection_.getInstanceCount(); }
-    size_t getMeshVariationCount() const { return collection_.getMeshVariationCount(); }
+    size_t getRockCount() const { return material_.getInstanceCount(); }
+    size_t getMeshVariationCount() const { return material_.getMeshVariationCount(); }
 
     // Get rock instances for physics integration (returns unified SceneObjectInstance)
-    const std::vector<SceneObjectInstance>& getRockInstances() const { return collection_.getInstances(); }
+    const std::vector<SceneObjectInstance>& getRockInstances() const { return material_.getInstances(); }
 
     // Get rock meshes for physics collision shapes
-    const std::vector<Mesh>& getRockMeshes() const { return collection_.getMeshes(); }
+    const std::vector<Mesh>& getRockMeshes() const { return material_.getMeshes(); }
 
 private:
     RockSystem() = default;  // Private: use factory
@@ -89,6 +93,6 @@ private:
 
     RockConfig config_;
 
-    // Scene object collection (composition pattern)
-    SceneObjectCollection collection_;
+    // Scene material (composition pattern)
+    SceneMaterial material_;
 };


### PR DESCRIPTION
Renames SceneObjectCollection to SceneMaterial to clarify that it represents a material (textures + properties + mesh variations + instances).

Adds SceneCollection as a registry that allows unified iteration over all materials in the scene (rock, detritus, etc.) via collectAllSceneObjects().

Changes:
- SceneObjectCollection → SceneMaterial (rename for clarity)
- RockSystem and DetritusSystem now use SceneMaterial with getMaterial() accessor
- New SceneCollection class holds references to materials, used by shadow pass
- RendererSystems owns SceneCollection, materials auto-register via setRock()/setDetritus()