### PR TITLE
Identify and reduce code duplication and boilerplate

### DIFF
--- a/src/water/WaterGBuffer.cpp
+++ b/src/water/WaterGBuffer.cpp
@@ -4,6 +4,7 @@
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
 #include "core/vulkan/VmaResources.h"
+#include "core/vulkan/PipelineLayoutBuilder.h"
 #include "core/ImageBuilder.h"
 #include <SDL3/SDL_log.h>
 #include <vulkan/vulkan.hpp>
@@ -397,13 +398,10 @@ bool WaterGBuffer::createDescriptorSetLayout() {
 }
 
 bool WaterGBuffer::createPipelineLayout() {
-    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}
-        .setSetLayouts(**descriptorSetLayout_);
-
-    try {
-        pipelineLayout_.emplace(*raiiDevice_, pipelineLayoutInfo);
-    } catch (const vk::SystemError& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "WaterGBuffer: Failed to create pipeline layout: %s", e.what());
+    if (!PipelineLayoutBuilder(*raiiDevice_)
+            .addDescriptorSetLayout(**descriptorSetLayout_)
+            .buildInto(pipelineLayout_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "WaterGBuffer: Failed to create pipeline layout");
         return false;
     }
 


### PR DESCRIPTION
Migrate water/ocean code to use consolidated builder patterns:

- OceanFFT.cpp: Replace 4 manual pipeline layouts with PipelineLayoutBuilder, migrate ~15 image barriers to use BarrierHelpers
- WaterTileCull.cpp: Replace manual pipeline layout with PipelineLayoutBuilder
- WaterGBuffer.cpp: Replace manual pipeline layout with PipelineLayoutBuilder
- FoamBuffer.cpp: Migrate image barriers to use BarrierHelpers

This reduces ~280 lines of boilerplate barrier and pipeline layout code while improving consistency with the rest of the codebase.