### PR TITLE
Simplify code using transform hierarchy

### DIFF
--- a/src/ik/ClimbingIKSolver.cpp
+++ b/src/ik/ClimbingIKSolver.cpp
@@ -37,10 +37,7 @@ void ClimbingIKSolver::solve(
 
             // Orient hand to grip
             if (climbing.leftHandBoneIndex >= 0) {
-                int32_t parentIdx = skeleton.joints[climbing.leftHandBoneIndex].parentIndex;
-                glm::mat4 parentGlobal = (parentIdx >= 0 && static_cast<size_t>(parentIdx) < globalTransforms.size())
-                    ? globalTransforms[parentIdx]
-                    : glm::mat4(1.0f);
+                glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(climbing.leftHandBoneIndex, globalTransforms);
                 orientHandToHold(skeleton.joints[climbing.leftHandBoneIndex],
                                 climbing.leftHandHold,
                                 parentGlobal);
@@ -55,10 +52,7 @@ void ClimbingIKSolver::solve(
             TwoBoneIKSolver::solveBlended(skeleton, armChains[1], globalTransforms, armChains[1].weight);
 
             if (climbing.rightHandBoneIndex >= 0) {
-                int32_t parentIdx = skeleton.joints[climbing.rightHandBoneIndex].parentIndex;
-                glm::mat4 parentGlobal = (parentIdx >= 0 && static_cast<size_t>(parentIdx) < globalTransforms.size())
-                    ? globalTransforms[parentIdx]
-                    : glm::mat4(1.0f);
+                glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(climbing.rightHandBoneIndex, globalTransforms);
                 orientHandToHold(skeleton.joints[climbing.rightHandBoneIndex],
                                 climbing.rightHandHold,
                                 parentGlobal);

--- a/src/ik/LookAtIKSolver.cpp
+++ b/src/ik/LookAtIKSolver.cpp
@@ -54,9 +54,7 @@ void LookAtIKSolver::solve(
         }
 
         Joint& spineJoint = skeleton.joints[lookAt.spineBoneIndex];
-        glm::mat4 parentGlobal = lookAt.spineBoneIndex >= 0 && spineJoint.parentIndex >= 0
-            ? globalTransforms[spineJoint.parentIndex]
-            : glm::mat4(1.0f);
+        glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(lookAt.spineBoneIndex, globalTransforms);
         applyBoneRotation(spineJoint, lookAt.currentSpineRotation, parentGlobal, 1.0f);
     }
 
@@ -73,9 +71,7 @@ void LookAtIKSolver::solve(
         }
 
         Joint& neckJoint = skeleton.joints[lookAt.neckBoneIndex];
-        glm::mat4 parentGlobal = neckJoint.parentIndex >= 0
-            ? globalTransforms[neckJoint.parentIndex]
-            : glm::mat4(1.0f);
+        glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(lookAt.neckBoneIndex, globalTransforms);
         applyBoneRotation(neckJoint, lookAt.currentNeckRotation, parentGlobal, 1.0f);
     }
 
@@ -92,9 +88,7 @@ void LookAtIKSolver::solve(
         }
 
         Joint& headJoint = skeleton.joints[lookAt.headBoneIndex];
-        glm::mat4 parentGlobal = headJoint.parentIndex >= 0
-            ? globalTransforms[headJoint.parentIndex]
-            : glm::mat4(1.0f);
+        glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(lookAt.headBoneIndex, globalTransforms);
         applyBoneRotation(headJoint, lookAt.currentHeadRotation, parentGlobal, 1.0f);
     }
 }

--- a/src/ik/StraddleIKSolver.cpp
+++ b/src/ik/StraddleIKSolver.cpp
@@ -63,9 +63,7 @@ void StraddleIKSolver::solve(
 
     // Apply hip tilt
     Joint& pelvisJoint = skeleton.joints[straddle.pelvisBoneIndex];
-    glm::mat4 parentGlobal = pelvisJoint.parentIndex >= 0
-        ? globalTransforms[pelvisJoint.parentIndex]
-        : glm::mat4(1.0f);
+    glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(straddle.pelvisBoneIndex, globalTransforms);
 
     applyHipTilt(pelvisJoint, straddle.currentHipTilt * straddle.weight,
                  straddle.currentHipShift * straddle.weight, parentGlobal);
@@ -73,9 +71,7 @@ void StraddleIKSolver::solve(
     // Apply spine counter-rotation to keep upper body upright
     if (straddle.spineBaseBoneIndex >= 0) {
         Joint& spineJoint = skeleton.joints[straddle.spineBaseBoneIndex];
-        glm::mat4 spineParentGlobal = spineJoint.parentIndex >= 0
-            ? globalTransforms[spineJoint.parentIndex]
-            : glm::mat4(1.0f);
+        glm::mat4 spineParentGlobal = skeleton.getParentGlobalTransform(straddle.spineBaseBoneIndex, globalTransforms);
 
         // Counter-rotate spine to compensate for hip tilt
         float compensation = -straddle.currentHipTilt * 0.7f * straddle.weight;

--- a/src/ik/TwoBoneIKSolver.cpp
+++ b/src/ik/TwoBoneIKSolver.cpp
@@ -186,10 +186,7 @@ bool TwoBoneIKSolver::solve(
     glm::vec3 newRootDir = glm::normalize(newMidPos - rootPos);
 
     // Get parent's world rotation to convert to local space
-    glm::mat4 parentGlobal = glm::mat4(1.0f);
-    if (rootJoint.parentIndex >= 0) {
-        parentGlobal = globalTransforms[rootJoint.parentIndex];
-    }
+    glm::mat4 parentGlobal = skeleton.getParentGlobalTransform(chain.rootBoneIndex, globalTransforms);
     glm::quat parentWorldRot = glm::quat_cast(glm::mat3(parentGlobal));
     glm::quat parentWorldRotInv = glm::inverse(parentWorldRot);
 

--- a/src/loaders/GLTFLoader.h
+++ b/src/loaders/GLTFLoader.h
@@ -48,6 +48,19 @@ struct Skeleton {
 
     void computeGlobalTransforms(std::vector<glm::mat4>& outGlobalTransforms) const;
     int32_t findJointIndex(const std::string& name) const;
+
+    // Helper to get parent's global transform for a joint (returns identity for root joints)
+    inline glm::mat4 getParentGlobalTransform(int32_t jointIndex,
+                                              const std::vector<glm::mat4>& globalTransforms) const {
+        if (jointIndex < 0 || static_cast<size_t>(jointIndex) >= joints.size()) {
+            return glm::mat4(1.0f);
+        }
+        int32_t parentIdx = joints[jointIndex].parentIndex;
+        if (parentIdx < 0 || static_cast<size_t>(parentIdx) >= globalTransforms.size()) {
+            return glm::mat4(1.0f);
+        }
+        return globalTransforms[parentIdx];
+    }
 };
 
 // Result of loading a glTF file (static mesh)


### PR DESCRIPTION
- Added getParentGlobalTransform() inline method to Skeleton struct that encapsulates the common pattern of looking up a joint's parent transform
- Updated LookAtIKSolver to use new helper (3 instances)
- Updated StraddleIKSolver to use new helper (2 instances)
- Updated ClimbingIKSolver to use new helper (2 instances)
- Updated TwoBoneIKSolver to use new helper (1 instance)

This reduces code duplication and makes the IK solvers more readable by replacing verbose ternary expressions with a single method call.