### PR TITLE
Fix GLM macro redefinition warning

### DIFF
--- a/src/ik/IKUtils.cpp
+++ b/src/ik/IKUtils.cpp
@@ -1,5 +1,7 @@
 #include "IKSolver.h"
+#ifndef GLM_ENABLE_EXPERIMENTAL
 #define GLM_ENABLE_EXPERIMENTAL
+#endif
 #include <glm/gtx/norm.hpp>
 #include <cmath>
 

--- a/tests/test_ik_utils.cpp
+++ b/tests/test_ik_utils.cpp
@@ -1,5 +1,7 @@
 #include <doctest/doctest.h>
+#ifndef GLM_ENABLE_EXPERIMENTAL
 #define GLM_ENABLE_EXPERIMENTAL
+#endif
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>


### PR DESCRIPTION
Add #ifndef guards around GLM_ENABLE_EXPERIMENTAL defines to prevent redefinition warnings when the macro is already defined on the command line.