### PR TITLE
Identify simplification opportunities in IK solver

### DIFF
--- a/src/ik/FootPlacementIKSolver.cpp
+++ b/src/ik/FootPlacementIKSolver.cpp
@@ -141,9 +141,9 @@ void FootPlacementIKSolver::solve(
         IKUtils::decomposeTransform(footJoint.localTransform, t, currentLocalRot, s);
 
         // Get parent world rotation to convert between local and world space
-        int32_t parentIdx = skeleton.joints[foot.footBoneIndex].parentIndex;
-        if (parentIdx >= 0) {
-            glm::quat parentWorldRot = glm::quat_cast(glm::mat3(updatedGlobalTransforms[parentIdx]));
+        glm::mat4 footParentGlobal = skeleton.getParentGlobalTransform(foot.footBoneIndex, updatedGlobalTransforms);
+        if (skeleton.joints[foot.footBoneIndex].parentIndex >= 0) {
+            glm::quat parentWorldRot = glm::quat_cast(glm::mat3(footParentGlobal));
 
             // Compute the foot's world rotation from its current local rotation
             glm::quat footWorldRot = parentWorldRot * currentLocalRot;

--- a/src/ik/TwoBoneIKSolver.cpp
+++ b/src/ik/TwoBoneIKSolver.cpp
@@ -235,14 +235,9 @@ bool TwoBoneIKSolver::solve(
     glm::vec3 desiredEndDir = glm::normalize(desiredEndOffset);
 
     // Mid bone's parent is root bone (after IK), so we need the new root global transform
-    // Use finalRootLocalRot which includes pre-rotation
-    glm::mat4 newRootGlobal;
-    if (rootJoint.parentIndex >= 0) {
-        newRootGlobal = globalTransforms[rootJoint.parentIndex] *
-                        IKUtils::composeTransform(rootTranslation, finalRootLocalRot, rootScale);
-    } else {
-        newRootGlobal = IKUtils::composeTransform(rootTranslation, finalRootLocalRot, rootScale);
-    }
+    // Use getParentGlobalTransform which returns identity for root bones
+    glm::mat4 rootParentGlobal = skeleton.getParentGlobalTransform(chain.rootBoneIndex, globalTransforms);
+    glm::mat4 newRootGlobal = rootParentGlobal * IKUtils::composeTransform(rootTranslation, finalRootLocalRot, rootScale);
 
     glm::quat midParentWorldRot = glm::quat_cast(glm::mat3(newRootGlobal));
     glm::quat midParentWorldRotInv = glm::inverse(midParentWorldRot);

--- a/src/loaders/FBXPostProcess.cpp
+++ b/src/loaders/FBXPostProcess.cpp
@@ -289,6 +289,9 @@ void process(GLTFSkinnedLoadResult& result, const FBXImportSettings& settings) {
 
     SDL_Log("FBXPostProcess: Processed %zu vertices, %zu joints, %zu animations",
             result.vertices.size(), result.skeleton.joints.size(), result.animations.size());
+
+    // Build internal transform hierarchy for efficient global transform computation
+    result.skeleton.buildHierarchy();
 }
 
 void process(GLTFLoadResult& result, const FBXImportSettings& settings) {

--- a/src/loaders/GLTFLoader.h
+++ b/src/loaders/GLTFLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Mesh.h"
+#include "scene/Transform.h"
 #include <string>
 #include <optional>
 #include <vector>
@@ -61,6 +62,19 @@ struct Skeleton {
         }
         return globalTransforms[parentIdx];
     }
+
+    // Build the internal transform hierarchy from joints (call after loading)
+    void buildHierarchy();
+
+    // Check if hierarchy has been built
+    bool hasHierarchy() const { return !jointHandles_.empty(); }
+
+private:
+    mutable TransformHierarchy hierarchy_;
+    std::vector<TransformHandle> jointHandles_;
+
+    // Sync joint local transforms to hierarchy (called before computing global transforms)
+    void syncToHierarchy() const;
 };
 
 // Result of loading a glTF file (static mesh)


### PR DESCRIPTION
- TwoBoneIKSolver: Use getParentGlobalTransform helper to eliminate if/else when computing post-IK root global transform
- FootPlacementIKSolver: Use getParentGlobalTransform helper for consistent parent transform lookup
- Skeleton: Add internal TransformHierarchy for efficient global transform computation with dirty tracking and caching
- Build hierarchy automatically after loading in GLTF and FBX loaders