### PR TITLE
Investigate pipeline bubble causes

### DIFF
--- a/src/water/WaterTileCull.h
+++ b/src/water/WaterTileCull.h
@@ -128,10 +128,13 @@ private:
     bool createComputePipeline();
     bool createDescriptorSets();
 
-    // Synchronize cull output for drawing and counter transfer
-    void barrierCullResultsForDrawAndTransfer(VkCommandBuffer cmd, uint32_t frameIndex);
+    // Synchronize counter buffer for transfer (compute → transfer)
+    void barrierCounterForTransfer(VkCommandBuffer cmd, uint32_t frameIndex);
 
-    // Synchronize counter readback for CPU access
+    // Synchronize tile/indirect buffers for drawing (compute → vertex/draw)
+    void barrierCullResultsForDraw(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    // Synchronize counter readback for CPU access (transfer → host)
     void barrierCounterForHostRead(VkCommandBuffer cmd, uint32_t frameIndex);
 
     VkDevice device = VK_NULL_HANDLE;


### PR DESCRIPTION
- Hi-Z pyramid: Use memory-only barriers between mip levels instead of layout transitions. The single layout transition at the end reduces per-mip barrier overhead significantly.

- Water tile cull: Split combined barrier into separate transfer and draw barriers. This prevents synchronization with unrelated pipeline stages (eVertexShader | eDrawIndirect for transfer operations).

- VT feedback: Use buffer-specific barriers instead of global memory barrier for more precise synchronization scope.

These changes address identified pipeline bubble sources by reducing unnecessary synchronization points and using more targeted barriers.