### PR TITLE
Move descriptor sets to owning systems

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -633,23 +633,8 @@ bool Renderer::createDescriptorSets() {
         return false;
     }
 
-    // Rock descriptor sets (RockSystem has its own textures, not in MaterialRegistry)
-    // Note: rockSystem is not initialized at this point - allocation only, writing done in initPhase2
-    rockDescriptorSets = descriptorManagerPool->allocate(**descriptorSetLayout_, MAX_FRAMES_IN_FLIGHT);
-    if (rockDescriptorSets.empty()) {
-        SDL_Log("Failed to allocate rock descriptor sets");
-        return false;
-    }
-
-    // Detritus descriptor sets (fallen branches - allocation only, writing done in initPhase2)
-    detritusDescriptorSets = descriptorManagerPool->allocate(**descriptorSetLayout_, MAX_FRAMES_IN_FLIGHT);
-    if (detritusDescriptorSets.empty()) {
-        SDL_Log("Failed to allocate detritus descriptor sets");
-        return false;
-    }
-
-    // Tree descriptor sets - allocation deferred to initPhase2 when TreeSystem is available
-    // Will allocate per texture type using string-based maps
+    // Rock and Detritus descriptor sets are now owned by their respective systems
+    // They are created in initPhase2 when the systems are initialized
 
     return true;
 }
@@ -1508,16 +1493,17 @@ void Renderer::recordSceneObjects(VkCommandBuffer cmd, uint32_t frameIndex) {
         renderObject(obj, currentDescSet);
     }
 
-    // Render procedural rocks (RockSystem uses its own descriptor sets)
-    VkDescriptorSet rockDescSet = rockDescriptorSets[frameIndex];
-    for (const auto& rock : systems_->rock().getSceneObjects()) {
-        renderObject(rock, rockDescSet);
+    // Render procedural rocks (RockSystem owns its own descriptor sets)
+    if (systems_->rock().hasDescriptorSets()) {
+        VkDescriptorSet rockDescSet = systems_->rock().getDescriptorSet(frameIndex);
+        for (const auto& rock : systems_->rock().getSceneObjects()) {
+            renderObject(rock, rockDescSet);
+        }
     }
 
-    // Render woodland detritus (fallen branches - uses its own descriptor sets)
-    // Bounds check: frameIndex must be within range, not just non-empty
-    if (systems_->detritus() && frameIndex < detritusDescriptorSets.size()) {
-        VkDescriptorSet detritusDescSet = detritusDescriptorSets[frameIndex];
+    // Render woodland detritus (DetritusSystem owns its own descriptor sets)
+    if (systems_->detritus() && systems_->detritus()->hasDescriptorSets()) {
+        VkDescriptorSet detritusDescSet = systems_->detritus()->getDescriptorSet(frameIndex);
         for (const auto& detritus : systems_->detritus()->getSceneObjects()) {
             renderObject(detritus, detritusDescSet);
         }

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -319,17 +319,6 @@ private:
     // Centralized asset management
     AssetRegistry assetRegistry_;
 
-    // Rock descriptor sets (RockSystem has its own textures, not in MaterialRegistry)
-    std::vector<VkDescriptorSet> rockDescriptorSets;
-
-    // Detritus descriptor sets (DetritusSystem has its own bark textures)
-    std::vector<VkDescriptorSet> detritusDescriptorSets;
-
-    // Tree descriptor sets per texture type (keyed by type name string)
-    // Each map has entries for each frame: map[typeName][frameIndex]
-    std::unordered_map<std::string, std::vector<VkDescriptorSet>> treeBarkDescriptorSets;
-    std::unordered_map<std::string, std::vector<VkDescriptorSet>> treeLeafDescriptorSets;
-
     // Convenience accessor for frame count (matches TripleBuffering::DEFAULT_FRAME_COUNT)
     static constexpr int MAX_FRAMES_IN_FLIGHT = TripleBuffering::DEFAULT_FRAME_COUNT;
 

--- a/src/core/RendererInit.h
+++ b/src/core/RendererInit.h
@@ -28,6 +28,8 @@ class MaterialRegistry;
 class SkinnedMeshRenderer;
 class RendererSystems;
 class PostProcessSystem;
+class RockSystem;
+class DetritusSystem;
 struct TerrainConfig;
 
 /**
@@ -128,10 +130,11 @@ public:
     static void updateCloudShadowBindings(
         VkDevice device,
         MaterialRegistry& materialRegistry,
-        const std::vector<VkDescriptorSet>& rockDescriptorSets,
-        const std::vector<VkDescriptorSet>& detritusDescriptorSets,
+        RockSystem& rockSystem,
+        DetritusSystem* detritusSystem,
         SkinnedMeshRenderer& skinnedMeshRenderer,
         VkImageView cloudShadowView,
-        VkSampler cloudShadowSampler
+        VkSampler cloudShadowSampler,
+        uint32_t frameCount
     );
 };

--- a/src/vegetation/DetritusSystem.h
+++ b/src/vegetation/DetritusSystem.h
@@ -15,6 +15,8 @@
 #include "scene/SceneMaterial.h"
 #include "scene/SceneObjectInstance.h"
 #include "scene/DeterministicRandom.h"
+#include "core/material/MaterialDescriptorFactory.h"
+#include "DescriptorManager.h"
 #include <optional>
 
 // Configuration for detritus generation and placement
@@ -89,6 +91,20 @@ public:
     // Get meshes for physics collision shapes
     const std::vector<Mesh>& getMeshes() const { return material_.getMeshes(); }
 
+    // Descriptor set management - DetritusSystem owns its descriptor sets
+    bool createDescriptorSets(
+        VkDevice device,
+        DescriptorManager::Pool& pool,
+        VkDescriptorSetLayout layout,
+        uint32_t frameCount,
+        std::function<MaterialDescriptorFactory::CommonBindings(uint32_t)> getCommonBindings);
+
+    VkDescriptorSet getDescriptorSet(uint32_t frameIndex) const {
+        return (frameIndex < descriptorSets_.size()) ? descriptorSets_[frameIndex] : VK_NULL_HANDLE;
+    }
+
+    bool hasDescriptorSets() const { return !descriptorSets_.empty(); }
+
 private:
     bool initInternal(const InitInfo& info, const DetritusConfig& config);
     void cleanup();
@@ -102,4 +118,7 @@ private:
 
     // Scene material (composition pattern)
     SceneMaterial material_;
+
+    // Descriptor sets for detritus rendering (one per frame in flight)
+    std::vector<VkDescriptorSet> descriptorSets_;
 };

--- a/src/vegetation/RockSystem.h
+++ b/src/vegetation/RockSystem.h
@@ -14,6 +14,8 @@
 #include "scene/SceneMaterial.h"
 #include "scene/SceneObjectInstance.h"
 #include "scene/DeterministicRandom.h"
+#include "core/material/MaterialDescriptorFactory.h"
+#include "DescriptorManager.h"
 #include <optional>
 
 // Configuration for rock generation and placement
@@ -86,6 +88,20 @@ public:
     // Get rock meshes for physics collision shapes
     const std::vector<Mesh>& getRockMeshes() const { return material_.getMeshes(); }
 
+    // Descriptor set management - RockSystem owns its descriptor sets
+    bool createDescriptorSets(
+        VkDevice device,
+        DescriptorManager::Pool& pool,
+        VkDescriptorSetLayout layout,
+        uint32_t frameCount,
+        std::function<MaterialDescriptorFactory::CommonBindings(uint32_t)> getCommonBindings);
+
+    VkDescriptorSet getDescriptorSet(uint32_t frameIndex) const {
+        return (frameIndex < descriptorSets_.size()) ? descriptorSets_[frameIndex] : VK_NULL_HANDLE;
+    }
+
+    bool hasDescriptorSets() const { return !descriptorSets_.empty(); }
+
 private:
     bool initInternal(const InitInfo& info, const RockConfig& config);
     void cleanup();
@@ -98,4 +114,7 @@ private:
 
     // Scene material (composition pattern)
     SceneMaterial material_;
+
+    // Descriptor sets for rock rendering (one per frame in flight)
+    std::vector<VkDescriptorSet> descriptorSets_;
 };


### PR DESCRIPTION
- RockSystem now owns its descriptor sets
- DetritusSystem now owns its descriptor sets
- Removed unused tree descriptor sets from Renderer (TreeRenderer has its own)
- Added createDescriptorSets(), getDescriptorSet(), hasDescriptorSets() methods to RockSystem and DetritusSystem
- Updated RendererInit::updateCloudShadowBindings to work with the new API
- Reduces coupling and improves encapsulation by having each system manage its own Vulkan resources