### PR TITLE
Move player render state to subsystem

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -13,6 +13,7 @@
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "core/pipeline/FrameGraphBuilder.h"
 #include "core/FrameUpdater.h"
+#include "interfaces/IPlayerControl.h"
 
 // Subsystem includes for render loop
 // Core systems
@@ -217,16 +218,6 @@ void Renderer::setupFrameGraph() {
 
 // Note: initCoreVulkanResources(), initDescriptorInfrastructure(), initSubsystems(),
 // and initResizeCoordinator() are implemented in RendererInitPhases.cpp
-
-void Renderer::setPlayerPosition(const glm::vec3& position, float radius) {
-    setPlayerState(position, glm::vec3(0.0f), radius);
-}
-
-void Renderer::setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius) {
-    playerPosition = position;
-    playerVelocity = velocity;
-    playerCapsuleRadius = radius;
-}
 
 void Renderer::updateRoadRiverVisualization() {
     if (!systems_->debugControl().isRoadRiverVisualizationEnabled()) {
@@ -1080,9 +1071,11 @@ FrameData Renderer::buildFrameData(const Camera& camera, float deltaTime, float 
     frame.sunDirection = glm::normalize(glm::vec3(ubo->toSunDirection));
     frame.sunIntensity = ubo->toSunDirection.w;
 
-    frame.playerPosition = playerPosition;
-    frame.playerVelocity = playerVelocity;
-    frame.playerCapsuleRadius = playerCapsuleRadius;
+    // Get player state from PlayerControlSubsystem
+    const auto& playerControl = systems_->playerControl();
+    frame.playerPosition = playerControl.getPlayerPosition();
+    frame.playerVelocity = playerControl.getPlayerVelocity();
+    frame.playerCapsuleRadius = playerControl.getPlayerCapsuleRadius();
 
     const auto& terrainConfig = systems_->terrain().getConfig();
     frame.terrainSize = terrainConfig.size;

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -180,9 +180,6 @@ public:
     void toggleCloudStyle() { useParaboloidClouds = !useParaboloidClouds; }
     bool isUsingParaboloidClouds() const { return useParaboloidClouds; }
 
-    // Player state for grass/snow interaction (used in render loop)
-    void setPlayerPosition(const glm::vec3& position, float radius);
-    void setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius);
 
     // Physics debug (local state)
     void setPhysicsDebugEnabled(bool enabled) { physicsDebugEnabled = enabled; }
@@ -332,10 +329,6 @@ private:
     bool framebufferResized = false;       // true = window resized, need to recreate swapchain
     bool windowSuspended = false;          // true = window minimized/hidden (macOS screen lock)
 
-    // Player position for grass displacement
-    glm::vec3 playerPosition = glm::vec3(0.0f);
-    glm::vec3 playerVelocity = glm::vec3(0.0f);
-    float playerCapsuleRadius = 0.3f;      // Default capsule radius
 
     // Dynamic lights
     float lightCullRadius = 100.0f;        // Radius from camera for light culling

--- a/src/core/controls/PlayerControlSubsystem.cpp
+++ b/src/core/controls/PlayerControlSubsystem.cpp
@@ -8,3 +8,9 @@ SceneBuilder& PlayerControlSubsystem::getSceneBuilder() {
 const SceneBuilder& PlayerControlSubsystem::getSceneBuilder() const {
     return scene_.getSceneBuilder();
 }
+
+void PlayerControlSubsystem::setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius) {
+    playerPosition_ = position;
+    playerVelocity_ = velocity;
+    playerCapsuleRadius_ = radius;
+}

--- a/src/core/controls/PlayerControlSubsystem.h
+++ b/src/core/controls/PlayerControlSubsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "interfaces/IPlayerControl.h"
+#include <glm/glm.hpp>
 
 class SceneManager;
 class SceneBuilder;
@@ -8,6 +9,7 @@ class SceneBuilder;
 /**
  * PlayerControlSubsystem - Implements IPlayerControl
  * Provides access to SceneBuilder for player-related controls.
+ * Owns player render state (position/velocity/radius) for interaction systems.
  */
 class PlayerControlSubsystem : public IPlayerControl {
 public:
@@ -17,6 +19,17 @@ public:
     SceneBuilder& getSceneBuilder() override;
     const SceneBuilder& getSceneBuilder() const override;
 
+    // Player render state
+    void setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius) override;
+    const glm::vec3& getPlayerPosition() const override { return playerPosition_; }
+    const glm::vec3& getPlayerVelocity() const override { return playerVelocity_; }
+    float getPlayerCapsuleRadius() const override { return playerCapsuleRadius_; }
+
 private:
     SceneManager& scene_;
+
+    // Player render state for interaction systems (grass displacement, snow, leaves, etc.)
+    glm::vec3 playerPosition_ = glm::vec3(0.0f);
+    glm::vec3 playerVelocity_ = glm::vec3(0.0f);
+    float playerCapsuleRadius_ = 0.3f;  // Default capsule radius
 };

--- a/src/core/interfaces/IPlayerControl.h
+++ b/src/core/interfaces/IPlayerControl.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <glm/glm.hpp>
+
 class SceneBuilder;
 
 /**
  * Interface for player-related controls.
  * Used by GuiPlayerTab to control player-specific settings.
+ * Also provides player render state (position/velocity/radius) for systems
+ * that need to interact with the player (grass displacement, snow footprints, etc.)
  */
 class IPlayerControl {
 public:
@@ -13,4 +17,10 @@ public:
     // Scene builder access (for player cape)
     virtual SceneBuilder& getSceneBuilder() = 0;
     virtual const SceneBuilder& getSceneBuilder() const = 0;
+
+    // Player render state for interaction systems
+    virtual void setPlayerState(const glm::vec3& position, const glm::vec3& velocity, float radius) = 0;
+    virtual const glm::vec3& getPlayerPosition() const = 0;
+    virtual const glm::vec3& getPlayerVelocity() const = 0;
+    virtual float getPlayerCapsuleRadius() const = 0;
 };

--- a/src/scene/Application.cpp
+++ b/src/scene/Application.cpp
@@ -28,6 +28,7 @@
 #include "core/interfaces/IDebugControl.h"
 #include "core/interfaces/IWeatherState.h"
 #include "core/interfaces/ITerrainControl.h"
+#include "core/interfaces/IPlayerControl.h"
 
 #ifdef JPH_DEBUG_RENDERER
 #include "PhysicsDebugRenderer.h"
@@ -542,8 +543,8 @@ void Application::run() {
         // Update scene object transforms from physics
         renderer_->getSystems().scene().update(physics());
 
-        // Update player position for grass interaction (always, regardless of camera mode)
-        renderer_->setPlayerState(playerTransform.position, physicsVelocity, PlayerMovement::CAPSULE_RADIUS);
+        // Update player state in PlayerControlSubsystem for grass/snow/leaf interaction
+        renderer_->getPlayerControl().setPlayerState(playerTransform.position, physicsVelocity, PlayerMovement::CAPSULE_RADIUS);
 
         // Wait for previous frame's GPU work to complete before updating dynamic meshes.
         // This prevents race conditions where we destroy mesh buffers while the GPU


### PR DESCRIPTION
The player position, velocity, and capsule radius state is now owned by PlayerControlSubsystem instead of Renderer. This better reflects the architectural ownership where PlayerControlSubsystem manages player-related state while Renderer consumes it via FrameData.

Changes:
- Add player state methods to IPlayerControl interface
- Add position/velocity/radius storage to PlayerControlSubsystem
- Update buildFrameData() to get state from PlayerControlSubsystem
- Update Application to call setPlayerState on PlayerControlSubsystem
- Remove player state members and methods from Renderer