### PR TITLE
Refactor PhysicsSystem for simplicity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ set(SOURCES
     src/lighting/ShadowSystem.cpp
     # Physics
     src/physics/PhysicsSystem.cpp
+    src/physics/JoltLayerConfig.cpp
+    src/physics/JoltRuntime.cpp
+    src/physics/CharacterController.cpp
     src/physics/PhysicsTerrainTileManager.cpp
     src/physics/ParticleSystem.cpp
     src/physics/ClothSimulation.cpp

--- a/src/physics/CharacterController.cpp
+++ b/src/physics/CharacterController.cpp
@@ -1,0 +1,156 @@
+#include "CharacterController.h"
+#include "PhysicsConversions.h"
+#include "JoltLayerConfig.h"
+
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/PhysicsSystem.h>
+#include <Jolt/Physics/Character/CharacterVirtual.h>
+#include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
+#include <Jolt/Core/TempAllocator.h>
+
+#include <SDL3/SDL_log.h>
+
+using namespace PhysicsConversions;
+
+CharacterController::CharacterController() = default;
+
+CharacterController::~CharacterController() = default;
+
+CharacterController::CharacterController(CharacterController&&) noexcept = default;
+
+CharacterController& CharacterController::operator=(CharacterController&&) noexcept = default;
+
+bool CharacterController::create(JPH::PhysicsSystem* physicsSystem, const glm::vec3& position,
+                                  float height, float radius) {
+    height_ = height;
+    radius_ = radius;
+
+    // Create a capsule shape for the character
+    // Capsule height is the cylinder height (excluding hemispheres)
+    float cylinderHeight = height - 2.0f * radius;
+    if (cylinderHeight < 0.0f) cylinderHeight = 0.01f;
+
+    JPH::RefConst<JPH::Shape> standingShape = new JPH::CapsuleShape(cylinderHeight * 0.5f, radius);
+
+    JPH::CharacterVirtualSettings settings;
+    settings.mShape = standingShape;
+    settings.mMaxSlopeAngle = JPH::DegreesToRadians(45.0f);
+    settings.mMaxStrength = 25.0f;
+    settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
+    settings.mCharacterPadding = 0.05f;
+    settings.mPenetrationRecoverySpeed = 0.4f;
+    settings.mPredictiveContactDistance = 0.1f;
+    settings.mSupportingVolume = JPH::Plane(JPH::Vec3::sAxisY(), -radius);
+    settings.mMass = 70.0f;
+
+    // Position the character so feet are at the given Y
+    JPH::RVec3 characterPos(position.x, position.y + height * 0.5f, position.z);
+
+    character_ = std::make_unique<JPH::CharacterVirtual>(
+        &settings,
+        characterPos,
+        JPH::Quat::sIdentity(),
+        0,  // User data
+        physicsSystem
+    );
+    character_->SetListener(&g_characterContactListener);
+
+    SDL_Log("Created character controller at (%.1f, %.1f, %.1f)", position.x, position.y, position.z);
+    return true;
+}
+
+void CharacterController::update(float deltaTime, JPH::PhysicsSystem* physicsSystem,
+                                  JPH::TempAllocatorImpl* tempAllocator) {
+    if (!character_) return;
+
+    // Apply character input following Jolt's CharacterVirtual documentation
+    JPH::Vec3 currentVelocity = character_->GetLinearVelocity();
+    JPH::CharacterVirtual::EGroundState groundState = character_->GetGroundState();
+    bool onGround = groundState == JPH::CharacterVirtual::EGroundState::OnGround;
+
+    JPH::Vec3 newVelocity;
+
+    // Horizontal velocity from input
+    newVelocity.SetX(desiredVelocity_.x);
+    newVelocity.SetZ(desiredVelocity_.z);
+
+    // Vertical velocity per Jolt docs:
+    // OnGround: groundVelocity + horizontal + optional jump + dt*gravity
+    // Else: currentVertical + horizontal + dt*gravity
+    if (onGround) {
+        JPH::Vec3 groundVelocity = character_->GetGroundVelocity();
+        float verticalVelocity = groundVelocity.GetY();
+
+        if (wantsJump_) {
+            verticalVelocity += 5.0f;
+            wantsJump_ = false;
+        }
+
+        newVelocity.SetY(verticalVelocity);
+    } else {
+        newVelocity.SetY(currentVelocity.GetY());
+    }
+
+    // Always apply gravity
+    newVelocity += physicsSystem->GetGravity() * deltaTime;
+
+    character_->SetLinearVelocity(newVelocity);
+
+    // ExtendedUpdate - use zero gravity to avoid applying extra downward force
+    JPH::CharacterVirtual::ExtendedUpdateSettings updateSettings;
+    updateSettings.mStickToFloorStepDown = JPH::Vec3(0, -0.5f, 0);
+    updateSettings.mWalkStairsStepUp = JPH::Vec3(0, 0.4f, 0);
+
+    JPH::DefaultBroadPhaseLayerFilter broadPhaseFilter(g_objectVsBroadPhaseLayerFilter, PhysicsLayers::CHARACTER);
+    JPH::DefaultObjectLayerFilter objectLayerFilter(g_objectLayerPairFilter, PhysicsLayers::CHARACTER);
+    JPH::BodyFilter bodyFilter;
+    JPH::ShapeFilter shapeFilter;
+
+    character_->ExtendedUpdate(
+        deltaTime,
+        JPH::Vec3::sZero(),  // No extra gravity - we already applied it above
+        updateSettings,
+        broadPhaseFilter,
+        objectLayerFilter,
+        bodyFilter,
+        shapeFilter,
+        *tempAllocator
+    );
+}
+
+void CharacterController::setInput(const glm::vec3& desiredVelocity, bool jump) {
+    desiredVelocity_ = desiredVelocity;
+    wantsJump_ = jump;
+}
+
+void CharacterController::setPosition(const glm::vec3& position) {
+    if (!character_) return;
+
+    // Character position is at center, so offset by half height
+    JPH::RVec3 centerPos(position.x, position.y + height_ * 0.5f, position.z);
+    character_->SetPosition(centerPos);
+    // Reset velocity to avoid glitches when teleporting
+    character_->SetLinearVelocity(JPH::Vec3::sZero());
+}
+
+glm::vec3 CharacterController::getPosition() const {
+    if (!character_) return glm::vec3(0.0f);
+
+    JPH::RVec3 pos = character_->GetPosition();
+    // Return foot position (bottom of character)
+    return glm::vec3(
+        static_cast<float>(pos.GetX()),
+        static_cast<float>(pos.GetY()) - height_ * 0.5f,
+        static_cast<float>(pos.GetZ())
+    );
+}
+
+glm::vec3 CharacterController::getVelocity() const {
+    if (!character_) return glm::vec3(0.0f);
+    return toGLM(character_->GetLinearVelocity());
+}
+
+bool CharacterController::isOnGround() const {
+    if (!character_) return false;
+    return character_->GetGroundState() == JPH::CharacterVirtual::EGroundState::OnGround;
+}

--- a/src/physics/CharacterController.h
+++ b/src/physics/CharacterController.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <memory>
+
+// Forward declarations for Jolt types
+namespace JPH {
+    class CharacterVirtual;
+    class PhysicsSystem;
+    class TempAllocatorImpl;
+}
+
+// Character controller wrapping Jolt's CharacterVirtual
+// Handles character physics separately from the main physics world
+class CharacterController {
+public:
+    CharacterController();
+    ~CharacterController();
+
+    // Move-only (CharacterVirtual is not copyable)
+    CharacterController(CharacterController&&) noexcept;
+    CharacterController& operator=(CharacterController&&) noexcept;
+    CharacterController(const CharacterController&) = delete;
+    CharacterController& operator=(const CharacterController&) = delete;
+
+    // Create the character at the given position
+    // Returns true on success
+    bool create(JPH::PhysicsSystem* physicsSystem, const glm::vec3& position,
+                float height, float radius);
+
+    // Update the character physics (called during fixed timestep)
+    void update(float deltaTime, JPH::PhysicsSystem* physicsSystem,
+                JPH::TempAllocatorImpl* tempAllocator);
+
+    // Set desired movement input (called from game logic)
+    void setInput(const glm::vec3& desiredVelocity, bool jump);
+
+    // Position management
+    void setPosition(const glm::vec3& position);
+    glm::vec3 getPosition() const;
+    glm::vec3 getVelocity() const;
+
+    // Ground state
+    bool isOnGround() const;
+
+    // Check if character is created
+    bool isValid() const { return character_ != nullptr; }
+
+private:
+    std::unique_ptr<JPH::CharacterVirtual> character_;
+    float height_ = 1.8f;
+    float radius_ = 0.3f;
+    glm::vec3 desiredVelocity_{0.0f};
+    bool wantsJump_ = false;
+};

--- a/src/physics/JoltLayerConfig.cpp
+++ b/src/physics/JoltLayerConfig.cpp
@@ -1,0 +1,7 @@
+#include "JoltLayerConfig.h"
+
+// Global instances for layer filtering
+BPLayerInterfaceImpl g_broadPhaseLayerInterface;
+ObjectLayerPairFilterImpl g_objectLayerPairFilter;
+ObjectVsBroadPhaseLayerFilterImpl g_objectVsBroadPhaseLayerFilter;
+CharacterContactListener g_characterContactListener;

--- a/src/physics/JoltLayerConfig.h
+++ b/src/physics/JoltLayerConfig.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/Collision/ObjectLayer.h>
+#include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>
+#include <Jolt/Physics/Character/CharacterVirtual.h>
+
+// Collision layers
+namespace PhysicsLayers {
+    constexpr uint8_t NON_MOVING = 0;
+    constexpr uint8_t MOVING = 1;
+    constexpr uint8_t CHARACTER = 2;
+    constexpr uint8_t NUM_LAYERS = 3;
+}
+
+// Broad phase layers
+namespace BroadPhaseLayers {
+    constexpr uint8_t NON_MOVING = 0;
+    constexpr uint8_t MOVING = 1;
+    constexpr uint8_t NUM_LAYERS = 2;
+}
+
+// Layer definitions for object vs broadphase layers
+class BPLayerInterfaceImpl final : public JPH::BroadPhaseLayerInterface {
+public:
+    BPLayerInterfaceImpl() {
+        objectToBroadPhase_[PhysicsLayers::NON_MOVING] = JPH::BroadPhaseLayer(BroadPhaseLayers::NON_MOVING);
+        objectToBroadPhase_[PhysicsLayers::MOVING] = JPH::BroadPhaseLayer(BroadPhaseLayers::MOVING);
+        objectToBroadPhase_[PhysicsLayers::CHARACTER] = JPH::BroadPhaseLayer(BroadPhaseLayers::MOVING);
+    }
+
+    uint32_t GetNumBroadPhaseLayers() const override {
+        return BroadPhaseLayers::NUM_LAYERS;
+    }
+
+    JPH::BroadPhaseLayer GetBroadPhaseLayer(JPH::ObjectLayer inLayer) const override {
+        JPH_ASSERT(inLayer < PhysicsLayers::NUM_LAYERS);
+        return objectToBroadPhase_[inLayer];
+    }
+
+#if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
+    const char* GetBroadPhaseLayerName(JPH::BroadPhaseLayer inLayer) const override {
+        switch ((JPH::BroadPhaseLayer::Type)inLayer) {
+            case BroadPhaseLayers::NON_MOVING: return "NON_MOVING";
+            case BroadPhaseLayers::MOVING: return "MOVING";
+            default: JPH_ASSERT(false); return "INVALID";
+        }
+    }
+#endif
+
+private:
+    JPH::BroadPhaseLayer objectToBroadPhase_[PhysicsLayers::NUM_LAYERS];
+};
+
+// Determines which object layers can collide
+class ObjectLayerPairFilterImpl : public JPH::ObjectLayerPairFilter {
+public:
+    bool ShouldCollide(JPH::ObjectLayer inObject1, JPH::ObjectLayer inObject2) const override {
+        switch (inObject1) {
+            case PhysicsLayers::NON_MOVING:
+                return inObject2 == PhysicsLayers::MOVING || inObject2 == PhysicsLayers::CHARACTER;
+            case PhysicsLayers::MOVING:
+                return true; // Moving objects collide with everything
+            case PhysicsLayers::CHARACTER:
+                return true; // Character collides with everything
+            default:
+                JPH_ASSERT(false);
+                return false;
+        }
+    }
+};
+
+// Determines if an object and broadphase layer can collide
+class ObjectVsBroadPhaseLayerFilterImpl : public JPH::ObjectVsBroadPhaseLayerFilter {
+public:
+    bool ShouldCollide(JPH::ObjectLayer inLayer1, JPH::BroadPhaseLayer inLayer2) const override {
+        switch (inLayer1) {
+            case PhysicsLayers::NON_MOVING:
+                return inLayer2 == JPH::BroadPhaseLayer(BroadPhaseLayers::MOVING);
+            case PhysicsLayers::MOVING:
+            case PhysicsLayers::CHARACTER:
+                return true;
+            default:
+                JPH_ASSERT(false);
+                return false;
+        }
+    }
+};
+
+// Contact listener for character
+class CharacterContactListener : public JPH::CharacterContactListener {
+public:
+    void OnContactAdded(const JPH::CharacterVirtual* inCharacter,
+                        const JPH::BodyID& inBodyID2,
+                        const JPH::SubShapeID& inSubShapeID2,
+                        JPH::RVec3Arg inContactPosition,
+                        JPH::Vec3Arg inContactNormal,
+                        JPH::CharacterContactSettings& ioSettings) override {
+        // Allow character to be pushed and to push objects
+        ioSettings.mCanPushCharacter = true;
+        ioSettings.mCanReceiveImpulses = true;
+    }
+};
+
+// Global instances (defined in .cpp file)
+extern BPLayerInterfaceImpl g_broadPhaseLayerInterface;
+extern ObjectLayerPairFilterImpl g_objectLayerPairFilter;
+extern ObjectVsBroadPhaseLayerFilterImpl g_objectVsBroadPhaseLayerFilter;
+extern CharacterContactListener g_characterContactListener;

--- a/src/physics/JoltRuntime.cpp
+++ b/src/physics/JoltRuntime.cpp
@@ -1,0 +1,70 @@
+#include "JoltRuntime.h"
+
+#include <Jolt/Jolt.h>
+#include <Jolt/RegisterTypes.h>
+#include <Jolt/Core/Factory.h>
+
+#include <SDL3/SDL_log.h>
+#include <cstdarg>
+#include <mutex>
+
+// Callback for traces
+static void TraceImpl(const char* inFMT, ...) {
+    va_list args;
+    va_start(args, inFMT);
+    char buffer[1024];
+    vsnprintf(buffer, sizeof(buffer), inFMT, args);
+    va_end(args);
+    SDL_Log("Jolt: %s", buffer);
+}
+
+#ifdef JPH_ENABLE_ASSERTS
+// Callback for asserts
+static bool AssertFailedImpl(const char* inExpression, const char* inMessage, const char* inFile, uint32_t inLine) {
+    SDL_Log("Jolt Assert: %s:%u: (%s) %s", inFile, inLine, inExpression, inMessage ? inMessage : "");
+    return true; // Break into debugger
+}
+#endif
+
+namespace {
+    std::weak_ptr<JoltRuntime> g_joltRuntime;
+    std::mutex g_joltMutex;
+}
+
+JoltRuntime::JoltRuntime() {
+    // Register allocation hook
+    JPH::RegisterDefaultAllocator();
+
+    // Install callbacks
+    JPH::Trace = TraceImpl;
+    JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = AssertFailedImpl;)
+
+    // Create factory
+    JPH::Factory::sInstance = new JPH::Factory();
+
+    // Register all Jolt physics types
+    JPH::RegisterTypes();
+
+    SDL_Log("Jolt runtime initialized");
+}
+
+JoltRuntime::~JoltRuntime() {
+    // Unregisters all types with the factory and cleans up the default material
+    JPH::UnregisterTypes();
+
+    // Destroy factory
+    delete JPH::Factory::sInstance;
+    JPH::Factory::sInstance = nullptr;
+
+    SDL_Log("Jolt runtime shutdown");
+}
+
+std::shared_ptr<JoltRuntime> JoltRuntime::acquire() {
+    std::lock_guard<std::mutex> lock(g_joltMutex);
+    auto runtime = g_joltRuntime.lock();
+    if (!runtime) {
+        runtime = std::make_shared<JoltRuntime>();
+        g_joltRuntime = runtime;
+    }
+    return runtime;
+}

--- a/src/physics/JoltRuntime.h
+++ b/src/physics/JoltRuntime.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <memory>
+
+// JoltRuntime RAII wrapper for global Jolt state
+// Uses weak_ptr to allow multiple PhysicsWorld instances to share runtime
+struct JoltRuntime {
+    JoltRuntime();
+    ~JoltRuntime();
+
+    // Get or create the shared runtime (thread-safe, ref-counted)
+    static std::shared_ptr<JoltRuntime> acquire();
+
+    // Non-copyable, non-movable
+    JoltRuntime(const JoltRuntime&) = delete;
+    JoltRuntime& operator=(const JoltRuntime&) = delete;
+    JoltRuntime(JoltRuntime&&) = delete;
+    JoltRuntime& operator=(JoltRuntime&&) = delete;
+};

--- a/src/physics/PhysicsConversions.h
+++ b/src/physics/PhysicsConversions.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Jolt/Jolt.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+// Conversion utilities between GLM and Jolt types
+namespace PhysicsConversions {
+
+inline JPH::Vec3 toJolt(const glm::vec3& v) {
+    return JPH::Vec3(v.x, v.y, v.z);
+}
+
+inline JPH::Quat toJolt(const glm::quat& q) {
+    return JPH::Quat(q.x, q.y, q.z, q.w);
+}
+
+inline glm::vec3 toGLM(const JPH::Vec3& v) {
+    return glm::vec3(v.GetX(), v.GetY(), v.GetZ());
+}
+
+// Only define RVec3 overload if it's a different type (double precision mode)
+#ifdef JPH_DOUBLE_PRECISION
+inline glm::vec3 toGLM(const JPH::RVec3& v) {
+    return glm::vec3(static_cast<float>(v.GetX()), static_cast<float>(v.GetY()), static_cast<float>(v.GetZ()));
+}
+#endif
+
+inline glm::quat toGLM(const JPH::Quat& q) {
+    return glm::quat(q.GetW(), q.GetX(), q.GetY(), q.GetZ());
+}
+
+} // namespace PhysicsConversions


### PR DESCRIPTION
Extract distinct responsibilities from PhysicsSystem.cpp (1072 lines) into separate, focused files:

- JoltLayerConfig.h/cpp: Collision layer interfaces and filters
- JoltRuntime.h/cpp: RAII wrapper for Jolt global state management
- PhysicsConversions.h: GLM/Jolt type conversion utilities
- CharacterController.h/cpp: Character physics handling

Also consolidate the four terrain heightfield creation methods into a single internal helper to reduce code duplication.

PhysicsSystem.cpp reduced from 1072 to 670 lines (~37% reduction). Public API unchanged for backwards compatibility.