### PR TITLE
Refactor renderer to reduce dependencies

### DIFF
--- a/src/core/DescriptorInfrastructure.cpp
+++ b/src/core/DescriptorInfrastructure.cpp
@@ -1,0 +1,132 @@
+#include "DescriptorInfrastructure.h"
+#include "VulkanContext.h"
+#include "UBOs.h"
+#include "Bindings.h"
+#include "vulkan/PipelineLayoutBuilder.h"
+#include "GraphicsPipelineFactory.h"
+#include "Mesh.h"
+#include <SDL3/SDL.h>
+
+void DescriptorInfrastructure::addCommonDescriptorBindings(DescriptorManager::LayoutBuilder& builder) {
+    // Main scene descriptor set layout - uses common bindings (0-11, 13-17)
+    // This must match definitions in shaders/bindings.h
+    builder
+        .addUniformBuffer(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)  // 0: UBO
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 1: diffuse
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 2: shadow
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 3: normal
+        .addStorageBuffer(VK_SHADER_STAGE_FRAGMENT_BIT)         // 4: lights
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 5: emissive
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 6: point shadow
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 7: spot shadow
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 8: snow mask
+        .addCombinedImageSampler(VK_SHADER_STAGE_FRAGMENT_BIT)  // 9: cloud shadow map
+        .addUniformBuffer(VK_SHADER_STAGE_FRAGMENT_BIT)         // 10: Snow UBO
+        .addUniformBuffer(VK_SHADER_STAGE_FRAGMENT_BIT)         // 11: Cloud shadow UBO
+        // Note: binding 12 (bone matrices) is added separately for skinned layout
+        .addBinding(Bindings::ROUGHNESS_MAP, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)  // 13: roughness
+        .addBinding(Bindings::METALLIC_MAP, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)   // 14: metallic
+        .addBinding(Bindings::AO_MAP, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)         // 15: AO
+        .addBinding(Bindings::HEIGHT_MAP, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)     // 16: height
+        .addBinding(Bindings::WIND_UBO, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_VERTEX_BIT);                // 17: wind UBO
+}
+
+bool DescriptorInfrastructure::initDescriptors(VulkanContext& context, const Config& config) {
+    VkDevice device = context.getVkDevice();
+
+    if (!createDescriptorSetLayout(device, context.getRaiiDevice())) {
+        return false;
+    }
+
+    if (!createDescriptorPool(device, config)) {
+        return false;
+    }
+
+    initialized_ = true;
+    return true;
+}
+
+bool DescriptorInfrastructure::createDescriptorSetLayout(VkDevice device, const vk::raii::Device& raiiDevice) {
+    DescriptorManager::LayoutBuilder builder(device);
+    addCommonDescriptorBindings(builder);
+    VkDescriptorSetLayout rawLayout = builder.build();
+
+    if (rawLayout == VK_NULL_HANDLE) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create descriptor set layout");
+        return false;
+    }
+
+    descriptorSetLayout_.emplace(raiiDevice, rawLayout);
+    return true;
+}
+
+bool DescriptorInfrastructure::createDescriptorPool(VkDevice device, const Config& config) {
+    // Create the auto-growing descriptor pool with configurable sizes
+    // Will automatically grow if exhausted
+    descriptorManagerPool_.emplace(device, config.setsPerPool, config.poolSizes);
+    return true;
+}
+
+bool DescriptorInfrastructure::createGraphicsPipeline(VulkanContext& context, VkRenderPass hdrRenderPass,
+                                                       const std::string& resourcePath) {
+    if (!initialized_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DescriptorInfrastructure::createGraphicsPipeline: not initialized");
+        return false;
+    }
+
+    vk::Device device(context.getVkDevice());
+    VkExtent2D swapchainExtent = context.getVkSwapchainExtent();
+
+    // Create pipeline layout using PipelineLayoutBuilder
+    auto layoutOpt = PipelineLayoutBuilder(context.getRaiiDevice())
+        .addDescriptorSetLayout(**descriptorSetLayout_)
+        .addPushConstantRange<PushConstants>(
+            vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment)
+        .build();
+
+    if (!layoutOpt) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create pipeline layout");
+        return false;
+    }
+    pipelineLayout_ = std::move(layoutOpt);
+
+    // Use factory for pipeline creation
+    auto bindingDescription = Vertex::getBindingDescription();
+    auto attributeDescriptions = Vertex::getAttributeDescriptions();
+
+    VkPipeline rawPipeline = VK_NULL_HANDLE;
+    GraphicsPipelineFactory factory(device);
+    bool success = factory
+        .applyPreset(GraphicsPipelineFactory::Preset::Default)
+        .setShaders(resourcePath + "/shaders/shader.vert.spv",
+                    resourcePath + "/shaders/shader.frag.spv")
+        .setVertexInput({bindingDescription},
+                        {attributeDescriptions.begin(), attributeDescriptions.end()})
+        .setRenderPass(hdrRenderPass)
+        .setPipelineLayout(**pipelineLayout_)
+        .setExtent(swapchainExtent)
+        .setBlendMode(GraphicsPipelineFactory::BlendMode::Alpha)
+        .build(rawPipeline);
+
+    if (!success) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create graphics pipeline");
+        return false;
+    }
+
+    graphicsPipeline_.emplace(context.getRaiiDevice(), rawPipeline);
+    return true;
+}
+
+void DescriptorInfrastructure::cleanup() {
+    // Cleanup in reverse order
+    graphicsPipeline_.reset();
+    pipelineLayout_.reset();
+    descriptorSetLayout_.reset();
+
+    if (descriptorManagerPool_.has_value()) {
+        descriptorManagerPool_->destroy();
+        descriptorManagerPool_.reset();
+    }
+
+    initialized_ = false;
+}

--- a/src/core/DescriptorInfrastructure.h
+++ b/src/core/DescriptorInfrastructure.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "material/DescriptorManager.h"
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
+#include <optional>
+#include <string>
+#include <functional>
+
+class VulkanContext;
+class PostProcessSystem;
+
+/**
+ * DescriptorInfrastructure - Owns descriptor layouts, pools, and graphics pipeline
+ *
+ * Extracted from Renderer to reduce coupling. Groups:
+ * - Main descriptor set layout (for scene rendering)
+ * - Pipeline layout (wraps descriptor layout + push constants)
+ * - Main graphics pipeline (for standard mesh rendering)
+ * - Descriptor pool (auto-growing pool for all systems)
+ *
+ * Lifecycle:
+ * - Create via default constructor
+ * - Call init() after VulkanContext and PostProcessSystem are ready
+ * - Access via getters for descriptor allocation and pipeline binding
+ */
+class DescriptorInfrastructure {
+public:
+    struct Config {
+        uint32_t setsPerPool = 64;
+        DescriptorPoolSizes poolSizes = DescriptorPoolSizes::standard();
+    };
+
+    DescriptorInfrastructure() = default;
+    ~DescriptorInfrastructure() = default;
+
+    // Non-copyable, non-movable (owns GPU resources)
+    DescriptorInfrastructure(const DescriptorInfrastructure&) = delete;
+    DescriptorInfrastructure& operator=(const DescriptorInfrastructure&) = delete;
+    DescriptorInfrastructure(DescriptorInfrastructure&&) = delete;
+    DescriptorInfrastructure& operator=(DescriptorInfrastructure&&) = delete;
+
+    /**
+     * Initialize descriptor set layout and pool.
+     * Call before createGraphicsPipeline().
+     */
+    bool initDescriptors(VulkanContext& context, const Config& config);
+
+    /**
+     * Create the graphics pipeline for standard scene rendering.
+     * Requires PostProcessSystem to be initialized (for HDR render pass).
+     */
+    bool createGraphicsPipeline(VulkanContext& context, VkRenderPass hdrRenderPass,
+                                const std::string& resourcePath);
+
+    /**
+     * Cleanup all resources.
+     * Called automatically by destructor, but can be called explicitly.
+     */
+    void cleanup();
+
+    // Accessors
+    vk::DescriptorSetLayout getDescriptorSetLayout() const {
+        return descriptorSetLayout_ ? **descriptorSetLayout_ : vk::DescriptorSetLayout{};
+    }
+
+    vk::PipelineLayout getPipelineLayout() const {
+        return pipelineLayout_ ? **pipelineLayout_ : vk::PipelineLayout{};
+    }
+
+    vk::Pipeline getGraphicsPipeline() const {
+        return graphicsPipeline_ ? **graphicsPipeline_ : vk::Pipeline{};
+    }
+
+    DescriptorManager::Pool* getDescriptorPool() {
+        return descriptorManagerPool_.has_value() ? &*descriptorManagerPool_ : nullptr;
+    }
+
+    const DescriptorManager::Pool* getDescriptorPool() const {
+        return descriptorManagerPool_.has_value() ? &*descriptorManagerPool_ : nullptr;
+    }
+
+    // Raw handle accessors for compatibility
+    VkDescriptorSetLayout getVkDescriptorSetLayout() const {
+        return descriptorSetLayout_ ? static_cast<VkDescriptorSetLayout>(**descriptorSetLayout_) : VK_NULL_HANDLE;
+    }
+
+    VkPipelineLayout getVkPipelineLayout() const {
+        return pipelineLayout_ ? static_cast<VkPipelineLayout>(**pipelineLayout_) : VK_NULL_HANDLE;
+    }
+
+    VkPipeline getVkGraphicsPipeline() const {
+        return graphicsPipeline_ ? static_cast<VkPipeline>(**graphicsPipeline_) : VK_NULL_HANDLE;
+    }
+
+    /**
+     * Add common descriptor bindings shared between main and skinned mesh layouts.
+     * Provides the standard binding layout used by shader.frag.
+     * Can be used by other systems (e.g., SkinnedMeshRenderer) to ensure layout compatibility.
+     */
+    static void addCommonDescriptorBindings(DescriptorManager::LayoutBuilder& builder);
+
+    bool isInitialized() const { return initialized_; }
+    bool hasPipeline() const { return graphicsPipeline_.has_value(); }
+
+private:
+    bool createDescriptorSetLayout(VkDevice device, const vk::raii::Device& raiiDevice);
+    bool createDescriptorPool(VkDevice device, const Config& config);
+
+    std::optional<vk::raii::DescriptorSetLayout> descriptorSetLayout_;
+    std::optional<vk::raii::PipelineLayout> pipelineLayout_;
+    std::optional<vk::raii::Pipeline> graphicsPipeline_;
+    std::optional<DescriptorManager::Pool> descriptorManagerPool_;
+
+    bool initialized_ = false;
+};

--- a/src/core/RenderingInfrastructure.cpp
+++ b/src/core/RenderingInfrastructure.cpp
@@ -1,0 +1,62 @@
+#include "RenderingInfrastructure.h"
+#include "VulkanContext.h"
+#include <SDL3/SDL.h>
+
+RenderingInfrastructure::~RenderingInfrastructure() {
+    if (initialized_) {
+        shutdown();
+    }
+}
+
+bool RenderingInfrastructure::init(VulkanContext& context, uint32_t threadCount) {
+    // Initialize async transfer manager for non-blocking GPU uploads
+    if (!asyncTransferManager_.initialize(context)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+            "AsyncTransferManager initialization failed - using synchronous transfers");
+        // Continue - not a fatal error
+    }
+
+    // Initialize threaded command pool for parallel command recording
+    if (threadCount > 0) {
+        if (!threadedCommandPool_.initialize(context, threadCount + 1)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                "ThreadedCommandPool initialization failed - using single-threaded recording");
+            // Continue - not a fatal error
+        }
+    }
+
+    // Initialize async texture uploader for non-blocking texture uploads
+    if (!asyncTextureUploader_.initialize(
+            context.getVkDevice(),
+            context.getAllocator(),
+            &asyncTransferManager_)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+            "AsyncTextureUploader initialization failed - using synchronous uploads");
+        // Continue - not a fatal error
+    }
+
+    // FrameGraph is initialized empty and populated later by FrameGraphBuilder
+    // AssetRegistry is initialized separately via initAssetRegistry()
+
+    initialized_ = true;
+    return true;
+}
+
+void RenderingInfrastructure::initAssetRegistry(VkDevice device, VkPhysicalDevice physicalDevice,
+                                                 VmaAllocator allocator, VkCommandPool commandPool,
+                                                 VkQueue graphicsQueue) {
+    assetRegistry_.init(device, physicalDevice, allocator, commandPool, graphicsQueue);
+}
+
+void RenderingInfrastructure::shutdown() {
+    if (!initialized_) return;
+
+    // Shutdown in reverse initialization order
+    asyncTextureUploader_.shutdown();  // Must shutdown before transfer manager
+    asyncTransferManager_.shutdown();
+    threadedCommandPool_.shutdown();
+    // FrameGraph has no explicit shutdown
+    // AssetRegistry cleanup is automatic (RAII)
+
+    initialized_ = false;
+}

--- a/src/core/RenderingInfrastructure.h
+++ b/src/core/RenderingInfrastructure.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "vulkan/AsyncTransferManager.h"
+#include "vulkan/ThreadedCommandPool.h"
+#include "pipeline/FrameGraph.h"
+#include "loading/LoadJobFactory.h"
+#include "asset/AssetRegistry.h"
+
+class VulkanContext;
+
+/**
+ * RenderingInfrastructure - Owns multi-threading and asset management infrastructure
+ *
+ * Extracted from Renderer to reduce coupling. Groups:
+ * - AsyncTransferManager: Non-blocking GPU uploads
+ * - ThreadedCommandPool: Parallel command buffer recording
+ * - FrameGraph: Render pass dependency management
+ * - AsyncTextureUploader: Background texture uploads
+ * - AssetRegistry: Centralized asset management with deduplication
+ *
+ * Lifecycle:
+ * - Create via default constructor
+ * - Call init() after VulkanContext is ready
+ * - Call shutdown() before destruction (or let destructor handle it)
+ */
+class RenderingInfrastructure {
+public:
+    RenderingInfrastructure() = default;
+    ~RenderingInfrastructure();
+
+    // Non-copyable, non-movable (owns GPU resources)
+    RenderingInfrastructure(const RenderingInfrastructure&) = delete;
+    RenderingInfrastructure& operator=(const RenderingInfrastructure&) = delete;
+    RenderingInfrastructure(RenderingInfrastructure&&) = delete;
+    RenderingInfrastructure& operator=(RenderingInfrastructure&&) = delete;
+
+    /**
+     * Initialize all infrastructure components.
+     * @param context Vulkan context (provides device, queues, allocator)
+     * @param threadCount Number of threads for parallel command recording (0 = single-threaded)
+     * @return true if all critical components initialized successfully
+     */
+    bool init(VulkanContext& context, uint32_t threadCount);
+
+    /**
+     * Initialize the asset registry separately (needs command pool from VulkanContext).
+     * Called after init() once command pool is available.
+     */
+    void initAssetRegistry(VkDevice device, VkPhysicalDevice physicalDevice,
+                           VmaAllocator allocator, VkCommandPool commandPool,
+                           VkQueue graphicsQueue);
+
+    /**
+     * Shutdown all infrastructure components in correct order.
+     */
+    void shutdown();
+
+    /**
+     * Process completed async transfers.
+     * Call once per frame from the render thread.
+     */
+    void processPendingTransfers() { asyncTransferManager_.processPendingTransfers(); }
+
+    // Component accessors
+    AsyncTransferManager& asyncTransferManager() { return asyncTransferManager_; }
+    const AsyncTransferManager& asyncTransferManager() const { return asyncTransferManager_; }
+
+    ThreadedCommandPool& threadedCommandPool() { return threadedCommandPool_; }
+    const ThreadedCommandPool& threadedCommandPool() const { return threadedCommandPool_; }
+
+    FrameGraph& frameGraph() { return frameGraph_; }
+    const FrameGraph& frameGraph() const { return frameGraph_; }
+
+    Loading::AsyncTextureUploader& asyncTextureUploader() { return asyncTextureUploader_; }
+    const Loading::AsyncTextureUploader& asyncTextureUploader() const { return asyncTextureUploader_; }
+
+    AssetRegistry& assetRegistry() { return assetRegistry_; }
+    const AssetRegistry& assetRegistry() const { return assetRegistry_; }
+
+    bool isInitialized() const { return initialized_; }
+
+private:
+    AsyncTransferManager asyncTransferManager_;
+    ThreadedCommandPool threadedCommandPool_;
+    FrameGraph frameGraph_;
+    Loading::AsyncTextureUploader asyncTextureUploader_;
+    AssetRegistry assetRegistry_;
+
+    bool initialized_ = false;
+};


### PR DESCRIPTION
Extract two infrastructure classes to reduce coupling in Renderer:

1. RenderingInfrastructure - owns multi-threading and asset management:
   - AsyncTransferManager (non-blocking GPU uploads)
   - ThreadedCommandPool (parallel command recording)
   - FrameGraph (render pass dependency management)
   - AsyncTextureUploader (background texture uploads)
   - AssetRegistry (centralized asset deduplication)

2. DescriptorInfrastructure - owns descriptor and pipeline resources:
   - Descriptor set layout (main scene rendering)
   - Pipeline layout (wraps descriptor layout + push constants)
   - Graphics pipeline (standard mesh rendering)
   - Descriptor pool (auto-growing pool)

This reduces Renderer.h from 33 includes to ~20 and removes 5 member variables in favor of 2 infrastructure objects with clear ownership.