### PR TITLE
Create interface for DescriptorManager

### DIFF
--- a/src/core/DescriptorInfrastructure.h
+++ b/src/core/DescriptorInfrastructure.h
@@ -9,6 +9,7 @@
 
 class VulkanContext;
 class PostProcessSystem;
+class IDescriptorAllocator;
 
 /**
  * DescriptorInfrastructure - Owns descriptor layouts, pools, and graphics pipeline
@@ -86,6 +87,11 @@ public:
     }
 
     const DescriptorManager::Pool* getDescriptorPool() const {
+        return descriptorManagerPool_.has_value() ? &*descriptorManagerPool_ : nullptr;
+    }
+
+    // Get allocator via interface (for reduced coupling)
+    IDescriptorAllocator* getDescriptorAllocator() {
         return descriptorManagerPool_.has_value() ? &*descriptorManagerPool_ : nullptr;
     }
 

--- a/src/core/material/DescriptorManager.h
+++ b/src/core/material/DescriptorManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "IDescriptorAllocator.h"
 #include <vulkan/vulkan.hpp>
 #include <vector>
 #include <unordered_map>
@@ -122,7 +123,7 @@ public:
     };
 
     // Pool that automatically grows when exhausted
-    class Pool {
+    class Pool : public IDescriptorAllocator {
     public:
         // Backwards-compatible constructor (uses standard defaults)
         Pool(VkDevice device, uint32_t initialSetsPerPool = 32);
@@ -139,13 +140,13 @@ public:
         Pool& operator=(Pool&& other) noexcept;
 
         // Allocate descriptor sets (grows pool if needed)
-        std::vector<VkDescriptorSet> allocate(VkDescriptorSetLayout layout, uint32_t count);
+        std::vector<VkDescriptorSet> allocate(VkDescriptorSetLayout layout, uint32_t count) override;
 
         // Allocate a single set
-        VkDescriptorSet allocateSingle(VkDescriptorSetLayout layout);
+        VkDescriptorSet allocateSingle(VkDescriptorSetLayout layout) override;
 
         // Reset all pools (frees all allocated sets)
-        void reset();
+        void reset() override;
 
         // Destroy all pools
         void destroy();

--- a/src/core/material/IDescriptorAllocator.h
+++ b/src/core/material/IDescriptorAllocator.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vector>
+
+// Interface for allocating descriptor sets
+// Allows systems to depend on allocation capability without coupling
+// to a specific implementation (e.g., auto-growing pool)
+class IDescriptorAllocator {
+public:
+    virtual ~IDescriptorAllocator() = default;
+
+    // Allocate multiple descriptor sets with the given layout
+    virtual std::vector<VkDescriptorSet> allocate(VkDescriptorSetLayout layout, uint32_t count) = 0;
+
+    // Allocate a single descriptor set with the given layout
+    virtual VkDescriptorSet allocateSingle(VkDescriptorSetLayout layout) = 0;
+
+    // Reset all allocated sets (returns them to the pool)
+    virtual void reset() = 0;
+};

--- a/src/core/material/MaterialRegistry.cpp
+++ b/src/core/material/MaterialRegistry.cpp
@@ -1,5 +1,5 @@
 #include "MaterialRegistry.h"
-#include "DescriptorManager.h"
+#include "IDescriptorAllocator.h"
 #include "Texture.h"
 #include <SDL3/SDL_log.h>
 
@@ -46,7 +46,7 @@ const MaterialRegistry::MaterialDef* MaterialRegistry::getMaterial(MaterialId id
 
 void MaterialRegistry::createDescriptorSets(
     VkDevice device,
-    DescriptorManager::Pool& pool,
+    IDescriptorAllocator& allocator,
     VkDescriptorSetLayout layout,
     uint32_t frames,
     const std::function<MaterialDescriptorFactory::CommonBindings(uint32_t frameIndex)>& getCommonBindings) {
@@ -60,7 +60,7 @@ void MaterialRegistry::createDescriptorSets(
         const auto& mat = materials[id];
 
         // Allocate descriptor sets for all frames
-        descriptorSets[id] = pool.allocate(layout, framesInFlight);
+        descriptorSets[id] = allocator.allocate(layout, framesInFlight);
         if (descriptorSets[id].empty()) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                 "MaterialRegistry: Failed to allocate descriptor sets for '%s'", mat.name.c_str());

--- a/src/core/material/MaterialRegistry.h
+++ b/src/core/material/MaterialRegistry.h
@@ -7,7 +7,7 @@
 #include <functional>
 #include "MaterialDescriptorFactory.h"
 
-class DescriptorManager;
+class IDescriptorAllocator;
 class Texture;
 
 /**
@@ -63,7 +63,7 @@ public:
     // Must be called after all materials are registered and resources are ready
     void createDescriptorSets(
         VkDevice device,
-        DescriptorManager::Pool& pool,
+        IDescriptorAllocator& allocator,
         VkDescriptorSetLayout layout,
         uint32_t framesInFlight,
         const std::function<MaterialDescriptorFactory::CommonBindings(uint32_t frameIndex)>& getCommonBindings);


### PR DESCRIPTION
Introduces IDescriptorAllocator interface to reduce coupling between systems that need descriptor allocation and the concrete Pool implementation.

- Add IDescriptorAllocator.h with allocate(), allocateSingle(), and reset()
- DescriptorManager::Pool now implements IDescriptorAllocator
- MaterialRegistry now accepts IDescriptorAllocator& instead of Pool&
- DescriptorInfrastructure provides getDescriptorAllocator() accessor