### PR TITLE
Fix physics debug visualization GUI display

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -238,7 +238,7 @@ void Renderer::setupFrameGraph() {
 
 #ifdef JPH_DEBUG_RENDERER
 void Renderer::updatePhysicsDebug(PhysicsWorld& physics, const glm::vec3& cameraPos) {
-    if (!physicsDebugEnabled) return;
+    if (!systems_->debugControlSubsystem().isPhysicsDebugEnabled()) return;
 
     // Begin debug line frame (clear previous and set frame index)
     // This is called here so physics debug lines can be collected before render()

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -134,11 +134,6 @@ public:
     void toggleSnowDepthDebug() { showSnowDepthDebug = !showSnowDepthDebug; }
     bool isShowingSnowDepthDebug() const { return showSnowDepthDebug; }
 
-
-    // Physics debug (local state)
-    void setPhysicsDebugEnabled(bool enabled) { physicsDebugEnabled = enabled; }
-    bool isPhysicsDebugEnabled() const { return physicsDebugEnabled; }
-
     // Resource access
     VkCommandPool getCommandPool() const { return vulkanContext_->getCommandPool(); }
     DescriptorManager::Pool* getDescriptorPool();
@@ -200,7 +195,6 @@ private:
     // Descriptor and pipeline infrastructure (extracted from Renderer)
     DescriptorInfrastructure descriptorInfra_;
 
-    bool physicsDebugEnabled = false;
     glm::mat4 lastViewProj{1.0f};  // Cached view-projection for debug rendering
     bool useVolumetricSnow = true;  // Use new volumetric system by default
 


### PR DESCRIPTION
The physics debug checkbox in GuiDebugTab was setting the flag in DebugControlSubsystem, but Renderer::updatePhysicsDebug was checking its own separate physicsDebugEnabled member variable. This caused the PhysicsDebugRenderer to never be created, so getPhysicsDebugRenderer() always returned nullptr and the GUI showed "Enable to see options".

Fix by having Renderer use the DebugControlSubsystem flag directly via systems_->debugControlSubsystem().isPhysicsDebugEnabled(). Also remove the now-unused physicsDebugEnabled member and related accessors from Renderer.