### PR TITLE
Add terrain sampling for grass cutouts

### DIFF
--- a/shaders/bindings.h
+++ b/shaders/bindings.h
@@ -136,6 +136,7 @@
 #define BINDING_GRASS_COMPUTE_TILE_ARRAY   5   // LOD tile array (high-res tiles near camera)
 #define BINDING_GRASS_COMPUTE_TILE_INFO    6   // Tile info SSBO
 #define BINDING_GRASS_COMPUTE_PARAMS       7   // Grass-specific params (terrain, displacement region)
+#define BINDING_GRASS_COMPUTE_HOLE_MASK    8   // Terrain hole mask (caves, wells)
 
 // =============================================================================
 // Grass Displacement Compute Shader Descriptor Set
@@ -569,6 +570,7 @@ constexpr uint32_t GRASS_COMPUTE_DISPLACEMENT = BINDING_GRASS_COMPUTE_DISPLACEME
 constexpr uint32_t GRASS_COMPUTE_TILE_ARRAY  = BINDING_GRASS_COMPUTE_TILE_ARRAY;
 constexpr uint32_t GRASS_COMPUTE_TILE_INFO   = BINDING_GRASS_COMPUTE_TILE_INFO;
 constexpr uint32_t GRASS_COMPUTE_PARAMS      = BINDING_GRASS_COMPUTE_PARAMS;
+constexpr uint32_t GRASS_COMPUTE_HOLE_MASK   = BINDING_GRASS_COMPUTE_HOLE_MASK;
 
 // Grass Displacement
 constexpr uint32_t GRASS_DISP_OUTPUT      = BINDING_GRASS_DISP_OUTPUT;

--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -47,6 +47,9 @@ layout(binding = BINDING_GRASS_COMPUTE_HEIGHT_MAP) uniform sampler2D terrainHeig
 // Displacement map for player/NPC grass interaction (RG16F - XZ displacement)
 layout(binding = BINDING_GRASS_COMPUTE_DISPLACEMENT) uniform sampler2D displacementMap;
 
+// Hole mask for terrain cutouts (caves, wells) - R8: 0=solid, 1=hole
+layout(binding = BINDING_GRASS_COMPUTE_HOLE_MASK) uniform sampler2D holeMask;
+
 // LOD tile array (high-res tiles near camera)
 layout(binding = BINDING_GRASS_COMPUTE_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
 
@@ -216,6 +219,10 @@ void main() {
 
     // Check if grass is within terrain bounds
     if (terrainUV.x < 0.0 || terrainUV.x > 1.0 || terrainUV.y < 0.0 || terrainUV.y > 1.0) return;
+
+    // Check hole mask - don't spawn grass in terrain holes (caves, wells)
+    float holeMaskValue = texture(holeMask, terrainUV).r;
+    if (holeMaskValue > 0.5) return;
 
     // Sample terrain height with tile cache support for ~1m resolution near camera
     float terrainY = sampleHeightWithTileCache(terrainHeightMap, heightMapTiles, terrainUV,

--- a/shaders/grass_tiled.comp
+++ b/shaders/grass_tiled.comp
@@ -47,6 +47,9 @@ layout(binding = BINDING_GRASS_COMPUTE_HEIGHT_MAP) uniform sampler2D terrainHeig
 // Displacement map for player/NPC grass interaction (RG16F - XZ displacement)
 layout(binding = BINDING_GRASS_COMPUTE_DISPLACEMENT) uniform sampler2D displacementMap;
 
+// Hole mask for terrain cutouts (caves, wells) - R8: 0=solid, 1=hole
+layout(binding = BINDING_GRASS_COMPUTE_HOLE_MASK) uniform sampler2D holeMask;
+
 // LOD tile array (high-res tiles near camera)
 layout(binding = BINDING_GRASS_COMPUTE_TILE_ARRAY) uniform sampler2DArray heightMapTiles;
 
@@ -205,6 +208,10 @@ void main() {
 
     // Check if grass is within terrain bounds
     if (terrainUV.x < 0.0 || terrainUV.x > 1.0 || terrainUV.y < 0.0 || terrainUV.y > 1.0) return;
+
+    // Check hole mask - don't spawn grass in terrain holes (caves, wells)
+    float holeMaskValue = texture(holeMask, terrainUV).r;
+    if (holeMaskValue > 0.5) return;
 
     // Sample terrain height with tile cache support
     float terrainY = sampleHeightWithTileCache(terrainHeightMap, heightMapTiles, terrainUV,

--- a/src/core/SystemWiring.cpp
+++ b/src/core/SystemWiring.cpp
@@ -72,7 +72,9 @@ void SystemWiring::wireGrassDescriptors(RendererSystems& systems) {
         vk::ImageView(terrain.getTileArrayView()),
         vk::Sampler(terrain.getTileSampler()),
         toVkBuffersArray<3>(collectTileInfoBuffers(terrain)),
-        &globalBuffers.dynamicRendererUBO);
+        &globalBuffers.dynamicRendererUBO,
+        vk::ImageView(terrain.getHoleMaskView()),
+        vk::Sampler(terrain.getHoleMaskSampler()));
 }
 
 void SystemWiring::wireLeafDescriptors(RendererSystems& systems) {

--- a/src/terrain/TerrainSystem.h
+++ b/src/terrain/TerrainSystem.h
@@ -323,6 +323,14 @@ public:
         return tileCache ? vk::Buffer(tileCache->getTileInfoBuffer(frameIndex)) : vk::Buffer{};
     }
 
+    // Hole mask accessors (for grass/other systems to avoid terrain cutouts)
+    vk::ImageView getHoleMaskView() const {
+        return tileCache ? vk::ImageView(tileCache->getHoleMaskView()) : vk::ImageView{};
+    }
+    vk::Sampler getHoleMaskSampler() const {
+        return tileCache ? vk::Sampler(tileCache->getHoleMaskSampler()) : vk::Sampler{};
+    }
+
     // ITerrainControl implementation
     void setTerrainEnabled(bool enabled) override { terrainEnabled_ = enabled; }
     bool isTerrainEnabled() const override { return terrainEnabled_; }

--- a/src/vegetation/GrassSystem.h
+++ b/src/vegetation/GrassSystem.h
@@ -120,7 +120,9 @@ public:
                               vk::ImageView tileArrayView = {},
                               vk::Sampler tileSampler = {},
                               const std::array<vk::Buffer, 3>& tileInfoBuffers = {},
-                              const BufferUtils::DynamicUniformBuffer* dynamicRendererUBO = nullptr);
+                              const BufferUtils::DynamicUniformBuffer* dynamicRendererUBO = nullptr,
+                              vk::ImageView holeMaskView = {},
+                              vk::Sampler holeMaskSampler = {});
 
     void updateUniforms(uint32_t frameIndex, const glm::vec3& cameraPos, const glm::mat4& viewProj,
                         float terrainSize, float terrainHeightScale, float time);
@@ -250,6 +252,10 @@ private:
     vk::ImageView tileArrayView_;
     vk::Sampler tileSampler_;
     TripleBuffered<vk::Buffer> tileInfoBuffers_;  // Triple-buffered for frames-in-flight sync
+
+    // Hole mask for terrain cutouts (caves, wells)
+    vk::ImageView holeMaskView_;
+    vk::Sampler holeMaskSampler_;
 
     // Renderer uniform buffers for per-frame descriptor updates (stores reference from updateDescriptorSets)
     std::vector<vk::Buffer> rendererUniformBuffers_;


### PR DESCRIPTION
Grass now samples the terrain hole mask texture to avoid spawning in areas marked as terrain cutouts (caves, wells, etc.). This ensures grass doesn't render inside holes in the terrain.

Changes:
- Add BINDING_GRASS_COMPUTE_HOLE_MASK (binding 8) for grass compute shaders
- Update grass.comp and grass_tiled.comp to sample hole mask and skip grass placement where holeMaskValue > 0.5
- Add holeMaskView_ and holeMaskSampler_ storage to GrassSystem
- Update GrassSystem descriptor set layout to include hole mask binding
- Add getHoleMaskView/Sampler accessors to TerrainSystem
- Wire hole mask from terrain to grass system in SystemWiring