### PR TITLE
Add normals to grass blade edges

### DIFF
--- a/shaders/grass.vert
+++ b/shaders/grass.vert
@@ -137,8 +137,20 @@ void main() {
                         terrainNormal * localTangent.y +
                         T * localTangent.z;
 
-    // Normal is perpendicular to both tangent and blade width direction
-    vec3 normal = normalize(cross(worldTangent, bladeRight));
+    // Base normal is perpendicular to both tangent and blade width direction
+    vec3 surfaceNormal = normalize(cross(worldTangent, bladeRight));
+
+    // Add curvature to make blades appear rounded rather than flat
+    // Determine which side of blade this vertex is on (-1 = left, +1 = right, 0 = tip)
+    float sideFactor = 0.0;
+    if (widthAtT > 0.001) {
+        sideFactor = localPos.x / widthAtT;  // -1 for left edge, +1 for right edge
+    }
+
+    // Tilt normal outward at edges (along bladeRight direction)
+    // This creates a curved appearance even though geometry is flat
+    vec3 outwardTilt = bladeRight * sideFactor;
+    vec3 normal = normalize(mix(surfaceNormal, outwardTilt, GRASS_BLADE_CURVATURE * 0.5));
 
     // Color gradient: darker at base, lighter at tip using unified constants
     fragColor = mix(GRASS_COLOR_BASE, GRASS_COLOR_TIP, t);

--- a/shaders/grass_constants.glsl
+++ b/shaders/grass_constants.glsl
@@ -57,6 +57,10 @@ const float GRASS_SSS_STRENGTH = 0.35;
 const float GRASS_SPECULAR_STRENGTH = 0.15;
 const float GRASS_BACKLIT_DIFFUSE = 0.6;
 
+// Blade normal curvature (makes blades appear rounded, not flat)
+// 0.0 = flat normals, 1.0 = strongly curved outward at edges
+const float GRASS_BLADE_CURVATURE = 0.6;
+
 // Rendering enhancements
 const float GRASS_EDGE_THICKEN_MAX = 3.0;
 const float GRASS_EDGE_THICKEN_FACTOR = 2.0;


### PR DESCRIPTION
Grass blades now have normals that curve outward at the edges, making them appear more cylindrical/rounded rather than completely flat. This improves lighting quality especially when viewed at grazing angles.

- Add GRASS_BLADE_CURVATURE constant (0.6) to control effect strength
- Calculate side factor (-1 left, +1 right, 0 tip) from vertex position
- Blend between surface normal and outward tilt based on curvature