### PR TITLE
Add immutable buffer configs and presets for buffer builders

### DIFF
--- a/src/core/DoubleBufferedBuffer.cpp
+++ b/src/core/DoubleBufferedBuffer.cpp
@@ -18,6 +18,67 @@ void destroyCreatedBuffers(VmaAllocator allocator,
 
 }  // namespace
 
+DoubleBufferedBufferConfig::DoubleBufferedBufferConfig(
+    VmaAllocator allocator,
+    uint32_t setCount,
+    VkDeviceSize size,
+    VkBufferUsageFlags usage,
+    VmaMemoryUsage memoryUsage,
+    VmaAllocationCreateFlags allocationFlags)
+    : allocator(allocator),
+      setCount(setCount),
+      size(size),
+      usage(usage),
+      memoryUsage(memoryUsage),
+      allocationFlags(allocationFlags) {}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::fromConfig(const DoubleBufferedBufferConfig& config) {
+    DoubleBufferedBufferBuilder builder;
+    builder.allocator_ = config.allocator;
+    builder.setCount_ = config.setCount;
+    builder.bufferSize_ = config.size;
+    builder.usage_ = config.usage;
+    builder.memoryUsage_ = config.memoryUsage;
+    builder.allocationFlags_ = config.allocationFlags;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withAllocator(VmaAllocator allocator) const {
+    auto builder = *this;
+    builder.allocator_ = allocator;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withSetCount(uint32_t count) const {
+    auto builder = *this;
+    builder.setCount_ = count;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withSize(VkDeviceSize size) const {
+    auto builder = *this;
+    builder.bufferSize_ = size;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withUsage(VkBufferUsageFlags usage) const {
+    auto builder = *this;
+    builder.usage_ = usage;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withMemoryUsage(VmaMemoryUsage usage) const {
+    auto builder = *this;
+    builder.memoryUsage_ = usage;
+    return builder;
+}
+
+DoubleBufferedBufferBuilder DoubleBufferedBufferBuilder::withAllocationFlags(VmaAllocationCreateFlags flags) const {
+    auto builder = *this;
+    builder.allocationFlags_ = flags;
+    return builder;
+}
+
 DoubleBufferedBufferBuilder& DoubleBufferedBufferBuilder::setAllocator(VmaAllocator newAllocator) {
     allocator_ = newAllocator;
     return *this;
@@ -43,6 +104,11 @@ DoubleBufferedBufferBuilder& DoubleBufferedBufferBuilder::setMemoryUsage(VmaMemo
     return *this;
 }
 
+DoubleBufferedBufferBuilder& DoubleBufferedBufferBuilder::setAllocationFlags(VmaAllocationCreateFlags flags) {
+    allocationFlags_ = flags;
+    return *this;
+}
+
 bool DoubleBufferedBufferBuilder::build(DoubleBufferedBufferSet& outBuffers) const {
     if (!allocator_ || setCount_ == 0 || bufferSize_ == 0 || usage_ == 0) {
         SDL_Log("DoubleBufferedBufferBuilder missing required fields (allocator=%p, setCount=%u, size=%zu, usage=%u)",
@@ -61,6 +127,7 @@ bool DoubleBufferedBufferBuilder::build(DoubleBufferedBufferSet& outBuffers) con
 
     VmaAllocationCreateInfo allocInfo{};
     allocInfo.usage = memoryUsage_;
+    allocInfo.flags = allocationFlags_;
 
     for (uint32_t i = 0; i < setCount_; i++) {
         if (vmaCreateBuffer(allocator_, reinterpret_cast<const VkBufferCreateInfo*>(&bufferInfo), &allocInfo, &result.buffers[i], &result.allocations[i], nullptr) !=

--- a/src/core/DoubleBufferedBuffer.h
+++ b/src/core/DoubleBufferedBuffer.h
@@ -11,13 +11,40 @@ struct DoubleBufferedBufferSet {
     std::vector<VmaAllocation> allocations;
 };
 
+struct DoubleBufferedBufferConfig {
+    const VmaAllocator allocator;
+    const uint32_t setCount;
+    const VkDeviceSize size;
+    const VkBufferUsageFlags usage;
+    const VmaMemoryUsage memoryUsage;
+    const VmaAllocationCreateFlags allocationFlags;
+
+    DoubleBufferedBufferConfig(
+        VmaAllocator allocator = VK_NULL_HANDLE,
+        uint32_t setCount = 2,
+        VkDeviceSize size = 0,
+        VkBufferUsageFlags usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        VmaMemoryUsage memoryUsage = VMA_MEMORY_USAGE_AUTO,
+        VmaAllocationCreateFlags allocationFlags = 0);
+};
+
 class DoubleBufferedBufferBuilder {
 public:
+    static DoubleBufferedBufferBuilder fromConfig(const DoubleBufferedBufferConfig& config);
+
+    DoubleBufferedBufferBuilder withAllocator(VmaAllocator allocator) const;
+    DoubleBufferedBufferBuilder withSetCount(uint32_t count) const;
+    DoubleBufferedBufferBuilder withSize(VkDeviceSize size) const;
+    DoubleBufferedBufferBuilder withUsage(VkBufferUsageFlags usage) const;
+    DoubleBufferedBufferBuilder withMemoryUsage(VmaMemoryUsage usage) const;
+    DoubleBufferedBufferBuilder withAllocationFlags(VmaAllocationCreateFlags flags) const;
+
     DoubleBufferedBufferBuilder& setAllocator(VmaAllocator allocator);
     DoubleBufferedBufferBuilder& setSetCount(uint32_t count);
     DoubleBufferedBufferBuilder& setSize(VkDeviceSize size);
     DoubleBufferedBufferBuilder& setUsage(VkBufferUsageFlags usage);
     DoubleBufferedBufferBuilder& setMemoryUsage(VmaMemoryUsage usage);
+    DoubleBufferedBufferBuilder& setAllocationFlags(VmaAllocationCreateFlags flags);
 
     bool build(DoubleBufferedBufferSet& outBuffers) const;
 
@@ -25,8 +52,9 @@ private:
     VmaAllocator allocator_ = VK_NULL_HANDLE;
     uint32_t setCount_ = 2;
     VkDeviceSize bufferSize_ = 0;
-    VkBufferUsageFlags usage_ = 0;
+    VkBufferUsageFlags usage_ = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     VmaMemoryUsage memoryUsage_ = VMA_MEMORY_USAGE_AUTO;
+    VmaAllocationCreateFlags allocationFlags_ = 0;
 };
 
 void destroyBuffers(VmaAllocator allocator, const DoubleBufferedBufferSet& buffers);

--- a/src/core/PerFrameBuffer.cpp
+++ b/src/core/PerFrameBuffer.cpp
@@ -18,6 +18,67 @@ void destroyCreatedBuffers(VmaAllocator allocator,
 
 }  // namespace
 
+PerFrameBufferConfig::PerFrameBufferConfig(
+    VmaAllocator allocator,
+    uint32_t frameCount,
+    VkDeviceSize size,
+    VkBufferUsageFlags usage,
+    VmaMemoryUsage memoryUsage,
+    VmaAllocationCreateFlags allocationFlags)
+    : allocator(allocator),
+      frameCount(frameCount),
+      size(size),
+      usage(usage),
+      memoryUsage(memoryUsage),
+      allocationFlags(allocationFlags) {}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::fromConfig(const PerFrameBufferConfig& config) {
+    PerFrameBufferBuilder builder;
+    builder.allocator_ = config.allocator;
+    builder.frameCount_ = config.frameCount;
+    builder.bufferSize_ = config.size;
+    builder.usage_ = config.usage;
+    builder.memoryUsage_ = config.memoryUsage;
+    builder.allocationFlags_ = config.allocationFlags;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withAllocator(VmaAllocator allocator) const {
+    auto builder = *this;
+    builder.allocator_ = allocator;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withFrameCount(uint32_t count) const {
+    auto builder = *this;
+    builder.frameCount_ = count;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withSize(VkDeviceSize size) const {
+    auto builder = *this;
+    builder.bufferSize_ = size;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withUsage(VkBufferUsageFlags usage) const {
+    auto builder = *this;
+    builder.usage_ = usage;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withMemoryUsage(VmaMemoryUsage usage) const {
+    auto builder = *this;
+    builder.memoryUsage_ = usage;
+    return builder;
+}
+
+PerFrameBufferBuilder PerFrameBufferBuilder::withAllocationFlags(VmaAllocationCreateFlags flags) const {
+    auto builder = *this;
+    builder.allocationFlags_ = flags;
+    return builder;
+}
+
 PerFrameBufferBuilder& PerFrameBufferBuilder::setAllocator(VmaAllocator newAllocator) {
     allocator_ = newAllocator;
     return *this;
@@ -82,6 +143,12 @@ bool PerFrameBufferBuilder::build(PerFrameBufferSet& outBuffers) const {
 
     outBuffers = std::move(result);
     return true;
+}
+
+bool makePerFrameUniformBuffers(const PerFrameBufferConfig& config, PerFrameBufferSet& outBuffers) {
+    return PerFrameBufferBuilder::fromConfig(config)
+        .withUsage(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+        .build(outBuffers);
 }
 
 void destroyBuffers(VmaAllocator allocator, const PerFrameBufferSet& buffers) {

--- a/src/core/PerFrameBuffer.h
+++ b/src/core/PerFrameBuffer.h
@@ -12,8 +12,35 @@ struct PerFrameBufferSet {
     std::vector<void*> mappedPointers;
 };
 
+struct PerFrameBufferConfig {
+    const VmaAllocator allocator;
+    const uint32_t frameCount;
+    const VkDeviceSize size;
+    const VkBufferUsageFlags usage;
+    const VmaMemoryUsage memoryUsage;
+    const VmaAllocationCreateFlags allocationFlags;
+
+    PerFrameBufferConfig(
+        VmaAllocator allocator = VK_NULL_HANDLE,
+        uint32_t frameCount = 0,
+        VkDeviceSize size = 0,
+        VkBufferUsageFlags usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+        VmaMemoryUsage memoryUsage = VMA_MEMORY_USAGE_AUTO,
+        VmaAllocationCreateFlags allocationFlags =
+            VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+};
+
 class PerFrameBufferBuilder {
 public:
+    static PerFrameBufferBuilder fromConfig(const PerFrameBufferConfig& config);
+
+    PerFrameBufferBuilder withAllocator(VmaAllocator allocator) const;
+    PerFrameBufferBuilder withFrameCount(uint32_t count) const;
+    PerFrameBufferBuilder withSize(VkDeviceSize size) const;
+    PerFrameBufferBuilder withUsage(VkBufferUsageFlags usage) const;
+    PerFrameBufferBuilder withMemoryUsage(VmaMemoryUsage usage) const;
+    PerFrameBufferBuilder withAllocationFlags(VmaAllocationCreateFlags flags) const;
+
     PerFrameBufferBuilder& setAllocator(VmaAllocator allocator);
     PerFrameBufferBuilder& setFrameCount(uint32_t count);
     PerFrameBufferBuilder& setSize(VkDeviceSize size);
@@ -32,6 +59,8 @@ private:
     VmaAllocationCreateFlags allocationFlags_ =
         VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
 };
+
+bool makePerFrameUniformBuffers(const PerFrameBufferConfig& config, PerFrameBufferSet& outBuffers);
 
 void destroyBuffers(VmaAllocator allocator, const PerFrameBufferSet& buffers);
 

--- a/src/vegetation/GrassSystem.cpp
+++ b/src/vegetation/GrassSystem.cpp
@@ -183,40 +183,34 @@ bool GrassSystem::createBuffers() {
 
     // Use framesInFlight for buffer set count to ensure proper triple buffering
     uint32_t bufferSetCount = getFramesInFlight();
+    const auto doubleBufferedConfig = BufferUtils::DoubleBufferedBufferConfig(getAllocator(), bufferSetCount);
+    const auto perFrameConfig = BufferUtils::PerFrameBufferConfig(getAllocator(), getFramesInFlight());
 
-    BufferUtils::DoubleBufferedBufferBuilder instanceBuilder;
-    if (!instanceBuilder.setAllocator(getAllocator())
-             .setSetCount(bufferSetCount)
-             .setSize(instanceBufferSize)
-             .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
+    if (!BufferUtils::DoubleBufferedBufferBuilder::fromConfig(doubleBufferedConfig)
+             .withSize(instanceBufferSize)
+             .withUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
              .build(instanceBuffers)) {
         SDL_Log("Failed to create grass instance buffers");
         return false;
     }
 
-    BufferUtils::DoubleBufferedBufferBuilder indirectBuilder;
-    if (!indirectBuilder.setAllocator(getAllocator())
-             .setSetCount(bufferSetCount)
-             .setSize(indirectBufferSize)
-             .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+    if (!BufferUtils::DoubleBufferedBufferBuilder::fromConfig(doubleBufferedConfig)
+             .withSize(indirectBufferSize)
+             .withUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
              .build(indirectBuffers)) {
         SDL_Log("Failed to create grass indirect buffers");
         return false;
     }
 
-    BufferUtils::PerFrameBufferBuilder uniformBuilder;
-    if (!uniformBuilder.setAllocator(getAllocator())
-             .setFrameCount(getFramesInFlight())
-             .setSize(cullingUniformSize)
+    if (!BufferUtils::PerFrameBufferBuilder::fromConfig(perFrameConfig)
+             .withSize(cullingUniformSize)
              .build(uniformBuffers)) {
         SDL_Log("Failed to create grass culling uniform buffers");
         return false;
     }
 
-    BufferUtils::PerFrameBufferBuilder paramsBuilder;
-    if (!paramsBuilder.setAllocator(getAllocator())
-             .setFrameCount(getFramesInFlight())
-             .setSize(grassParamsSize)
+    if (!BufferUtils::PerFrameBufferBuilder::fromConfig(perFrameConfig)
+             .withSize(grassParamsSize)
              .build(paramsBuffers)) {
         SDL_Log("Failed to create grass params buffers");
         return false;


### PR DESCRIPTION
### Motivation
- Reduce repetitive builder chains for per-frame and double-buffered buffers by providing immutable preset configurations with sensible defaults.
- Make it easier to create buffer builders by value and override only differing fields (size, frame/set count, usage) to improve readability and reduce errors.
- Support allocation flags consistently for both per-frame and double-buffered allocations.

### Description
- Add `PerFrameBufferConfig` and `DoubleBufferedBufferConfig` structs with default values and constructors in `src/core/PerFrameBuffer.h` and `src/core/DoubleBufferedBuffer.h` respectively.
- Implement `fromConfig` factory methods and immutable `with*` helpers on `PerFrameBufferBuilder` and `DoubleBufferedBufferBuilder` so builders are returned by value and can be modified via copy-with semantics in `src/core/PerFrameBuffer.cpp` and `src/core/DoubleBufferedBuffer.cpp`.
- Add `makePerFrameUniformBuffers(const PerFrameBufferConfig&, ...)` convenience helper and expose allocation flag handling for double-buffered builders so `VmaAllocationCreateInfo.flags` is set during creation.
- Refactor buffer creation sites in `src/vegetation/LeafSystem.cpp` and `src/vegetation/GrassSystem.cpp` to construct shared `DoubleBufferedBufferConfig` and `PerFrameBufferConfig` presets and override only `size`/`usage` via the new `fromConfig(...).withSize(...).withUsage(...)` pattern.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ce7cbd108327b83409c3ba29c48e)