### PR TITLE
Add VMA image RAII handle and immutable builder; refactor terrain & virtual-texture image creation

### DIFF
--- a/src/core/vulkan/VmaImageHandle.h
+++ b/src/core/vulkan/VmaImageHandle.h
@@ -1,0 +1,225 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <vk_mem_alloc.h>
+#include <SDL3/SDL_log.h>
+#include <utility>
+
+class VmaImageHandle {
+public:
+    VmaImageHandle() = default;
+
+    VmaImageHandle(VmaAllocator allocator, VkDevice device, VkImage image,
+                   VmaAllocation allocation, VkImageView view)
+        : allocator_(allocator)
+        , device_(device)
+        , image_(image)
+        , allocation_(allocation)
+        , view_(view) {}
+
+    ~VmaImageHandle() {
+        reset();
+    }
+
+    VmaImageHandle(const VmaImageHandle&) = delete;
+    VmaImageHandle& operator=(const VmaImageHandle&) = delete;
+
+    VmaImageHandle(VmaImageHandle&& other) noexcept {
+        *this = std::move(other);
+    }
+
+    VmaImageHandle& operator=(VmaImageHandle&& other) noexcept {
+        if (this != &other) {
+            reset();
+            allocator_ = other.allocator_;
+            device_ = other.device_;
+            image_ = other.image_;
+            allocation_ = other.allocation_;
+            view_ = other.view_;
+
+            other.allocator_ = VK_NULL_HANDLE;
+            other.device_ = VK_NULL_HANDLE;
+            other.image_ = VK_NULL_HANDLE;
+            other.allocation_ = VK_NULL_HANDLE;
+            other.view_ = VK_NULL_HANDLE;
+        }
+        return *this;
+    }
+
+    void reset() {
+        if (device_ != VK_NULL_HANDLE && view_ != VK_NULL_HANDLE) {
+            vk::Device vkDevice(device_);
+            vkDevice.destroyImageView(view_);
+            view_ = VK_NULL_HANDLE;
+        }
+        if (allocator_ != VK_NULL_HANDLE && image_ != VK_NULL_HANDLE) {
+            vmaDestroyImage(allocator_, image_, allocation_);
+            image_ = VK_NULL_HANDLE;
+            allocation_ = VK_NULL_HANDLE;
+        }
+    }
+
+    VkImage getImage() const { return image_; }
+    VkImageView getView() const { return view_; }
+    VmaAllocation getAllocation() const { return allocation_; }
+
+    bool isValid() const { return image_ != VK_NULL_HANDLE && view_ != VK_NULL_HANDLE; }
+
+private:
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    VkDevice device_ = VK_NULL_HANDLE;
+    VkImage image_ = VK_NULL_HANDLE;
+    VmaAllocation allocation_ = VK_NULL_HANDLE;
+    VkImageView view_ = VK_NULL_HANDLE;
+};
+
+struct VmaImageSpec {
+    vk::Format format = vk::Format::eUndefined;
+    vk::Extent3D extent{1, 1, 1};
+    vk::ImageUsageFlags usage{};
+    uint32_t mipLevels = 1;
+    uint32_t arrayLayers = 1;
+    vk::ImageType imageType = vk::ImageType::e2D;
+    vk::ImageViewType viewType = vk::ImageViewType::e2D;
+    vk::ImageAspectFlags aspectMask = vk::ImageAspectFlagBits::eColor;
+    uint32_t baseMipLevel = 0;
+    uint32_t levelCount = 1;
+    uint32_t baseArrayLayer = 0;
+    uint32_t layerCount = 1;
+    vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
+    vk::ImageTiling tiling = vk::ImageTiling::eOptimal;
+    vk::ImageCreateFlags flags{};
+    VmaMemoryUsage memoryUsage = VMA_MEMORY_USAGE_AUTO;
+    VkMemoryPropertyFlags requiredFlags = 0;
+
+    [[nodiscard]] VmaImageSpec withFormat(vk::Format newFormat) const {
+        auto copy = *this;
+        copy.format = newFormat;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withExtent(vk::Extent3D newExtent) const {
+        auto copy = *this;
+        copy.extent = newExtent;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withUsage(vk::ImageUsageFlags newUsage) const {
+        auto copy = *this;
+        copy.usage = newUsage;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withMipLevels(uint32_t newMipLevels) const {
+        auto copy = *this;
+        copy.mipLevels = newMipLevels;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withArrayLayers(uint32_t newArrayLayers) const {
+        auto copy = *this;
+        copy.arrayLayers = newArrayLayers;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withView(vk::ImageViewType newViewType,
+                                        vk::ImageAspectFlags newAspectMask,
+                                        uint32_t newBaseMipLevel,
+                                        uint32_t newLevelCount,
+                                        uint32_t newBaseArrayLayer,
+                                        uint32_t newLayerCount) const {
+        auto copy = *this;
+        copy.viewType = newViewType;
+        copy.aspectMask = newAspectMask;
+        copy.baseMipLevel = newBaseMipLevel;
+        copy.levelCount = newLevelCount;
+        copy.baseArrayLayer = newBaseArrayLayer;
+        copy.layerCount = newLayerCount;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withSamples(vk::SampleCountFlagBits newSamples) const {
+        auto copy = *this;
+        copy.samples = newSamples;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withTiling(vk::ImageTiling newTiling) const {
+        auto copy = *this;
+        copy.tiling = newTiling;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withFlags(vk::ImageCreateFlags newFlags) const {
+        auto copy = *this;
+        copy.flags = newFlags;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withMemoryUsage(VmaMemoryUsage newUsage) const {
+        auto copy = *this;
+        copy.memoryUsage = newUsage;
+        return copy;
+    }
+
+    [[nodiscard]] VmaImageSpec withRequiredFlags(VkMemoryPropertyFlags newFlags) const {
+        auto copy = *this;
+        copy.requiredFlags = newFlags;
+        return copy;
+    }
+
+    VmaImageHandle build(VmaAllocator allocator, VkDevice device) const {
+        auto imageInfo = vk::ImageCreateInfo{}
+            .setImageType(imageType)
+            .setFormat(format)
+            .setExtent(extent)
+            .setMipLevels(mipLevels)
+            .setArrayLayers(arrayLayers)
+            .setSamples(samples)
+            .setTiling(tiling)
+            .setUsage(usage)
+            .setSharingMode(vk::SharingMode::eExclusive)
+            .setInitialLayout(vk::ImageLayout::eUndefined)
+            .setFlags(flags);
+
+        VmaAllocationCreateInfo allocInfo{};
+        allocInfo.usage = memoryUsage;
+        allocInfo.requiredFlags = requiredFlags;
+
+        VkImage image = VK_NULL_HANDLE;
+        VmaAllocation allocation = VK_NULL_HANDLE;
+        VkResult result = vmaCreateImage(allocator,
+                                         reinterpret_cast<const VkImageCreateInfo*>(&imageInfo),
+                                         &allocInfo, &image, &allocation, nullptr);
+        if (result != VK_SUCCESS) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VmaImageSpec::build failed to create image: %d", result);
+            return {};
+        }
+
+        uint32_t resolvedLevelCount = levelCount == 0 ? mipLevels : levelCount;
+        uint32_t resolvedLayerCount = layerCount == 0 ? arrayLayers : layerCount;
+
+        auto viewInfo = vk::ImageViewCreateInfo{}
+            .setImage(image)
+            .setViewType(viewType)
+            .setFormat(format)
+            .setSubresourceRange(vk::ImageSubresourceRange{}
+                .setAspectMask(aspectMask)
+                .setBaseMipLevel(baseMipLevel)
+                .setLevelCount(resolvedLevelCount)
+                .setBaseArrayLayer(baseArrayLayer)
+                .setLayerCount(resolvedLayerCount));
+
+        vk::Device vkDevice(device);
+        VkImageView view = VK_NULL_HANDLE;
+        try {
+            view = static_cast<VkImageView>(vkDevice.createImageView(viewInfo));
+        } catch (const vk::SystemError& e) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VmaImageSpec::build failed to create view: %s", e.what());
+            vmaDestroyImage(allocator, image, allocation);
+            return {};
+        }
+
+        return VmaImageHandle(allocator, device, image, allocation, view);
+    }
+};

--- a/src/core/vulkan/VmaResources.h
+++ b/src/core/vulkan/VmaResources.h
@@ -7,10 +7,12 @@
 // For fine-grained includes, use the specific headers directly:
 //   - VmaBuffer.h       : VmaBuffer, VmaBufferDeleter, ManagedBuffer
 //   - VmaImage.h        : VmaImage, VmaImageDeleter, ManagedImage
+//   - VmaImageHandle.h  : VmaImageHandle, VmaImageSpec
 //   - VmaBufferFactory.h: VmaBufferFactory namespace with buffer creation helpers
 //   - SamplerFactory.h  : SamplerFactory namespace with sampler creation helpers
 
 #include "VmaBuffer.h"
 #include "VmaImage.h"
+#include "VmaImageHandle.h"
 #include "VmaBufferFactory.h"
 #include "SamplerFactory.h"

--- a/src/terrain/TerrainTextures.h
+++ b/src/terrain/TerrainTextures.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <optional>
 #include <memory>
+#include "VmaImageHandle.h"
 
 // Terrain textures - albedo and grass far LOD textures
 class TerrainTextures {
@@ -36,11 +37,11 @@ public:
     TerrainTextures& operator=(const TerrainTextures&) = delete;
 
     // Terrain albedo texture
-    VkImageView getAlbedoView() const { return albedoView; }
+    VkImageView getAlbedoView() const { return albedoImage_.getView(); }
     VkSampler getAlbedoSampler() const { return albedoSampler_ ? **albedoSampler_ : VK_NULL_HANDLE; }
 
     // Grass far LOD texture (for terrain blending at distance)
-    VkImageView getGrassFarLODView() const { return grassFarLODView; }
+    VkImageView getGrassFarLODView() const { return grassFarLODImage_.getView(); }
     VkSampler getGrassFarLODSampler() const { return grassFarLODSampler_ ? **grassFarLODSampler_ : VK_NULL_HANDLE; }
 
 private:
@@ -60,16 +61,12 @@ private:
     std::string resourcePath;
 
     // Terrain albedo texture
-    VkImage albedoImage = VK_NULL_HANDLE;
-    VmaAllocation albedoAllocation = VK_NULL_HANDLE;
-    VkImageView albedoView = VK_NULL_HANDLE;
+    VmaImageHandle albedoImage_{};
     std::optional<vk::raii::Sampler> albedoSampler_;
     uint32_t albedoMipLevels = 1;
 
     // Grass far LOD texture
-    VkImage grassFarLODImage = VK_NULL_HANDLE;
-    VmaAllocation grassFarLODAllocation = VK_NULL_HANDLE;
-    VkImageView grassFarLODView = VK_NULL_HANDLE;
+    VmaImageHandle grassFarLODImage_{};
     std::optional<vk::raii::Sampler> grassFarLODSampler_;
     uint32_t grassFarLODMipLevels = 1;
 };

--- a/src/terrain/virtual_texture/VirtualTextureCache.h
+++ b/src/terrain/virtual_texture/VirtualTextureCache.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <memory>
 #include "VmaBuffer.h"
+#include "VmaImageHandle.h"
 
 namespace VirtualTexture {
 
@@ -85,7 +86,7 @@ public:
     uint32_t getStagingBufferCount() const { return static_cast<uint32_t>(stagingBuffers_.size()); }
 
     // Get the cache texture image view
-    VkImageView getCacheImageView() const { return cacheImageView; }
+    VkImageView getCacheImageView() const { return cacheImage_.getView(); }
 
     // Get the sampler for the cache texture
     VkSampler getCacheSampler() const { return cacheSampler_ ? **cacheSampler_ : VK_NULL_HANDLE; }
@@ -126,9 +127,7 @@ private:
     const vk::raii::Device* raiiDevice_ = nullptr;
 
     // Physical cache texture
-    VkImage cacheImage = VK_NULL_HANDLE;
-    VmaAllocation cacheAllocation = VK_NULL_HANDLE;
-    VkImageView cacheImageView = VK_NULL_HANDLE;
+    VmaImageHandle cacheImage_{};
     std::optional<vk::raii::Sampler> cacheSampler_;
 
     // Per-frame staging buffers to avoid race conditions with in-flight frames

--- a/src/terrain/virtual_texture/VirtualTexturePageTable.h
+++ b/src/terrain/virtual_texture/VirtualTexturePageTable.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include "VmaBuffer.h"
+#include "VmaImageHandle.h"
 
 namespace VirtualTexture {
 
@@ -100,9 +101,7 @@ private:
     const vk::raii::Device* raiiDevice_ = nullptr;
 
     // One image per mip level
-    std::vector<VkImage> pageTableImages;
-    std::vector<VmaAllocation> pageTableAllocations;
-    std::vector<VkImageView> pageTableViews;
+    std::vector<VmaImageHandle> pageTableImages_;
 
     // Combined image view (texture array)
     VkImageView combinedImageView = VK_NULL_HANDLE;


### PR DESCRIPTION
### Motivation

- Centralize VMA image + view allocation into an RAII type to avoid scattered manual `vmaCreateImage` / `vkCreateImageView` and ensure deterministic cleanup. 
- Provide an immutable builder to capture image/view configuration (format, extent, usage, mip levels, view settings) so callers can construct images declaratively and keep Vulkan-hpp `.set*()` usage localized. 
- Replace repeated inline allocation/view code in virtual-texture cache/page table and terrain textures to reduce duplication and make ownership semantics explicit.

### Description

- Add a new RAII wrapper and builder in `src/core/vulkan/VmaImageHandle.h`: `VmaImageHandle` owns `VkImage`, `VmaAllocation`, and `VkImageView` and destroys them in its destructor, and `VmaImageSpec` is an immutable builder with a `build(VmaAllocator, VkDevice)` method that creates the image and view using Vulkan-hpp `set*()` builders. 
- Expose the new header via the umbrella include by updating `src/core/vulkan/VmaResources.h`. 
- Refactor image creation and storage to use the new wrapper in three places: `src/terrain/virtual_texture/VirtualTextureCache.{h,cpp}` (cache texture), `src/terrain/virtual_texture/VirtualTexturePageTable.{h,cpp}` (page table mip images), and `src/terrain/TerrainTextures.{h,cpp}` (albedo and grass far-LOD textures); raw `VkImage`/`VmaAllocation`/`VkImageView` members were replaced with `VmaImageHandle` and callsites now use `.getImage()` / `.getView()`. 
- Kept Vulkan-hpp `.set*()` usage inside the builder (`VmaImageSpec::build`) and preserved prior allocation flags (e.g., `VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`) when constructing specs.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ce8ad1a88327a2ea80f1f8515fc0)