### PR TITLE
Use RAII shader modules for pipeline creation

### DIFF
--- a/src/core/ShaderLoader.cpp
+++ b/src/core/ShaderLoader.cpp
@@ -4,6 +4,40 @@
 
 namespace ShaderLoader {
 
+ScopedShaderModule::ScopedShaderModule(VkDevice device, VkShaderModule module)
+    : device_(device)
+    , module_(module) {}
+
+ScopedShaderModule::~ScopedShaderModule() {
+    reset();
+}
+
+ScopedShaderModule::ScopedShaderModule(ScopedShaderModule&& other) noexcept
+    : device_(other.device_)
+    , module_(other.module_) {
+    other.device_ = VK_NULL_HANDLE;
+    other.module_ = VK_NULL_HANDLE;
+}
+
+ScopedShaderModule& ScopedShaderModule::operator=(ScopedShaderModule&& other) noexcept {
+    if (this != &other) {
+        reset();
+        device_ = other.device_;
+        module_ = other.module_;
+        other.device_ = VK_NULL_HANDLE;
+        other.module_ = VK_NULL_HANDLE;
+    }
+    return *this;
+}
+
+void ScopedShaderModule::reset() {
+    if (device_ != VK_NULL_HANDLE && module_ != VK_NULL_HANDLE) {
+        vk::Device(device_).destroyShaderModule(module_);
+    }
+    device_ = VK_NULL_HANDLE;
+    module_ = VK_NULL_HANDLE;
+}
+
 std::optional<std::vector<char>> readFile(const std::string& filename) {
     std::ifstream file(filename, std::ios::ate | std::ios::binary);
 
@@ -41,6 +75,43 @@ std::optional<vk::ShaderModule> loadShaderModule(vk::Device device, const std::s
         return std::nullopt;
     }
     return createShaderModule(device, *code);
+}
+
+std::optional<vk::raii::ShaderModule> createShaderModule(const vk::raii::Device& device, const std::vector<char>& code) {
+    auto createInfo = vk::ShaderModuleCreateInfo{}
+        .setCodeSize(code.size())
+        .setPCode(reinterpret_cast<const uint32_t*>(code.data()));
+
+    try {
+        return device.createShaderModule(createInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create shader module: %s", e.what());
+        return std::nullopt;
+    }
+}
+
+std::optional<vk::raii::ShaderModule> loadShaderModule(const vk::raii::Device& device, const std::string& path) {
+    auto code = readFile(path);
+    if (!code) {
+        return std::nullopt;
+    }
+    return createShaderModule(device, *code);
+}
+
+std::optional<ScopedShaderModule> createShaderModule(VkDevice device, const std::vector<char>& code, RaiiTag) {
+    auto result = createShaderModule(vk::Device(device), code);
+    if (!result) {
+        return std::nullopt;
+    }
+    return ScopedShaderModule(device, static_cast<VkShaderModule>(*result));
+}
+
+std::optional<ScopedShaderModule> loadShaderModule(VkDevice device, std::string_view path, RaiiTag) {
+    auto code = readFile(std::string(path));
+    if (!code) {
+        return std::nullopt;
+    }
+    return createShaderModule(device, *code, RaiiTag{});
 }
 
 }

--- a/src/core/ShaderLoader.h
+++ b/src/core/ShaderLoader.h
@@ -1,15 +1,46 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 #include <vector>
 #include <string>
 #include <optional>
+#include <string_view>
 
 namespace ShaderLoader {
+
+struct RaiiTag {
+    explicit RaiiTag() = default;
+};
+
+class ScopedShaderModule {
+public:
+    ScopedShaderModule() = default;
+    ScopedShaderModule(VkDevice device, VkShaderModule module);
+    ~ScopedShaderModule();
+
+    ScopedShaderModule(const ScopedShaderModule&) = delete;
+    ScopedShaderModule& operator=(const ScopedShaderModule&) = delete;
+    ScopedShaderModule(ScopedShaderModule&& other) noexcept;
+    ScopedShaderModule& operator=(ScopedShaderModule&& other) noexcept;
+
+    VkShaderModule get() const { return module_; }
+    explicit operator bool() const { return module_ != VK_NULL_HANDLE; }
+
+private:
+    void reset();
+
+    VkDevice device_ = VK_NULL_HANDLE;
+    VkShaderModule module_ = VK_NULL_HANDLE;
+};
 
 std::optional<std::vector<char>> readFile(const std::string& filename);
 std::optional<vk::ShaderModule> createShaderModule(vk::Device device, const std::vector<char>& code);
 std::optional<vk::ShaderModule> loadShaderModule(vk::Device device, const std::string& path);
+std::optional<vk::raii::ShaderModule> createShaderModule(const vk::raii::Device& device, const std::vector<char>& code);
+std::optional<vk::raii::ShaderModule> loadShaderModule(const vk::raii::Device& device, const std::string& path);
+std::optional<ScopedShaderModule> createShaderModule(VkDevice device, const std::vector<char>& code, RaiiTag);
+std::optional<ScopedShaderModule> loadShaderModule(VkDevice device, std::string_view path, RaiiTag);
 
 // Convenience overloads for raw VkDevice (for gradual migration)
 inline std::optional<VkShaderModule> createShaderModule(VkDevice device, const std::vector<char>& code) {


### PR DESCRIPTION
### Motivation

- Reduce manual shader module lifetime management by providing RAII-friendly loader overloads and a small scoped wrapper so shader cleanup happens automatically.
- Migrate hot paths that create pipelines (debug lines and terrain shadow-cull pipelines) to the RAII APIs to avoid explicit `destroyShaderModule` calls.

### Description

- Add `ShaderLoader::ScopedShaderModule` (move-only) and a `RaiiTag` plus overloads that return `vk::raii::ShaderModule` for `vk::raii::Device` and `ScopedShaderModule` for raw `VkDevice` call sites in `src/core/ShaderLoader.h/.cpp` and implement move/destructor behavior.
- Update `src/debug/DebugLineSystem.cpp` to load shaders via the RAII-scoped loader and replace direct module uses with `ScopedShaderModule::get()`, removing explicit `destroyShaderModule` calls.
- Update `src/terrain/TerrainPipelines.cpp` shadow-cull pipeline creation to use `ShaderLoader::loadShaderModule` returning `vk::raii::ShaderModule` and remove manual shader-module destruction; tidy up an unused `using`.

### Testing

- Automated tests: none were executed as part of this change (no CI/build run in this rollout).
- Suggested manual verification: run `cmake --preset debug && cmake --build build/debug` to compile shaders and binaries, then run `./run-debug.sh` and verify the application initializes, debug lines render, and terrain shadow-cull pipelines are created without shader destruction errors or double-free issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ce90c0f88327a135fa267b15e5e2)