### PR TITLE
Add InitInfoBuilder and migrate InitContext-based create() overloads to use it

### DIFF
--- a/src/atmosphere/AtmosphereLUTSystem.cpp
+++ b/src/atmosphere/AtmosphereLUTSystem.cpp
@@ -1,4 +1,5 @@
 #include "AtmosphereLUTSystem.h"
+#include "core/InitInfoBuilder.h"
 #include <SDL3/SDL_log.h>
 
 std::unique_ptr<AtmosphereLUTSystem> AtmosphereLUTSystem::create(const InitInfo& info) {
@@ -10,13 +11,7 @@ std::unique_ptr<AtmosphereLUTSystem> AtmosphereLUTSystem::create(const InitInfo&
 }
 
 std::unique_ptr<AtmosphereLUTSystem> AtmosphereLUTSystem::create(const InitContext& ctx) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/atmosphere/CloudShadowSystem.cpp
+++ b/src/atmosphere/CloudShadowSystem.cpp
@@ -3,6 +3,7 @@
 #include "DescriptorManager.h"
 #include "VmaImage.h"
 #include "SamplerFactory.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
@@ -21,15 +22,9 @@ std::unique_ptr<CloudShadowSystem> CloudShadowSystem::create(const InitInfo& inf
 }
 
 std::unique_ptr<CloudShadowSystem> CloudShadowSystem::create(const InitContext& ctx, VkImageView cloudMapLUTView_, VkSampler cloudMapLUTSampler_) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.cloudMapLUTView = cloudMapLUTView_;
     info.cloudMapLUTSampler = cloudMapLUTSampler_;
-    info.raiiDevice = ctx.raiiDevice;
     return create(info);
 }
 

--- a/src/atmosphere/SkySystem.cpp
+++ b/src/atmosphere/SkySystem.cpp
@@ -3,6 +3,7 @@
 #include "GraphicsPipelineFactory.h"
 #include "DescriptorManager.h"
 #include "UBOs.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include <vulkan/vulkan.hpp>
 #include <SDL3/SDL.h>
@@ -17,15 +18,8 @@ std::unique_ptr<SkySystem> SkySystem::create(const InitInfo& info) {
 }
 
 std::unique_ptr<SkySystem> SkySystem::create(const InitContext& ctx, VkRenderPass hdrPass) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.extent = ctx.extent;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.hdrRenderPass = hdrPass;
-    info.raiiDevice = ctx.raiiDevice;
     return create(info);
 }
 

--- a/src/core/InitInfoBuilder.h
+++ b/src/core/InitInfoBuilder.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+#include <vulkan/vulkan.hpp>
+
+#include "InitContext.h"
+
+namespace InitInfoBuilder {
+namespace detail {
+template <typename T, typename = void>
+struct has_device : std::false_type {};
+template <typename T>
+struct has_device<T, std::void_t<decltype(std::declval<T>().device)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_physical_device : std::false_type {};
+template <typename T>
+struct has_physical_device<T, std::void_t<decltype(std::declval<T>().physicalDevice)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_allocator : std::false_type {};
+template <typename T>
+struct has_allocator<T, std::void_t<decltype(std::declval<T>().allocator)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_command_pool : std::false_type {};
+template <typename T>
+struct has_command_pool<T, std::void_t<decltype(std::declval<T>().commandPool)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_graphics_queue : std::false_type {};
+template <typename T>
+struct has_graphics_queue<T, std::void_t<decltype(std::declval<T>().graphicsQueue)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_descriptor_pool : std::false_type {};
+template <typename T>
+struct has_descriptor_pool<T, std::void_t<decltype(std::declval<T>().descriptorPool)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_extent : std::false_type {};
+template <typename T>
+struct has_extent<T, std::void_t<decltype(std::declval<T>().extent)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_shader_path : std::false_type {};
+template <typename T>
+struct has_shader_path<T, std::void_t<decltype(std::declval<T>().shaderPath)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_resource_path : std::false_type {};
+template <typename T>
+struct has_resource_path<T, std::void_t<decltype(std::declval<T>().resourcePath)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_frames_in_flight : std::false_type {};
+template <typename T>
+struct has_frames_in_flight<T, std::void_t<decltype(std::declval<T>().framesInFlight)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_max_frames_in_flight : std::false_type {};
+template <typename T>
+struct has_max_frames_in_flight<T, std::void_t<decltype(std::declval<T>().maxFramesInFlight)>> : std::true_type {};
+
+template <typename T, typename = void>
+struct has_raii_device : std::false_type {};
+template <typename T>
+struct has_raii_device<T, std::void_t<decltype(std::declval<T>().raiiDevice)>> : std::true_type {};
+
+template <typename Info>
+void assignDevice(Info& info, VkDevice device) {
+    if constexpr (has_device<Info>::value) {
+        using MemberType = std::decay_t<decltype(info.device)>;
+        if constexpr (std::is_same_v<MemberType, VkDevice>) {
+            info.device = device;
+        } else if constexpr (std::is_same_v<MemberType, vk::Device>) {
+            info.device = vk::Device(device);
+        }
+    }
+}
+
+template <typename Info>
+void assignPhysicalDevice(Info& info, VkPhysicalDevice physicalDevice) {
+    if constexpr (has_physical_device<Info>::value) {
+        using MemberType = std::decay_t<decltype(info.physicalDevice)>;
+        if constexpr (std::is_same_v<MemberType, VkPhysicalDevice>) {
+            info.physicalDevice = physicalDevice;
+        } else if constexpr (std::is_same_v<MemberType, vk::PhysicalDevice>) {
+            info.physicalDevice = vk::PhysicalDevice(physicalDevice);
+        }
+    }
+}
+
+template <typename Info>
+void assignAllocator(Info& info, VmaAllocator allocator) {
+    if constexpr (has_allocator<Info>::value) {
+        info.allocator = allocator;
+    }
+}
+
+template <typename Info>
+void assignCommandPool(Info& info, VkCommandPool commandPool) {
+    if constexpr (has_command_pool<Info>::value) {
+        using MemberType = std::decay_t<decltype(info.commandPool)>;
+        if constexpr (std::is_same_v<MemberType, VkCommandPool>) {
+            info.commandPool = commandPool;
+        } else if constexpr (std::is_same_v<MemberType, vk::CommandPool>) {
+            info.commandPool = vk::CommandPool(commandPool);
+        }
+    }
+}
+
+template <typename Info>
+void assignGraphicsQueue(Info& info, VkQueue graphicsQueue) {
+    if constexpr (has_graphics_queue<Info>::value) {
+        using MemberType = std::decay_t<decltype(info.graphicsQueue)>;
+        if constexpr (std::is_same_v<MemberType, VkQueue>) {
+            info.graphicsQueue = graphicsQueue;
+        } else if constexpr (std::is_same_v<MemberType, vk::Queue>) {
+            info.graphicsQueue = vk::Queue(graphicsQueue);
+        }
+    }
+}
+
+template <typename Info>
+void assignDescriptorPool(Info& info, DescriptorManager::Pool* descriptorPool) {
+    if constexpr (has_descriptor_pool<Info>::value) {
+        info.descriptorPool = descriptorPool;
+    }
+}
+
+template <typename Info>
+void assignExtent(Info& info, VkExtent2D extent) {
+    if constexpr (has_extent<Info>::value) {
+        using MemberType = std::decay_t<decltype(info.extent)>;
+        if constexpr (std::is_same_v<MemberType, VkExtent2D>) {
+            info.extent = extent;
+        } else if constexpr (std::is_same_v<MemberType, vk::Extent2D>) {
+            info.extent = vk::Extent2D{extent.width, extent.height};
+        }
+    }
+}
+
+template <typename Info>
+void assignShaderPath(Info& info, const std::string& shaderPath) {
+    if constexpr (has_shader_path<Info>::value) {
+        info.shaderPath = shaderPath;
+    }
+}
+
+template <typename Info>
+void assignResourcePath(Info& info, const std::string& resourcePath) {
+    if constexpr (has_resource_path<Info>::value) {
+        info.resourcePath = resourcePath;
+    }
+}
+
+template <typename Info>
+void assignFramesInFlight(Info& info, uint32_t framesInFlight) {
+    if constexpr (has_frames_in_flight<Info>::value) {
+        info.framesInFlight = framesInFlight;
+    }
+    if constexpr (has_max_frames_in_flight<Info>::value) {
+        info.maxFramesInFlight = framesInFlight;
+    }
+}
+
+template <typename Info>
+void assignRaiiDevice(Info& info, const vk::raii::Device* raiiDevice) {
+    if constexpr (has_raii_device<Info>::value) {
+        info.raiiDevice = raiiDevice;
+    }
+}
+}  // namespace detail
+
+template <typename Info>
+Info fromContext(const InitContext& ctx) {
+    Info info{};
+    detail::assignDevice(info, ctx.device);
+    detail::assignPhysicalDevice(info, ctx.physicalDevice);
+    detail::assignAllocator(info, ctx.allocator);
+    detail::assignCommandPool(info, ctx.commandPool);
+    detail::assignGraphicsQueue(info, ctx.graphicsQueue);
+    detail::assignDescriptorPool(info, ctx.descriptorPool);
+    detail::assignExtent(info, ctx.extent);
+    detail::assignShaderPath(info, ctx.shaderPath);
+    detail::assignResourcePath(info, ctx.resourcePath);
+    detail::assignFramesInFlight(info, ctx.framesInFlight);
+    detail::assignRaiiDevice(info, ctx.raiiDevice);
+    return info;
+}
+}  // namespace InitInfoBuilder

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -1,6 +1,7 @@
 #include "FroxelSystem.h"
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
 #include "core/vulkan/SamplerFactory.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
@@ -21,17 +22,10 @@ std::unique_ptr<FroxelSystem> FroxelSystem::create(const InitInfo& info) {
 
 std::unique_ptr<FroxelSystem> FroxelSystem::create(const InitContext& ctx, VkImageView shadowMapView_, VkSampler shadowSampler_,
                                                     const std::vector<VkBuffer>& lightBuffers_) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.shadowMapView = shadowMapView_;
     info.shadowSampler = shadowSampler_;
     info.lightBuffers = lightBuffers_;
-    info.raiiDevice = ctx.raiiDevice;
 
     return create(info);
 }

--- a/src/lighting/ShadowSystem.cpp
+++ b/src/lighting/ShadowSystem.cpp
@@ -6,6 +6,7 @@
 #include "GraphicsPipelineFactory.h"
 #include "debug/QueueSubmitDiagnostics.h"
 #include "shaders/bindings.h"
+#include "core/InitInfoBuilder.h"
 #include <vulkan/vulkan.hpp>
 #include <SDL3/SDL.h>
 #include <algorithm>
@@ -26,15 +27,9 @@ std::unique_ptr<ShadowSystem> ShadowSystem::create(const InitInfo& info) {
 std::unique_ptr<ShadowSystem> ShadowSystem::create(const InitContext& ctx,
                                                     VkDescriptorSetLayout mainDescriptorSetLayout_,
                                                     VkDescriptorSetLayout skinnedDescriptorSetLayout_) {
-    InitInfo info;
-    info.raiiDevice = ctx.raiiDevice;
-    info.device = ctx.device;
-    info.physicalDevice = ctx.physicalDevice;
-    info.allocator = ctx.allocator;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.mainDescriptorSetLayout = mainDescriptorSetLayout_;
     info.skinnedDescriptorSetLayout = skinnedDescriptorSetLayout_;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
     return create(info);
 }
 

--- a/src/postprocess/BilateralGridSystem.cpp
+++ b/src/postprocess/BilateralGridSystem.cpp
@@ -1,5 +1,6 @@
 #include "BilateralGridSystem.h"
 #include "ShaderLoader.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/SamplerFactory.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
@@ -39,14 +40,7 @@ std::unique_ptr<BilateralGridSystem> BilateralGridSystem::create(const InitInfo&
 }
 
 std::unique_ptr<BilateralGridSystem> BilateralGridSystem::create(const InitContext& ctx) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/postprocess/BloomSystem.cpp
+++ b/src/postprocess/BloomSystem.cpp
@@ -3,6 +3,7 @@
 #include "SamplerFactory.h"
 #include "DescriptorManager.h"
 #include "core/ImageBuilder.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include <vulkan/vulkan.hpp>
@@ -20,13 +21,7 @@ std::unique_ptr<BloomSystem> BloomSystem::create(const InitInfo& info) {
 }
 
 std::unique_ptr<BloomSystem> BloomSystem::create(const InitContext& ctx) {
-    InitInfo info;
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/postprocess/ComputeBloomSystem.cpp
+++ b/src/postprocess/ComputeBloomSystem.cpp
@@ -2,6 +2,7 @@
 #include "SamplerFactory.h"
 #include "DescriptorManager.h"
 #include "core/ImageBuilder.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "ShaderLoader.h"
@@ -20,13 +21,7 @@ std::unique_ptr<ComputeBloomSystem> ComputeBloomSystem::create(const InitInfo& i
 }
 
 std::unique_ptr<ComputeBloomSystem> ComputeBloomSystem::create(const InitContext& ctx) {
-    InitInfo info;
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/postprocess/GodRaysSystem.cpp
+++ b/src/postprocess/GodRaysSystem.cpp
@@ -1,6 +1,7 @@
 #include "GodRaysSystem.h"
 #include "SamplerFactory.h"
 #include "DescriptorManager.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "ShaderLoader.h"
 #include <vulkan/vulkan.hpp>
@@ -15,13 +16,7 @@ std::unique_ptr<GodRaysSystem> GodRaysSystem::create(const InitInfo& info) {
 }
 
 std::unique_ptr<GodRaysSystem> GodRaysSystem::create(const InitContext& ctx) {
-    InitInfo info;
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/postprocess/HiZSystem.cpp
+++ b/src/postprocess/HiZSystem.cpp
@@ -3,6 +3,7 @@
 #include "VmaBufferFactory.h"
 #include "SamplerFactory.h"
 #include "core/ImageBuilder.h"
+#include "core/InitInfoBuilder.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
@@ -21,15 +22,8 @@ std::unique_ptr<HiZSystem> HiZSystem::create(const InitInfo& info) {
 }
 
 std::unique_ptr<HiZSystem> HiZSystem::create(const InitContext& ctx, VkFormat depthFormat_) {
-    InitInfo info;
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.depthFormat = depthFormat_;
-    info.raiiDevice = ctx.raiiDevice;
     return create(info);
 }
 

--- a/src/postprocess/PostProcessSystem.cpp
+++ b/src/postprocess/PostProcessSystem.cpp
@@ -3,6 +3,7 @@
 #include "BilateralGridSystem.h"
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
+#include "core/InitInfoBuilder.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
 #include "SamplerFactory.h"
 #include "VmaBuffer.h"
@@ -22,16 +23,9 @@ std::unique_ptr<PostProcessSystem> PostProcessSystem::create(const InitInfo& inf
 }
 
 std::unique_ptr<PostProcessSystem> PostProcessSystem::create(const InitContext& ctx, VkRenderPass outputRenderPass, VkFormat swapchainFormat) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.outputRenderPass = outputRenderPass;
-    info.descriptorPool = ctx.descriptorPool;
-    info.extent = ctx.extent;
     info.swapchainFormat = swapchainFormat;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.raiiDevice = ctx.raiiDevice;
     return create(info);
 }
 

--- a/src/postprocess/SSRSystem.cpp
+++ b/src/postprocess/SSRSystem.cpp
@@ -2,6 +2,7 @@
 #include "ShaderLoader.h"
 #include "DescriptorManager.h"
 #include "CommandBufferUtils.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/SamplerFactory.h"
 #include "core/pipeline/ComputePipelineBuilder.h"
 #include "core/vulkan/PipelineLayoutBuilder.h"
@@ -20,17 +21,8 @@ std::unique_ptr<SSRSystem> SSRSystem::create(const InitInfo& info) {
 }
 
 std::unique_ptr<SSRSystem> SSRSystem::create(const InitContext& ctx) {
-    InitInfo info;
-    info.device = ctx.device;
-    info.physicalDevice = ctx.physicalDevice;
-    info.allocator = ctx.allocator;
-    info.commandPool = ctx.commandPool;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     info.computeQueue = ctx.graphicsQueue;  // Use graphics queue for compute
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.extent = ctx.extent;
-    info.descriptorPool = ctx.descriptorPool;
-    info.raiiDevice = ctx.raiiDevice;
     return create(info);
 }
 

--- a/src/vegetation/DisplacementSystem.cpp
+++ b/src/vegetation/DisplacementSystem.cpp
@@ -3,6 +3,7 @@
 #include "InitContext.h"
 #include "ComputePipelineBuilder.h"
 #include "core/ImageBuilder.h"
+#include "core/InitInfoBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
 #include "core/vulkan/SamplerFactory.h"
 #include <SDL3/SDL.h>
@@ -24,13 +25,7 @@ std::unique_ptr<DisplacementSystem> DisplacementSystem::create(const InitInfo& i
 }
 
 std::unique_ptr<DisplacementSystem> DisplacementSystem::create(const InitContext& ctx) {
-    InitInfo info{};
-    info.device = ctx.device;
-    info.allocator = ctx.allocator;
-    info.descriptorPool = ctx.descriptorPool;
-    info.shaderPath = ctx.shaderPath;
-    info.framesInFlight = ctx.framesInFlight;
-    info.raiiDevice = ctx.raiiDevice;
+    InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);
     return create(info);
 }
 

--- a/src/vegetation/VegetationSystemGroup.cpp
+++ b/src/vegetation/VegetationSystemGroup.cpp
@@ -10,6 +10,7 @@
 #include "TreeRenderer.h"
 #include "TreeLODSystem.h"
 #include "ImpostorCullSystem.h"
+#include "core/InitInfoBuilder.h"
 #include <SDL3/SDL.h>
 
 std::optional<VegetationSystemGroup::Bundle> VegetationSystemGroup::createAll(
@@ -83,18 +84,10 @@ std::optional<VegetationSystemGroup::Bundle> VegetationSystemGroup::createAll(
 
     // 4. Create TreeRenderer
     {
-        TreeRenderer::InitInfo info{};
-        info.raiiDevice = ctx.raiiDevice;
-        info.device = vk::Device(ctx.device);
-        info.physicalDevice = vk::PhysicalDevice(ctx.physicalDevice);
-        info.allocator = ctx.allocator;
+        TreeRenderer::InitInfo info = InitInfoBuilder::fromContext<TreeRenderer::InitInfo>(ctx);
         info.hdrRenderPass = vk::RenderPass(deps.hdrRenderPass);
         info.shadowRenderPass = vk::RenderPass(deps.shadowRenderPass);
-        info.descriptorPool = ctx.descriptorPool;
-        info.extent = vk::Extent2D{ctx.extent.width, ctx.extent.height};
         info.shadowMapSize = deps.shadowMapSize;
-        info.resourcePath = ctx.resourcePath;
-        info.maxFramesInFlight = ctx.framesInFlight;
 
         bundle.treeRenderer = TreeRenderer::create(info);
         if (!bundle.treeRenderer) {


### PR DESCRIPTION
### Motivation
- Reduce repeated boilerplate when converting an `InitContext` into per-system `InitInfo` by centralizing common field population and type conversions.
- Keep the existing `create(const InitInfo&, ...)` overloads while making `create(const InitContext&, ...)` thin wrappers that only apply system-specific extras.
- Avoid scattered `vk::Device`/`vk::PhysicalDevice` conversion code by handling those conversions in a single helper.

### Description
- Add a new helper `InitInfoBuilder::fromContext<Info>(const InitContext&)` in `src/core/InitInfoBuilder.h` which populates supported fields and performs Vulkan handle type conversions (e.g., `VkDevice` ↔ `vk::Device`).
- Replace manual `InitInfo` population in multiple systems' `create(const InitContext&, ...)` overloads (lighting, atmosphere, postprocess, vegetation) with `InitInfo info = InitInfoBuilder::fromContext<InitInfo>(ctx);` and leave system-specific fields set in the thin wrapper before calling `create(info)`.
- Centralize `TreeRenderer` conversions in `VegetationSystemGroup` using the same builder so the code path that adapted `ctx.device`/`ctx.physicalDevice` into `vk::` wrappers is no longer duplicated.
- Files changed include the new `src/core/InitInfoBuilder.h` and updates to `src/lighting/*`, `src/atmosphere/*`, `src/postprocess/*`, and `src/vegetation/*` to use the builder while preserving per-system extras.
- How to test manually: build with `cmake --preset debug && cmake --build build/debug` and run `./run-debug.sh` (or the usual launcher) and verify systems that use the wrappers initialize without `SDL_LogError` messages during startup.

### Testing
- Automated tests: none were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ceb0f1208327bfd916710324737b)