### PR TITLE
Add immutable DescriptorLayoutBuilder and migrate water/subdivision layouts to use it

### DIFF
--- a/src/core/material/DescriptorManager.h
+++ b/src/core/material/DescriptorManager.h
@@ -61,6 +61,35 @@ struct DescriptorPoolSizes {
 
 class DescriptorManager {
 public:
+    // Immutable builder for descriptor set layouts with optional explicit bindings
+    class DescriptorLayoutBuilder {
+    public:
+        explicit DescriptorLayoutBuilder(VkDevice device);
+
+        DescriptorLayoutBuilder addUniformBuffer(VkShaderStageFlags stages, uint32_t count = 1,
+                                                 std::optional<uint32_t> binding = std::nullopt) const;
+        DescriptorLayoutBuilder addDynamicUniformBuffer(VkShaderStageFlags stages, uint32_t count = 1,
+                                                        std::optional<uint32_t> binding = std::nullopt) const;
+        DescriptorLayoutBuilder addStorageBuffer(VkShaderStageFlags stages, uint32_t count = 1,
+                                                 std::optional<uint32_t> binding = std::nullopt) const;
+        DescriptorLayoutBuilder addCombinedImageSampler(VkShaderStageFlags stages, uint32_t count = 1,
+                                                        std::optional<uint32_t> binding = std::nullopt) const;
+        DescriptorLayoutBuilder addStorageImage(VkShaderStageFlags stages, uint32_t count = 1,
+                                                std::optional<uint32_t> binding = std::nullopt) const;
+
+        DescriptorLayoutBuilder addBinding(uint32_t binding, VkDescriptorType type,
+                                           VkShaderStageFlags stages, uint32_t count = 1) const;
+        DescriptorLayoutBuilder addBinding(VkDescriptorType type, VkShaderStageFlags stages,
+                                           uint32_t count = 1, std::optional<uint32_t> binding = std::nullopt) const;
+
+        VkDescriptorSetLayout build() const;
+
+    private:
+        VkDevice device;
+        std::vector<VkDescriptorSetLayoutBinding> bindings;
+        uint32_t nextBinding = 0;
+    };
+
     // Builder for creating descriptor set layouts with a declarative API
     class LayoutBuilder {
     public:

--- a/src/subdivision/CatmullClarkSystem.cpp
+++ b/src/subdivision/CatmullClarkSystem.cpp
@@ -145,44 +145,15 @@ bool CatmullClarkSystem::createIndirectBuffers() {
 }
 
 bool CatmullClarkSystem::createComputeDescriptorSetLayout() {
-    std::array<vk::DescriptorSetLayoutBinding, 5> bindings = {
-        // Binding 0: Scene UBO
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(0)
-            .setDescriptorType(vk::DescriptorType::eUniformBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 1: CBT buffer
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(1)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 2: Mesh vertices
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(2)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 3: Mesh halfedges
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(3)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 4: Mesh faces
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(4)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-    };
-
-    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
-        .setBindings(bindings);
-
     try {
-        computeDescriptorSetLayout_.emplace(*raiiDevice_, layoutInfo);
+        VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+            .addUniformBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 0)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 1)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 2)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 3)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 4)
+            .build();
+        computeDescriptorSetLayout_.emplace(*raiiDevice_, rawLayout);
     } catch (const vk::SystemError& e) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create compute descriptor set layout: %s", e.what());
         return false;
@@ -192,44 +163,15 @@ bool CatmullClarkSystem::createComputeDescriptorSetLayout() {
 }
 
 bool CatmullClarkSystem::createRenderDescriptorSetLayout() {
-    std::array<vk::DescriptorSetLayoutBinding, 5> bindings = {
-        // Binding 0: Scene UBO
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(0)
-            .setDescriptorType(vk::DescriptorType::eUniformBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment),
-        // Binding 1: CBT buffer
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(1)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eVertex),
-        // Binding 2: Mesh vertices
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(2)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eVertex),
-        // Binding 3: Mesh halfedges
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(3)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eVertex),
-        // Binding 4: Mesh faces
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(4)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eVertex)
-    };
-
-    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
-        .setBindings(bindings);
-
     try {
-        renderDescriptorSetLayout_.emplace(*raiiDevice_, layoutInfo);
+        VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+            .addUniformBuffer(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 1, 0)
+            .addStorageBuffer(VK_SHADER_STAGE_VERTEX_BIT, 1, 1)
+            .addStorageBuffer(VK_SHADER_STAGE_VERTEX_BIT, 1, 2)
+            .addStorageBuffer(VK_SHADER_STAGE_VERTEX_BIT, 1, 3)
+            .addStorageBuffer(VK_SHADER_STAGE_VERTEX_BIT, 1, 4)
+            .build();
+        renderDescriptorSetLayout_.emplace(*raiiDevice_, rawLayout);
     } catch (const vk::SystemError& e) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create render descriptor set layout: %s", e.what());
         return false;

--- a/src/water/OceanFFT.cpp
+++ b/src/water/OceanFFT.cpp
@@ -324,27 +324,13 @@ bool OceanFFT::createComputePipelines() {
     // Spectrum Generation Pipeline
     // =========================================================================
     {
-        std::array<vk::DescriptorSetLayoutBinding, 3> spectrumBindings = {
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_SPECTRUM_H0)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_SPECTRUM_OMEGA)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_SPECTRUM_PARAMS)
-                .setDescriptorType(vk::DescriptorType::eUniformBuffer)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-        };
-
-        auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(spectrumBindings);
         try {
-            spectrumDescLayout_.emplace(*raiiDevice_, layoutInfo);
+            VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_SPECTRUM_H0)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_SPECTRUM_OMEGA)
+                .addUniformBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_SPECTRUM_PARAMS)
+                .build();
+            spectrumDescLayout_.emplace(*raiiDevice_, rawLayout);
         } catch (const vk::SystemError& e) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create spectrum descriptor layout: %s", e.what());
             return false;
@@ -369,37 +355,15 @@ bool OceanFFT::createComputePipelines() {
     // Time Evolution Pipeline
     // =========================================================================
     {
-        std::array<vk::DescriptorSetLayoutBinding, 5> timeBindings = {
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_HKT_DY)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_HKT_DX)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_HKT_DZ)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_H0_INPUT)
-                .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_OMEGA_INPUT)
-                .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-        };
-
-        auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(timeBindings);
         try {
-            timeEvolutionDescLayout_.emplace(*raiiDevice_, layoutInfo);
+            VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_HKT_DY)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_HKT_DX)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_HKT_DZ)
+                .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_H0_INPUT)
+                .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_OMEGA_INPUT)
+                .build();
+            timeEvolutionDescLayout_.emplace(*raiiDevice_, rawLayout);
         } catch (const vk::SystemError& e) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create time evolution descriptor layout: %s", e.what());
             return false;
@@ -425,22 +389,12 @@ bool OceanFFT::createComputePipelines() {
     // FFT Pipeline
     // =========================================================================
     {
-        std::array<vk::DescriptorSetLayoutBinding, 2> fftBindings = {
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_FFT_INPUT)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_FFT_OUTPUT)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-        };
-
-        auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(fftBindings);
         try {
-            fftDescLayout_.emplace(*raiiDevice_, layoutInfo);
+            VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_FFT_INPUT)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_FFT_OUTPUT)
+                .build();
+            fftDescLayout_.emplace(*raiiDevice_, rawLayout);
         } catch (const vk::SystemError& e) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create FFT descriptor layout: %s", e.what());
             return false;
@@ -466,42 +420,16 @@ bool OceanFFT::createComputePipelines() {
     // Displacement Generation Pipeline
     // =========================================================================
     {
-        std::array<vk::DescriptorSetLayoutBinding, 6> dispBindings = {
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_DISP_DY)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_DISP_DX)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_DISP_DZ)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_DISP_OUTPUT)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_NORMAL_OUTPUT)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-            vk::DescriptorSetLayoutBinding{}
-                .setBinding(Bindings::OCEAN_FOAM_OUTPUT)
-                .setDescriptorType(vk::DescriptorType::eStorageImage)
-                .setDescriptorCount(1)
-                .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-        };
-
-        auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(dispBindings);
         try {
-            displacementDescLayout_.emplace(*raiiDevice_, layoutInfo);
+            VkDescriptorSetLayout rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_DISP_DY)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_DISP_DX)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_DISP_DZ)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_DISP_OUTPUT)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_NORMAL_OUTPUT)
+                .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, Bindings::OCEAN_FOAM_OUTPUT)
+                .build();
+            displacementDescLayout_.emplace(*raiiDevice_, rawLayout);
         } catch (const vk::SystemError& e) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create displacement descriptor layout: %s", e.what());
             return false;

--- a/src/water/WaterDisplacement.cpp
+++ b/src/water/WaterDisplacement.cpp
@@ -165,32 +165,14 @@ bool WaterDisplacement::createParticleBuffer() {
 
 bool WaterDisplacement::createComputePipeline() {
     // Descriptor set layout
-    std::array<vk::DescriptorSetLayoutBinding, 3> bindings = {
-        // Binding 0: Current displacement map (storage image, write)
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(0)
-            .setDescriptorType(vk::DescriptorType::eStorageImage)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 1: Previous displacement map (sampled image, read)
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(1)
-            .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute),
-        // Binding 2: Particle buffer (SSBO)
-        vk::DescriptorSetLayoutBinding{}
-            .setBinding(2)
-            .setDescriptorType(vk::DescriptorType::eStorageBuffer)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute)
-    };
-
-    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
-        .setBindings(bindings);
-
+    VkDescriptorSetLayout rawLayout = VK_NULL_HANDLE;
     try {
-        descriptorSetLayout_.emplace(*raiiDevice_, layoutInfo);
+        rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+            .addStorageImage(VK_SHADER_STAGE_COMPUTE_BIT, 1, 0)
+            .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT, 1, 1)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 2)
+            .build();
+        descriptorSetLayout_.emplace(*raiiDevice_, rawLayout);
     } catch (const vk::SystemError& e) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create displacement descriptor set layout: %s", e.what());
         return false;

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -158,26 +158,15 @@ bool WaterTileCull::createComputePipeline() {
     // 2: Counter buffer (storage)
     // 3: Indirect draw buffer (storage)
 
-    auto makeComputeBinding = [](uint32_t binding, vk::DescriptorType type) {
-        return vk::DescriptorSetLayoutBinding{}
-            .setBinding(binding)
-            .setDescriptorType(type)
-            .setDescriptorCount(1)
-            .setStageFlags(vk::ShaderStageFlagBits::eCompute);
-    };
-
-    std::array<vk::DescriptorSetLayoutBinding, 4> bindings = {
-        makeComputeBinding(0, vk::DescriptorType::eCombinedImageSampler),
-        makeComputeBinding(1, vk::DescriptorType::eStorageBuffer),
-        makeComputeBinding(2, vk::DescriptorType::eStorageBuffer),
-        makeComputeBinding(3, vk::DescriptorType::eStorageBuffer)
-    };
-
-    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
-        .setBindings(bindings);
-
+    VkDescriptorSetLayout rawLayout = VK_NULL_HANDLE;
     try {
-        descriptorSetLayout_.emplace(*raiiDevice_, layoutInfo);
+        rawLayout = DescriptorManager::DescriptorLayoutBuilder(device)
+            .addCombinedImageSampler(VK_SHADER_STAGE_COMPUTE_BIT, 1, 0)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 1)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 2)
+            .addStorageBuffer(VK_SHADER_STAGE_COMPUTE_BIT, 1, 3)
+            .build();
+        descriptorSetLayout_.emplace(*raiiDevice_, rawLayout);
     } catch (const vk::SystemError& e) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create tile cull descriptor set layout: %s", e.what());
         return false;


### PR DESCRIPTION
### Motivation
- Provide an immutable, chainable API for building Vulkan descriptor set layouts so callers can compose layout definitions without mutating shared builders.
- Allow optional explicit binding indices while keeping automatic next-binding allocation to reduce boilerplate when declaring many bindings.
- Add convenient helpers for common descriptor types (storage image, combined image sampler, uniform/storage buffers) and keep error handling using existing SDL logging patterns.

### Description
- Introduced `DescriptorManager::DescriptorLayoutBuilder` in `src/core/material/DescriptorManager.h/.cpp` with an immutable API that returns new instances from `add*` calls, supports optional explicit `binding` arguments, and provides chainable helpers: `addUniformBuffer`, `addDynamicUniformBuffer`, `addStorageBuffer`, `addCombinedImageSampler`, `addStorageImage`, and generic `addBinding` overloads.
- Replaced manual inline `VkDescriptorSetLayoutBinding` arrays with builder usage in the following files: `src/water/FoamBuffer.cpp`, `src/water/OceanFFT.cpp`, `src/water/WaterTileCull.cpp`, `src/water/WaterDisplacement.cpp`, and `src/subdivision/CatmullClarkSystem.cpp` so layouts are now constructed with the new builder and explicit binding indices where required.
- Preserved and used existing SDL logging for error reporting on descriptor layout creation failures (e.g., `SDL_LogError`), keeping error handling consistent.

### Testing
- Attempted automated build with `cmake --preset debug && cmake --build build/debug`, which failed due to the environment missing the vcpkg toolchain (`/scripts/buildsystems/vcpkg.cmake`) and a Ninja build program, so no successful automated build artifacts were produced.
- No other automated tests were run as part of this change because the project could not be configured/built in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971cecd9b308327876b9496ea9e8d73)