### PR TITLE
Introduce Fruit DI module for renderer subsystems and refactor init flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(fastgltf CONFIG REQUIRED)
 find_package(unofficial-openfbx CONFIG REQUIRED)
 find_package(lodepng CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
+find_package(fruit CONFIG REQUIRED)
 
 find_path(STB_INCLUDE_DIRS "stb_image.h")
 
@@ -45,6 +46,7 @@ set(SOURCES
     src/core/ResizeCoordinator.cpp
     src/core/UBOBuilder.cpp
     src/core/RendererSystems.cpp
+    src/core/di/RendererComponent.cpp
     src/core/InitContext.cpp
     src/core/RenderingInfrastructure.cpp
     src/core/DescriptorInfrastructure.cpp
@@ -293,6 +295,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     unoffical::openfbx::openfbx
     lodepng
     nlohmann_json::nlohmann_json
+    fruit::fruit
 )
 
 # Enable Jolt Physics debug renderer for visualization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
     src/core/DoubleBufferedBuffer.cpp
     src/core/DynamicUniformBuffer.cpp
     src/core/DoubleBufferedImage.cpp
+    src/core/GlobalBufferManager.cpp
     src/core/FrameIndexedBuffers.cpp
     src/core/TripleBuffering.cpp
     src/core/Texture.cpp

--- a/src/animation/SkinnedMeshRenderer.h
+++ b/src/animation/SkinnedMeshRenderer.h
@@ -18,6 +18,7 @@
 #include "PerFrameBuffer.h"
 
 class AnimatedCharacter;
+class VulkanContext;
 
 // Skinned mesh renderer - handles GPU skinning pipeline and bone matrices
 class SkinnedMeshRenderer {
@@ -73,6 +74,12 @@ public:
      * Returns nullptr on failure.
      */
     static std::unique_ptr<SkinnedMeshRenderer> create(const InitInfo& info);
+    static std::unique_ptr<SkinnedMeshRenderer> createWithDependencies(
+        VulkanContext& vulkanContext,
+        DescriptorManager::Pool* descriptorPool,
+        VkRenderPass hdrRenderPass,
+        uint32_t framesInFlight,
+        const std::string& resourcePath);
 
 
     ~SkinnedMeshRenderer();

--- a/src/core/GlobalBufferManager.cpp
+++ b/src/core/GlobalBufferManager.cpp
@@ -1,0 +1,13 @@
+#include "GlobalBufferManager.h"
+#include "VulkanContext.h"
+
+std::unique_ptr<GlobalBufferManager> GlobalBufferManager::createWithDependencies(
+    VulkanContext& vulkanContext,
+    uint32_t frameCount,
+    uint32_t maxBones) {
+    return GlobalBufferManager::create(
+        vulkanContext.getAllocator(),
+        vulkanContext.getVkPhysicalDevice(),
+        frameCount,
+        maxBones);
+}

--- a/src/core/GlobalBufferManager.h
+++ b/src/core/GlobalBufferManager.h
@@ -13,6 +13,8 @@
 #include "Light.h"
 #include "UBOs.h"
 
+class VulkanContext;
+
 /**
  * GlobalBufferManager - Manages per-frame shared GPU buffers
  *
@@ -43,6 +45,9 @@ public:
         }
         return manager;
     }
+    static std::unique_ptr<GlobalBufferManager> createWithDependencies(VulkanContext& vulkanContext,
+                                                                        uint32_t frameCount,
+                                                                        uint32_t maxBones = 128);
 
 
     ~GlobalBufferManager() {

--- a/src/core/di/RendererComponent.cpp
+++ b/src/core/di/RendererComponent.cpp
@@ -108,26 +108,12 @@ std::unique_ptr<SceneManager> provideSceneManager(
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SceneManager requires a valid TerrainSystem");
         return nullptr;
     }
-
-    SceneBuilder::InitInfo sceneInfo{};
-    sceneInfo.allocator = vulkanContext.getAllocator();
-    sceneInfo.device = vulkanContext.getVkDevice();
-    sceneInfo.commandPool = vulkanContext.getCommandPool();
-    sceneInfo.graphicsQueue = vulkanContext.getVkGraphicsQueue();
-    sceneInfo.physicalDevice = vulkanContext.getVkPhysicalDevice();
-    sceneInfo.resourcePath = resourcePath;
-    sceneInfo.assetRegistry = assetRegistry;
-    sceneInfo.getTerrainHeight = [terrain = terrainSystem.get()](float x, float z) {
-        return terrain ? terrain->getHeightAt(x, z) : 0.0f;
-    };
-    sceneInfo.sceneOrigin = sceneOrigin;
-    sceneInfo.deferRenderables = true;
-
-    auto sceneManager = SceneManager::create(sceneInfo);
-    if (!sceneManager) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SceneManager");
-    }
-    return sceneManager;
+    return SceneManager::createWithDependencies(
+        vulkanContext,
+        *terrainSystem,
+        assetRegistry,
+        resourcePath,
+        sceneOrigin);
 }
 
 CoreResources provideCoreResources(

--- a/src/core/di/RendererComponent.cpp
+++ b/src/core/di/RendererComponent.cpp
@@ -3,7 +3,6 @@
 #include <SDL3/SDL_log.h>
 
 #include "DebugLineSystem.h"
-#include "DescriptorInfrastructure.h"
 #include "GlobalBufferManager.h"
 #include "HiZSystem.h"
 #include "Profiler.h"
@@ -39,25 +38,12 @@ std::unique_ptr<SkinnedMeshRenderer> provideSkinnedMeshRenderer(
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SkinnedMeshRenderer requires a valid PostProcessSystem");
         return nullptr;
     }
-
-    SkinnedMeshRenderer::InitInfo info{};
-    info.device = vulkanContext.getVkDevice();
-    info.raiiDevice = &vulkanContext.getRaiiDevice();
-    info.allocator = vulkanContext.getAllocator();
-    info.descriptorPool = descriptorPool;
-    info.renderPass = postProcessBundle->postProcess->getHDRRenderPass();
-    info.extent = vulkanContext.getVkSwapchainExtent();
-    info.shaderPath = resourcePath + "/shaders";
-    info.framesInFlight = framesInFlight;
-    info.addCommonBindings = [](DescriptorManager::LayoutBuilder& builder) {
-        DescriptorInfrastructure::addCommonDescriptorBindings(builder);
-    };
-
-    auto skinnedMeshRenderer = SkinnedMeshRenderer::create(info);
-    if (!skinnedMeshRenderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SkinnedMeshRenderer");
-    }
-    return skinnedMeshRenderer;
+    return SkinnedMeshRenderer::createWithDependencies(
+        vulkanContext,
+        descriptorPool,
+        postProcessBundle->postProcess->getHDRRenderPass(),
+        framesInFlight,
+        resourcePath);
 }
 
 std::unique_ptr<GlobalBufferManager> provideGlobalBufferManager(

--- a/src/core/di/RendererComponent.cpp
+++ b/src/core/di/RendererComponent.cpp
@@ -1,0 +1,390 @@
+#include "di/RendererComponent.h"
+
+#include <SDL3/SDL_log.h>
+
+#include "DebugLineSystem.h"
+#include "DescriptorInfrastructure.h"
+#include "GlobalBufferManager.h"
+#include "HiZSystem.h"
+#include "Profiler.h"
+#include "SceneManager.h"
+#include "SkinnedMeshRenderer.h"
+#include "TerrainFactory.h"
+#include "VulkanContext.h"
+#include "asset/AssetRegistry.h"
+#include "lighting/ShadowSystem.h"
+
+namespace core::di {
+namespace {
+std::optional<PostProcessSystem::Bundle> providePostProcessBundle(
+    const InitContext& initContext,
+    VulkanContext& vulkanContext) {
+    VkFormat swapchainImageFormat = static_cast<VkFormat>(vulkanContext.getVkSwapchainImageFormat());
+    auto bundle = PostProcessSystem::createWithDependencies(initContext,
+                                                            vulkanContext.getRenderPass(),
+                                                            swapchainImageFormat);
+    if (!bundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize PostProcessSystem bundle");
+    }
+    return bundle;
+}
+
+std::unique_ptr<SkinnedMeshRenderer> provideSkinnedMeshRenderer(
+    const std::optional<PostProcessSystem::Bundle>& postProcessBundle,
+    VulkanContext& vulkanContext,
+    DescriptorManager::Pool* descriptorPool,
+    uint32_t framesInFlight,
+    const std::string& resourcePath) {
+    if (!postProcessBundle || !postProcessBundle->postProcess) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SkinnedMeshRenderer requires a valid PostProcessSystem");
+        return nullptr;
+    }
+
+    SkinnedMeshRenderer::InitInfo info{};
+    info.device = vulkanContext.getVkDevice();
+    info.raiiDevice = &vulkanContext.getRaiiDevice();
+    info.allocator = vulkanContext.getAllocator();
+    info.descriptorPool = descriptorPool;
+    info.renderPass = postProcessBundle->postProcess->getHDRRenderPass();
+    info.extent = vulkanContext.getVkSwapchainExtent();
+    info.shaderPath = resourcePath + "/shaders";
+    info.framesInFlight = framesInFlight;
+    info.addCommonBindings = [](DescriptorManager::LayoutBuilder& builder) {
+        DescriptorInfrastructure::addCommonDescriptorBindings(builder);
+    };
+
+    auto skinnedMeshRenderer = SkinnedMeshRenderer::create(info);
+    if (!skinnedMeshRenderer) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SkinnedMeshRenderer");
+    }
+    return skinnedMeshRenderer;
+}
+
+std::unique_ptr<GlobalBufferManager> provideGlobalBufferManager(
+    VulkanContext& vulkanContext,
+    uint32_t framesInFlight) {
+    auto buffers = GlobalBufferManager::create(vulkanContext.getAllocator(),
+                                               vulkanContext.getVkPhysicalDevice(),
+                                               framesInFlight);
+    if (!buffers) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize GlobalBufferManager");
+    }
+    return buffers;
+}
+
+std::unique_ptr<ShadowSystem> provideShadowSystem(
+    const InitContext& initContext,
+    const std::unique_ptr<SkinnedMeshRenderer>& skinnedMesh,
+    VkDescriptorSetLayout mainDescriptorSetLayout) {
+    if (!skinnedMesh) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ShadowSystem requires a valid SkinnedMeshRenderer");
+        return nullptr;
+    }
+    auto shadowSystem = ShadowSystem::create(initContext,
+                                             mainDescriptorSetLayout,
+                                             skinnedMesh->getDescriptorSetLayout());
+    if (!shadowSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize ShadowSystem");
+    }
+    return shadowSystem;
+}
+
+std::unique_ptr<TerrainSystem> provideTerrainSystem(
+    const InitContext& initContext,
+    const std::optional<PostProcessSystem::Bundle>& postProcessBundle,
+    const std::unique_ptr<ShadowSystem>& shadowSystem,
+    const std::string& resourcePath) {
+    if (!postProcessBundle || !postProcessBundle->postProcess || !shadowSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TerrainSystem requires PostProcessSystem and ShadowSystem");
+        return nullptr;
+    }
+
+    TerrainFactory::Config terrainFactoryConfig{};
+    terrainFactoryConfig.hdrRenderPass = postProcessBundle->postProcess->getHDRRenderPass();
+    terrainFactoryConfig.shadowRenderPass = shadowSystem->getShadowRenderPass();
+    terrainFactoryConfig.shadowMapSize = shadowSystem->getShadowMapSize();
+    terrainFactoryConfig.resourcePath = resourcePath;
+
+    auto terrainSystem = TerrainFactory::create(initContext, terrainFactoryConfig);
+    if (!terrainSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize TerrainSystem");
+    }
+    return terrainSystem;
+}
+
+std::unique_ptr<SceneManager> provideSceneManager(
+    const std::unique_ptr<TerrainSystem>& terrainSystem,
+    VulkanContext& vulkanContext,
+    AssetRegistry* assetRegistry,
+    const std::string& resourcePath,
+    const glm::vec2& sceneOrigin) {
+    if (!terrainSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SceneManager requires a valid TerrainSystem");
+        return nullptr;
+    }
+
+    SceneBuilder::InitInfo sceneInfo{};
+    sceneInfo.allocator = vulkanContext.getAllocator();
+    sceneInfo.device = vulkanContext.getVkDevice();
+    sceneInfo.commandPool = vulkanContext.getCommandPool();
+    sceneInfo.graphicsQueue = vulkanContext.getVkGraphicsQueue();
+    sceneInfo.physicalDevice = vulkanContext.getVkPhysicalDevice();
+    sceneInfo.resourcePath = resourcePath;
+    sceneInfo.assetRegistry = assetRegistry;
+    sceneInfo.getTerrainHeight = [terrain = terrainSystem.get()](float x, float z) {
+        return terrain ? terrain->getHeightAt(x, z) : 0.0f;
+    };
+    sceneInfo.sceneOrigin = sceneOrigin;
+    sceneInfo.deferRenderables = true;
+
+    auto sceneManager = SceneManager::create(sceneInfo);
+    if (!sceneManager) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create SceneManager");
+    }
+    return sceneManager;
+}
+
+CoreResources provideCoreResources(
+    const std::optional<PostProcessSystem::Bundle>& postProcessBundle,
+    const std::unique_ptr<ShadowSystem>& shadowSystem,
+    const std::unique_ptr<TerrainSystem>& terrainSystem,
+    uint32_t framesInFlight) {
+    if (!postProcessBundle || !postProcessBundle->postProcess || !shadowSystem || !terrainSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "CoreResources requires PostProcess, Shadow, and Terrain systems");
+        return {};
+    }
+
+    return CoreResources::collect(*postProcessBundle->postProcess, *shadowSystem, *terrainSystem, framesInFlight);
+}
+
+std::optional<SnowSystemGroup::Bundle> provideSnowBundle(
+    const InitContext& initContext,
+    const CoreResources& coreResources) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Snow systems require valid core resources");
+        return std::nullopt;
+    }
+
+    SnowSystemGroup::CreateDeps snowDeps{initContext, coreResources.hdr.renderPass};
+    auto snowBundle = SnowSystemGroup::createAll(snowDeps);
+    if (!snowBundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize SnowSystemGroup");
+    }
+    return snowBundle;
+}
+
+std::optional<VegetationSystemGroup::Bundle> provideVegetationBundle(
+    const InitContext& initContext,
+    const CoreResources& coreResources,
+    const ScatterSystemFactory::RockConfig& rockConfig) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Vegetation systems require valid core resources");
+        return std::nullopt;
+    }
+
+    VegetationSystemGroup::CreateDeps vegDeps{
+        initContext,
+        coreResources.hdr.renderPass,
+        coreResources.shadow.renderPass,
+        coreResources.shadow.mapSize,
+        coreResources.terrain.size,
+        coreResources.terrain.getHeightAt,
+        rockConfig
+    };
+
+    auto vegBundle = VegetationSystemGroup::createAll(vegDeps);
+    if (!vegBundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize VegetationSystemGroup");
+    }
+    return vegBundle;
+}
+
+std::optional<AtmosphereSystemGroup::Bundle> provideAtmosphereBundle(
+    const InitContext& initContext,
+    const CoreResources& coreResources,
+    const std::unique_ptr<GlobalBufferManager>& globalBuffers) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Atmosphere systems require valid core resources");
+        return std::nullopt;
+    }
+    if (!globalBuffers) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Atmosphere systems require GlobalBufferManager");
+        return std::nullopt;
+    }
+
+    AtmosphereSystemGroup::CreateDeps atmosDeps{
+        initContext,
+        coreResources.hdr.renderPass,
+        coreResources.shadow.cascadeView,
+        coreResources.shadow.sampler,
+        globalBuffers->lightBuffers.buffers
+    };
+
+    auto atmosBundle = AtmosphereSystemGroup::createAll(atmosDeps);
+    if (!atmosBundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize AtmosphereSystemGroup");
+    }
+    return atmosBundle;
+}
+
+std::optional<GeometrySystemGroup::Bundle> provideGeometryBundle(
+    const InitContext& initContext,
+    const CoreResources& coreResources,
+    const std::unique_ptr<GlobalBufferManager>& globalBuffers,
+    const std::string& resourcePath) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Geometry systems require valid core resources");
+        return std::nullopt;
+    }
+    if (!globalBuffers) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Geometry systems require GlobalBufferManager");
+        return std::nullopt;
+    }
+
+    GeometrySystemGroup::CreateDeps geomDeps{
+        initContext,
+        coreResources.hdr.renderPass,
+        globalBuffers->uniformBuffers.buffers,
+        resourcePath,
+        coreResources.terrain.getHeightAt
+    };
+
+    auto geomBundle = GeometrySystemGroup::createAll(geomDeps);
+    if (!geomBundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize GeometrySystemGroup");
+    }
+    return geomBundle;
+}
+
+std::unique_ptr<HiZSystem> provideHiZSystem(
+    const InitContext& initContext,
+    VulkanContext& vulkanContext) {
+    auto hiZSystem = HiZSystem::create(initContext, vulkanContext.getDepthFormat());
+    if (!hiZSystem) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Warning: Hi-Z system initialization failed, occlusion culling disabled");
+    }
+    return hiZSystem;
+}
+
+std::unique_ptr<Profiler> provideProfiler(
+    VulkanContext& vulkanContext,
+    uint32_t framesInFlight) {
+    return Profiler::create(vulkanContext.getVkDevice(), vulkanContext.getVkPhysicalDevice(), framesInFlight);
+}
+
+std::optional<WaterSystemGroup::Bundle> provideWaterBundle(
+    const InitContext& initContext,
+    const CoreResources& coreResources,
+    const std::string& resourcePath) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Water systems require valid core resources");
+        return std::nullopt;
+    }
+
+    WaterSystemGroup::CreateDeps waterDeps{
+        initContext,
+        coreResources.hdr.renderPass,
+        65536.0f,
+        resourcePath
+    };
+
+    auto waterBundle = WaterSystemGroup::createAll(waterDeps);
+    if (!waterBundle) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize WaterSystemGroup");
+    }
+    return waterBundle;
+}
+
+std::unique_ptr<DebugLineSystem> provideDebugLineSystem(
+    const InitContext& initContext,
+    const CoreResources& coreResources) {
+    if (!coreResources.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "DebugLineSystem requires valid core resources");
+        return nullptr;
+    }
+
+    auto debugLineSystem = DebugLineSystem::create(initContext, coreResources.hdr.renderPass);
+    if (!debugLineSystem) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create debug line system");
+    }
+    return debugLineSystem;
+}
+
+RendererSubsystemBundle provideRendererSubsystemBundle(
+    std::optional<PostProcessSystem::Bundle> postProcess,
+    std::unique_ptr<SkinnedMeshRenderer> skinnedMesh,
+    std::unique_ptr<GlobalBufferManager> globalBuffers,
+    std::unique_ptr<ShadowSystem> shadow,
+    std::unique_ptr<TerrainSystem> terrain,
+    std::unique_ptr<SceneManager> scene,
+    CoreResources core,
+    std::optional<SnowSystemGroup::Bundle> snow,
+    std::optional<VegetationSystemGroup::Bundle> vegetation,
+    std::optional<AtmosphereSystemGroup::Bundle> atmosphere,
+    std::optional<GeometrySystemGroup::Bundle> geometry,
+    std::unique_ptr<HiZSystem> hiZ,
+    std::unique_ptr<Profiler> profiler,
+    std::optional<WaterSystemGroup::Bundle> water,
+    std::unique_ptr<DebugLineSystem> debugLine) {
+    RendererSubsystemBundle bundle{};
+    bundle.postProcess = std::move(postProcess);
+    bundle.skinnedMesh = std::move(skinnedMesh);
+    bundle.globalBuffers = std::move(globalBuffers);
+    bundle.shadow = std::move(shadow);
+    bundle.terrain = std::move(terrain);
+    bundle.scene = std::move(scene);
+    bundle.core = std::move(core);
+    bundle.snow = std::move(snow);
+    bundle.vegetation = std::move(vegetation);
+    bundle.atmosphere = std::move(atmosphere);
+    bundle.geometry = std::move(geometry);
+    bundle.hiZ = std::move(hiZ);
+    bundle.profiler = std::move(profiler);
+    bundle.water = std::move(water);
+    bundle.debugLine = std::move(debugLine);
+    return bundle;
+}
+} // namespace
+
+fruit::Component<RendererSubsystemBundle> getRendererComponent(
+    VulkanContext& vulkanContext,
+    const InitContext& initContext,
+    const Renderer::Config& rendererConfig,
+    const std::string& resourcePath,
+    uint32_t framesInFlight,
+    DescriptorManager::Pool* descriptorPool,
+    VkDescriptorSetLayout mainDescriptorSetLayout,
+    const ScatterSystemFactory::RockConfig& rockConfig,
+    AssetRegistry* assetRegistry,
+    const glm::vec2& sceneOrigin) {
+    return fruit::createComponent()
+        .bindInstance(vulkanContext)
+        .bindInstance(initContext)
+        .bindInstance(rendererConfig)
+        .bindInstance(resourcePath)
+        .bindInstance(framesInFlight)
+        .bindInstance(descriptorPool)
+        .bindInstance(mainDescriptorSetLayout)
+        .bindInstance(rockConfig)
+        .bindInstance(assetRegistry)
+        .bindInstance(sceneOrigin)
+        .registerProvider(providePostProcessBundle)
+        .registerProvider(provideSkinnedMeshRenderer)
+        .registerProvider(provideGlobalBufferManager)
+        .registerProvider(provideShadowSystem)
+        .registerProvider(provideTerrainSystem)
+        .registerProvider(provideSceneManager)
+        .registerProvider(provideCoreResources)
+        .registerProvider(provideSnowBundle)
+        .registerProvider(provideVegetationBundle)
+        .registerProvider(provideAtmosphereBundle)
+        .registerProvider(provideGeometryBundle)
+        .registerProvider(provideHiZSystem)
+        .registerProvider(provideProfiler)
+        .registerProvider(provideWaterBundle)
+        .registerProvider(provideDebugLineSystem)
+        .registerProvider(provideRendererSubsystemBundle);
+}
+
+} // namespace core::di

--- a/src/core/di/RendererComponent.cpp
+++ b/src/core/di/RendererComponent.cpp
@@ -49,9 +49,7 @@ std::unique_ptr<SkinnedMeshRenderer> provideSkinnedMeshRenderer(
 std::unique_ptr<GlobalBufferManager> provideGlobalBufferManager(
     VulkanContext& vulkanContext,
     uint32_t framesInFlight) {
-    auto buffers = GlobalBufferManager::create(vulkanContext.getAllocator(),
-                                               vulkanContext.getVkPhysicalDevice(),
-                                               framesInFlight);
+    auto buffers = GlobalBufferManager::createWithDependencies(vulkanContext, framesInFlight);
     if (!buffers) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize GlobalBufferManager");
     }
@@ -66,9 +64,10 @@ std::unique_ptr<ShadowSystem> provideShadowSystem(
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ShadowSystem requires a valid SkinnedMeshRenderer");
         return nullptr;
     }
-    auto shadowSystem = ShadowSystem::create(initContext,
-                                             mainDescriptorSetLayout,
-                                             skinnedMesh->getDescriptorSetLayout());
+    auto shadowSystem = ShadowSystem::createWithDependencies(
+        initContext,
+        mainDescriptorSetLayout,
+        skinnedMesh.get());
     if (!shadowSystem) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize ShadowSystem");
     }

--- a/src/core/di/RendererComponent.h
+++ b/src/core/di/RendererComponent.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <fruit/fruit.h>
+#include <optional>
+#include <string>
+
+#include <glm/glm.hpp>
+
+#include "CoreResources.h"
+#include "DescriptorManager.h"
+#include "Renderer.h"
+#include "atmosphere/AtmosphereSystemGroup.h"
+#include "atmosphere/SnowSystemGroup.h"
+#include "postprocess/PostProcessSystem.h"
+#include "subdivision/GeometrySystemGroup.h"
+#include "vegetation/ScatterSystemFactory.h"
+#include "vegetation/VegetationSystemGroup.h"
+#include "water/WaterSystemGroup.h"
+
+class AssetRegistry;
+class DebugLineSystem;
+class GlobalBufferManager;
+class HiZSystem;
+class Profiler;
+class SceneManager;
+class ShadowSystem;
+class SkinnedMeshRenderer;
+class TerrainSystem;
+class VulkanContext;
+
+namespace core::di {
+
+struct RendererSubsystemBundle {
+    std::optional<PostProcessSystem::Bundle> postProcess;
+    std::unique_ptr<SkinnedMeshRenderer> skinnedMesh;
+    std::unique_ptr<GlobalBufferManager> globalBuffers;
+    std::unique_ptr<ShadowSystem> shadow;
+    std::unique_ptr<TerrainSystem> terrain;
+    std::unique_ptr<SceneManager> scene;
+    CoreResources core;
+    std::optional<SnowSystemGroup::Bundle> snow;
+    std::optional<VegetationSystemGroup::Bundle> vegetation;
+    std::optional<AtmosphereSystemGroup::Bundle> atmosphere;
+    std::optional<GeometrySystemGroup::Bundle> geometry;
+    std::unique_ptr<HiZSystem> hiZ;
+    std::unique_ptr<Profiler> profiler;
+    std::optional<WaterSystemGroup::Bundle> water;
+    std::unique_ptr<DebugLineSystem> debugLine;
+};
+
+fruit::Component<RendererSubsystemBundle> getRendererComponent(
+    VulkanContext& vulkanContext,
+    const InitContext& initContext,
+    const Renderer::Config& rendererConfig,
+    const std::string& resourcePath,
+    uint32_t framesInFlight,
+    DescriptorManager::Pool* descriptorPool,
+    VkDescriptorSetLayout mainDescriptorSetLayout,
+    const ScatterSystemFactory::RockConfig& rockConfig,
+    AssetRegistry* assetRegistry,
+    const glm::vec2& sceneOrigin);
+
+} // namespace core::di

--- a/src/lighting/ShadowSystem.cpp
+++ b/src/lighting/ShadowSystem.cpp
@@ -4,6 +4,7 @@
 #include "Mesh.h"
 #include "PipelineBuilder.h"
 #include "GraphicsPipelineFactory.h"
+#include "SkinnedMeshRenderer.h"
 #include "debug/QueueSubmitDiagnostics.h"
 #include "shaders/bindings.h"
 #include <vulkan/vulkan.hpp>
@@ -36,6 +37,17 @@ std::unique_ptr<ShadowSystem> ShadowSystem::create(const InitContext& ctx,
     info.shaderPath = ctx.shaderPath;
     info.framesInFlight = ctx.framesInFlight;
     return create(info);
+}
+
+std::unique_ptr<ShadowSystem> ShadowSystem::createWithDependencies(
+    const InitContext& ctx,
+    VkDescriptorSetLayout mainDescriptorSetLayout,
+    const SkinnedMeshRenderer* skinnedRenderer) {
+    VkDescriptorSetLayout skinnedLayout = VK_NULL_HANDLE;
+    if (skinnedRenderer) {
+        skinnedLayout = skinnedRenderer->getDescriptorSetLayout();
+    }
+    return ShadowSystem::create(ctx, mainDescriptorSetLayout, skinnedLayout);
 }
 
 // Destructor

--- a/src/lighting/ShadowSystem.h
+++ b/src/lighting/ShadowSystem.h
@@ -17,6 +17,8 @@
 #include "SkinnedMesh.h"
 #include "VulkanHelpers.h"
 
+class SkinnedMeshRenderer;
+
 // Number of cascades for CSM
 static constexpr uint32_t NUM_SHADOW_CASCADES = 4;
 
@@ -54,6 +56,10 @@ public:
     static std::unique_ptr<ShadowSystem> create(const InitContext& ctx,
                                                  VkDescriptorSetLayout mainDescriptorSetLayout,
                                                  VkDescriptorSetLayout skinnedDescriptorSetLayout = VK_NULL_HANDLE);
+    static std::unique_ptr<ShadowSystem> createWithDependencies(
+        const InitContext& ctx,
+        VkDescriptorSetLayout mainDescriptorSetLayout,
+        const SkinnedMeshRenderer* skinnedRenderer);
 
     ~ShadowSystem();
 

--- a/src/scene/SceneManager.h
+++ b/src/scene/SceneManager.h
@@ -8,6 +8,10 @@
 #include "PhysicsSystem.h"
 
 // Centralized scene management - handles visual objects, physics bodies, and lighting
+class AssetRegistry;
+class TerrainSystem;
+class VulkanContext;
+
 class SceneManager {
 public:
     // Passkey for controlled construction via make_unique
@@ -19,6 +23,12 @@ public:
      * Returns nullptr on failure.
      */
     static std::unique_ptr<SceneManager> create(SceneBuilder::InitInfo& builderInfo);
+    static std::unique_ptr<SceneManager> createWithDependencies(
+        VulkanContext& vulkanContext,
+        TerrainSystem& terrainSystem,
+        AssetRegistry* assetRegistry,
+        const std::string& resourcePath,
+        const glm::vec2& sceneOrigin);
 
 
     ~SceneManager();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -46,6 +46,7 @@
     "tinyexr",
     "miniz",
     "libarchive",
-    "doctest"
+    "doctest",
+    "fruit"
   ]
 }


### PR DESCRIPTION
### Motivation
- Introduce a dependency-injection layer to centralize construction of renderer subsystems and factories and reduce imperative ctor ordering in `Renderer::initSubsystems`.
- Ensure subsystems that require runtime Vulkan handles (render passes, descriptor layouts, allocators) are provided by the already-initialized `VulkanContext`/`InitContext` rather than constructed in-place.
- Prepare a clearer spot to bind runtime values (resource path, `MAX_FRAMES_IN_FLIGHT`, descriptor pool/layout, etc.) and to expose provider functions for existing factories (`PostProcessSystem::createWithDependencies`, `VegetationSystemGroup::createAll`, `WaterSystemGroup::createAll`, etc.).

### Description
- Add new DI module `src/core/di/RendererComponent.h` and `src/core/di/RendererComponent.cpp` which defines `RendererSubsystemBundle` and registers provider functions that wrap existing factory APIs (post-process, skinned mesh, global buffers, shadow, terrain, scene manager, snow/vegetation/atmosphere/geometry/water bundles, HiZ, profiler, debug line, and core resource collection) via Fruit.
- Refactor `Renderer::initSubsystems` (in `src/core/RendererInitPhases.cpp`) to build a Fruit injector via `core::di::getRendererComponent(...)`, obtain a populated `RendererSubsystemBundle`, move the produced subsystem instances into `systems_`, and then perform the remaining imperative wiring (descriptor creation, `SystemWiring`, deferred terrain objects, water configuration, `RendererCore::init`, etc.).
- Bind runtime values into the component: `VulkanContext&`, `InitContext`, `Renderer::Config`/`resourcePath`, `MAX_FRAMES_IN_FLIGHT`, descriptor pool/layout, `ScatterSystemFactory::RockConfig`, `AssetRegistry*`, and `sceneOrigin` so those are injected into providers instead of recreated inside them.
- Update build config to include Fruit: add `find_package(fruit)` + link `fruit::fruit` in `CMakeLists.txt` and add `"fruit"` to `vcpkg.json` dependencies.

### Testing
- Attempted an automated build via `./build-claude.sh`, which failed during vcpkg bootstrap because the environment could not clone vcpkg (GitHub returned a 403), so a full compile/test was not completed.
- No unit test suite or `ctest` runs were executed post-change because the project build did not complete due to the vcpkg clone failure.
- Manual smoke runs (`./run-debug.sh`) were not performed since the build step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971cf20ac64832787f881c377829cb6)