### PR TITLE
Improve slum placement logic and add DCEL safety checks

### DIFF
--- a/tools/town_generator/src/geom/DCEL.cpp
+++ b/tools/town_generator/src/geom/DCEL.cpp
@@ -210,7 +210,10 @@ std::vector<HalfEdgePtr> DCEL::circumference(const HalfEdgePtr& startEdge,
         if (!face || !face->halfEdge) continue;
 
         auto edge = face->halfEdge;
+        int edgeCount = 0;
+        const int maxEdges = 10000;  // Safety limit for malformed DCEL
         do {
+            if (++edgeCount > maxEdges) break;  // Safety break
             // Edge is on boundary if twin is null or twin's face is not in set
             auto twinEdge = edge->getTwin();
             if (!twinEdge) {
@@ -256,7 +259,14 @@ std::vector<HalfEdgePtr> DCEL::circumference(const HalfEdgePtr& startEdge,
         // Find next boundary edge
         // Walk around the destination vertex to find the next boundary edge
         auto next = current->next;
+        int safetyCounter = 0;
+        const int maxIterations = static_cast<int>(boundaryEdges.size()) * 2 + 100;
         while (next && boundarySet.find(next.get()) == boundarySet.end()) {
+            if (++safetyCounter > maxIterations) {
+                // Safety break to prevent infinite loop in malformed DCEL
+                next = nullptr;
+                break;
+            }
             auto nextTwin = next->getTwin();
             if (nextTwin) {
                 next = nextTwin->next;
@@ -305,7 +315,10 @@ std::vector<std::vector<FacePtr>> DCEL::split(const std::vector<FacePtr>& faceLi
             // Add adjacent faces that are in the face set
             if (current->halfEdge) {
                 auto edge = current->halfEdge;
+                int edgeCount = 0;
+                const int maxEdges = 10000;  // Safety limit
                 do {
+                    if (++edgeCount > maxEdges) break;  // Safety break
                     auto twinEdge = edge->getTwin();
                     if (twinEdge) {
                         auto neighborFace = twinEdge->getFace();


### PR DESCRIPTION
## Summary
This PR enhances the town generator with improved slum placement constraints and adds safety mechanisms to prevent infinite loops in the DCEL (Doubly Connected Edge List) data structure.

## Key Changes

### Slum Placement Logic (City.cpp)
- **Added road proximity check**: Introduced `isNearRoad()` helper function that identifies cells within 5.0 units of any road
- **Wall adjacency validation**: Modified slum candidate selection to only allow slums on sides adjacent to walls or roads, preventing slums from forming on outward-facing sides
- **Improved spatial constraints**: Slums now respect both city walls and road networks when determining valid placement locations

### DCEL Safety Improvements (DCEL.cpp)
- **Circumference method**: Added edge count safety limit (10,000 max) to prevent infinite loops when traversing face boundaries
- **Boundary edge traversal**: Implemented iteration counter with dynamic limit based on boundary edge set size to catch malformed DCEL structures
- **Split method**: Added edge count safety limit (10,000 max) when iterating through face edges during face adjacency checks

## Implementation Details
- The road threshold distance (5.0 units) is configurable via the `roadThreshold` constant
- Safety limits in DCEL are set conservatively to catch issues while allowing legitimate complex geometries
- The slum placement logic now requires cells to be adjacent to either city walls or roads, creating more realistic urban boundaries