### PR TITLE
Add deferred physics collider generation for procedurally generated trees

### DIFF
--- a/src/vegetation/DeferredTerrainObjects.cpp
+++ b/src/vegetation/DeferredTerrainObjects.cpp
@@ -90,6 +90,11 @@ bool DeferredTerrainObjects::tryGenerate(
             config_.shadowSampler
         );
 
+        // Invoke callback to create physics colliders for the generated trees
+        if (onTreesGenerated_) {
+            onTreesGenerated_(*tree);
+        }
+
         SDL_Log("DeferredTerrainObjects: Tree generation complete");
     }
 

--- a/src/vegetation/DeferredTerrainObjects.h
+++ b/src/vegetation/DeferredTerrainObjects.h
@@ -66,6 +66,9 @@ public:
 
     using GetCommonBindingsFunc = std::function<MaterialDescriptorFactory::CommonBindings(uint32_t)>;
 
+    // Callback invoked after trees are generated, passing the TreeSystem with new trees
+    using OnTreesGeneratedFunc = std::function<void(TreeSystem&)>;
+
     /**
      * Factory: Create DeferredTerrainObjects instance.
      */
@@ -76,6 +79,12 @@ public:
      * Must be called before tryGenerate() if detritus needs descriptor sets.
      */
     void setCommonBindingsFunc(GetCommonBindingsFunc func) { getCommonBindings_ = std::move(func); }
+
+    /**
+     * Set callback invoked after trees are generated.
+     * Use this to create physics colliders for the generated trees.
+     */
+    void setOnTreesGeneratedCallback(OnTreesGeneratedFunc func) { onTreesGenerated_ = std::move(func); }
 
     /**
      * Attempt to generate terrain objects if not already done and terrain is ready.
@@ -117,6 +126,7 @@ private:
 
     Config config_;
     GetCommonBindingsFunc getCommonBindings_;
+    OnTreesGeneratedFunc onTreesGenerated_;
     bool generated_ = false;
     bool generating_ = false;
 };


### PR DESCRIPTION
## Summary
This PR adds support for creating physics colliders for trees that are procedurally generated after initial scene setup. Previously, colliders were only created for trees present during application initialization, leaving dynamically generated forest/woods trees without collision detection.

## Key Changes
- **DeferredTerrainObjects**: Added `OnTreesGeneratedFunc` callback mechanism to notify when trees have been generated
  - New `setOnTreesGeneratedCallback()` method to register a callback
  - Callback is invoked after tree generation completes in `tryGenerate()`
  
- **Application initialization**: Implemented deferred collider generation
  - Track count of trees with colliders after initial setup
  - Register callback with `DeferredTerrainObjects` to handle newly generated trees
  - Create compound capsule colliders for deferred trees using the same configuration as initial trees
  - Log statistics on newly created colliders

## Implementation Details
- The callback captures `treesWithColliders` count to identify which trees are new
- Only processes trees added after initial setup (index >= `treesWithColliders`)
- Reuses existing `TreeCollision::Config` and physics creation logic for consistency
- Maintains the same capsule generation parameters (maxBranchLevel=2, minBranchRadius=0.05f) for both initial and deferred trees
- Includes defensive check to skip processing if no new trees were added