### PR TITLE
Add crash handler with backtrace support for debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     src/scene/Transform.cpp
     src/scene/InputSystem.cpp
     # Core
+    src/core/CrashHandler.cpp
     src/core/Renderer.cpp
     src/core/RendererCore.cpp
     src/core/RendererInitPhases.cpp

--- a/src/core/CrashHandler.cpp
+++ b/src/core/CrashHandler.cpp
@@ -1,0 +1,100 @@
+#include "CrashHandler.h"
+#include <SDL3/SDL.h>
+#include <csignal>
+#include <cstdlib>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <execinfo.h>
+#include <cxxabi.h>
+#include <dlfcn.h>
+#endif
+
+namespace {
+
+const char* getSignalName(int sig) {
+    switch (sig) {
+        case SIGSEGV: return "SIGSEGV (Segmentation fault)";
+        case SIGABRT: return "SIGABRT (Abort)";
+        case SIGFPE:  return "SIGFPE (Floating point exception)";
+        case SIGILL:  return "SIGILL (Illegal instruction)";
+        case SIGBUS:  return "SIGBUS (Bus error)";
+        default:      return "Unknown signal";
+    }
+}
+
+#if defined(__APPLE__) || defined(__linux__)
+void printBacktrace() {
+    constexpr int maxFrames = 64;
+    void* frames[maxFrames];
+
+    int frameCount = backtrace(frames, maxFrames);
+    if (frameCount == 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  (no backtrace available)");
+        return;
+    }
+
+    char** symbols = backtrace_symbols(frames, frameCount);
+    if (!symbols) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  (failed to get symbols)");
+        return;
+    }
+
+    // Skip first few frames (signal handler internals)
+    for (int i = 2; i < frameCount; ++i) {
+        // Try to demangle C++ symbols
+        Dl_info info;
+        if (dladdr(frames[i], &info) && info.dli_sname) {
+            int status = 0;
+            char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
+
+            if (status == 0 && demangled) {
+                ptrdiff_t offset = static_cast<char*>(frames[i]) - static_cast<char*>(info.dli_saddr);
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  %2d: %s +%td",
+                    i - 2, demangled, offset);
+                free(demangled);
+            } else {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  %2d: %s", i - 2, symbols[i]);
+            }
+        } else {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  %2d: %s", i - 2, symbols[i]);
+        }
+    }
+
+    free(symbols);
+}
+#else
+void printBacktrace() {
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "  (backtrace not available on this platform)");
+}
+#endif
+
+void crashSignalHandler(int sig) {
+    // Prevent recursive crashes
+    signal(sig, SIG_DFL);
+
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "========================================");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "CRASH: %s", getSignalName(sig));
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "========================================");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Backtrace:");
+
+    printBacktrace();
+
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "========================================");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "");
+
+    // Re-raise signal to get default behavior (core dump, etc.)
+    raise(sig);
+}
+
+} // anonymous namespace
+
+void installCrashHandler() {
+    signal(SIGSEGV, crashSignalHandler);
+    signal(SIGABRT, crashSignalHandler);
+    signal(SIGFPE,  crashSignalHandler);
+    signal(SIGILL,  crashSignalHandler);
+    signal(SIGBUS,  crashSignalHandler);
+
+    SDL_Log("Crash handler installed");
+}

--- a/src/core/CrashHandler.h
+++ b/src/core/CrashHandler.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Install signal handlers to print crash backtraces to console
+// Call this early in main() before any other initialization
+void installCrashHandler();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "Application.h"
+#include "core/CrashHandler.h"
 #include <SDL3/SDL.h>
 #include <string>
 #include <vector>
@@ -29,6 +30,8 @@ static void printUsage(const char* progName) {
 }
 
 int main(int argc, char* argv[]) {
+    installCrashHandler();
+
     // Parse command line arguments
     std::vector<std::pair<std::string, bool>> toggleChanges;
     bool minimalMode = false;


### PR DESCRIPTION
## Summary
Implements a crash handler that captures and logs stack backtraces when the application crashes due to signals like segmentation faults, aborts, or illegal instructions. This significantly improves debugging capabilities by providing detailed crash information directly in the console output.

## Changes
- **New CrashHandler module** (`src/core/CrashHandler.h/cpp`):
  - Installs signal handlers for common crash signals (SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS)
  - Captures and prints formatted stack backtraces on crash
  - Supports symbol demangling for C++ function names on macOS and Linux
  - Includes offset information for each stack frame
  - Falls back gracefully on platforms without backtrace support
  - Re-raises the original signal to preserve default OS behavior (core dumps, etc.)

- **Integration in main()**:
  - Calls `installCrashHandler()` early in `main()` before any other initialization
  - Ensures crash handling is active for the entire application lifetime

- **Build system**:
  - Added `src/core/CrashHandler.cpp` to CMakeLists.txt

## Implementation Details
- Uses platform-specific headers (`execinfo.h`, `cxxabi.h`, `dlfcn.h`) for Unix-like systems
- Leverages SDL3 logging for consistent output formatting
- Skips first few stack frames to avoid noise from signal handler internals
- Prevents recursive crashes by resetting signal handler to default before processing
- Provides human-readable signal names and formatted backtrace output