### PR TITLE
Add progress callbacks for renderer initialization feedback

### DIFF
--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -43,6 +43,10 @@ public:
         DescriptorPoolSizes descriptorPoolSizes = DescriptorPoolSizes::standard();
     };
 
+    // Progress callback for async loading feedback
+    // Called during initialization with progress (0.0-1.0) and phase description
+    using ProgressCallback = std::function<void(float progress, const char* phase)>;
+
     struct InitInfo {
         SDL_Window* window;
         std::string resourcePath;
@@ -52,6 +56,11 @@ public:
         // If provided, Renderer takes ownership and completes device init.
         // If nullptr, Renderer creates and fully initializes a new VulkanContext.
         std::unique_ptr<VulkanContext> vulkanContext;
+
+        // Optional: progress callback for async loading feedback
+        // When provided, renderer will call this between initialization phases
+        // to allow the caller to render a loading screen with progress updates
+        ProgressCallback progressCallback;
     };
 
     /**
@@ -238,6 +247,9 @@ private:
 
     // GUI rendering callback
     GuiRenderCallback guiRenderCallback;
+
+    // Progress callback for async loading (stored during init)
+    ProgressCallback progressCallback_;
 
     // Skinned mesh rendering
     bool initSkinnedMeshRenderer();


### PR DESCRIPTION
## Summary
This PR adds progress callback support to the Renderer initialization system, allowing the application to display a loading screen with real-time progress updates during the potentially long initialization phase. The loading screen now stays visible and animated throughout the entire renderer setup, providing visual feedback to users instead of a frozen window.

## Key Changes

- **Progress Callback Infrastructure**: Added `ProgressCallback` type definition and optional `progressCallback` field to `Renderer::InitInfo` to allow callers to receive initialization progress updates.

- **Initialization Phase Tracking**: Instrumented `Renderer::initInternal()` with progress reporting at major initialization milestones (0.0 → 1.0), including:
  - Core Vulkan resources (0.05)
  - Asset registry (0.08)
  - Descriptor infrastructure (0.10)
  - Subsystems initialization (0.12-0.95)
  - Control subsystems, resize coordinator, pass recorders, and frame graph setup (0.95-1.0)

- **Subsystem-Level Progress**: Added fine-grained progress reporting within `initSubsystems()` that maps subsystem initialization (0.12-0.95 range) with individual phase updates for post-processing, graphics pipeline, skinned mesh, shadow, terrain, scene, vegetation, atmosphere, geometry, and water systems.

- **Loading Screen Integration**: Refactored `Application::init()` to:
  - Keep the loading screen renderer alive throughout full renderer initialization
  - Pass a progress callback that updates the loading screen in real-time
  - Eliminate the previous async texture loading job queue (which was redundant with renderer's own asset loading)
  - Simplify the loading flow while maintaining visual feedback

## Implementation Details

- Progress values are normalized to 0.0-1.0 range with descriptive phase strings for each milestone
- Subsystem progress is mapped to the 0.12-0.95 range to provide detailed feedback during the heaviest initialization phase
- The callback is optional (no-op if not provided) to maintain backward compatibility
- Loading screen remains responsive with small SDL_Delay yields during callback execution