### PR TITLE
Add yield callbacks to keep loading screen responsive during terrain init

### DIFF
--- a/src/terrain/TerrainFactory.cpp
+++ b/src/terrain/TerrainFactory.cpp
@@ -7,6 +7,7 @@ std::unique_ptr<TerrainSystem> TerrainFactory::create(const InitContext& ctx, co
     terrainParams.shadowRenderPass = config.shadowRenderPass;
     terrainParams.shadowMapSize = config.shadowMapSize;
     terrainParams.texturePath = config.resourcePath + "/textures";
+    terrainParams.yieldCallback = config.yieldCallback;
 
     // Build terrain config with sensible defaults
     TerrainConfig terrainConfig = buildTerrainConfig(config);

--- a/src/terrain/TerrainFactory.h
+++ b/src/terrain/TerrainFactory.h
@@ -23,6 +23,9 @@
  */
 class TerrainFactory {
 public:
+    // Callback invoked during long operations to yield to the UI
+    using YieldCallback = std::function<void(float, const char*)>;
+
     /**
      * Configuration for terrain creation with sensible defaults.
      */
@@ -51,6 +54,9 @@ public:
 
         // Virtual texturing
         bool useVirtualTexture = true;
+
+        // Loading callback
+        YieldCallback yieldCallback;  // Optional: yield during long operations
     };
 
     /**

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -92,6 +92,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
         tileCacheInfo.commandPool = commandPool;
         tileCacheInfo.terrainSize = config.size;
         tileCacheInfo.heightScale = config.heightScale;
+        tileCacheInfo.yieldCallback = yieldCallback_;
         tileCache = TerrainTileCache::create(tileCacheInfo);
         if (!tileCache) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize tile cache, using global heightmap only");
@@ -178,6 +179,9 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
 }
 
 bool TerrainSystem::initInternal(const InitContext& ctx, const TerrainInitParams& params, const TerrainConfig& cfg) {
+    // Store yield callback for use during initialization
+    yieldCallback_ = params.yieldCallback;
+
     InitInfo info{};
     info.raiiDevice = ctx.raiiDevice;
     info.device = ctx.device;

--- a/src/terrain/TerrainSystem.h
+++ b/src/terrain/TerrainSystem.h
@@ -26,6 +26,7 @@
 #include "core/material/TerrainLiquidUBO.h"
 #include "core/material/MaterialLayer.h"
 #include <optional>
+#include <functional>
 
 class GpuProfiler;
 
@@ -154,12 +155,16 @@ public:
         vk::CommandPool commandPool;
     };
 
+    // Callback invoked during long operations to yield to the UI
+    using YieldCallback = std::function<void(float, const char*)>;
+
     // System-specific params for InitContext-based init
     struct TerrainInitParams {
         vk::RenderPass renderPass;
         vk::RenderPass shadowRenderPass;
         uint32_t shadowMapSize;
         std::string texturePath;
+        YieldCallback yieldCallback;  // Optional: yield during long operations
     };
 
     /**
@@ -389,6 +394,9 @@ private:
     uint32_t framesInFlight = 0;
     vk::Queue graphicsQueue;
     vk::CommandPool commandPool;
+
+    // Yield callback for long init operations
+    YieldCallback yieldCallback_;
 
     // Composed subsystems (RAII-managed)
     std::unique_ptr<TerrainTextures> textures;


### PR DESCRIPTION
## Summary
This PR adds yield callback support throughout the terrain initialization pipeline to prevent the loading screen from freezing during long-running operations. The callbacks allow the UI event loop to remain responsive by periodically pumping events while terrain data is being loaded and processed.

## Key Changes
- **Renderer.cpp**: Added SDL3 header include and implemented a yield callback that maps terrain initialization progress (0.20-0.28 of overall progress) and calls `SDL_PumpEvents()` to keep the window responsive
- **TerrainFactory**: Added `YieldCallback` type definition and `yieldCallback` field to `TerrainFactoryConfig` to pass the callback through the factory
- **TerrainSystem**: 
  - Added `YieldCallback` type and `yieldCallback` field to `TerrainInitParams`
  - Stores the callback as a member variable during initialization for use by subsystems
  - Passes the callback to `TerrainTileCache` during initialization
- **TerrainTileCache**: 
  - Added `YieldCallback` type and field to `InitInfo`
  - Invokes callback during `loadBaseLODTiles()` after each tile is loaded (0-50% of terrain progress)
  - Invokes callback during `createBaseHeightMap()` at regular intervals (50-90% of terrain progress)
  - Updated log message to remove "synchronously" descriptor

## Implementation Details
- The callback signature is `void(float progress, const char* phase)` where progress is 0-1 and phase is a descriptive string
- Progress ranges are carefully mapped: tile loading uses 0-50% of the terrain's allocated progress window, heightmap creation uses 50-90%
- Callbacks are optional (checked with `if (yieldCallback_)`) to maintain backward compatibility
- `SDL_PumpEvents()` is called from the main renderer thread to process pending events without blocking
- The yield interval for heightmap creation is set to every 32 rows to balance responsiveness with callback overhead