### PR TITLE
Rename Camera::getFront() to getForward() for clarity

### DIFF
--- a/src/core/updaters/UBOUpdater.cpp
+++ b/src/core/updaters/UBOUpdater.cpp
@@ -73,7 +73,7 @@ UBOUpdater::Result UBOUpdater::update(
     LightBuffer lightBuffer{};
     glm::mat4 viewProj = camera.getProjectionMatrix() * camera.getViewMatrix();
     systems.scene().getLightManager().buildLightBuffer(
-        lightBuffer, camera.getPosition(), camera.getFront(), viewProj, config.lightCullRadius);
+        lightBuffer, camera.getPosition(), camera.getForward(), viewProj, config.lightCullRadius);
     systems.globalBuffers().updateLightBuffer(frameIndex, lightBuffer);
 
     // Calculate sun screen position (pure) and update post-process (state mutation)

--- a/src/gui/GuiIKTab.cpp
+++ b/src/gui/GuiIKTab.cpp
@@ -76,7 +76,7 @@ void GuiIKTab::render(ISceneControl& sceneControl, const Camera& camera, IKDebug
                 break;
             case IKDebugSettings::LookAtMode::Mouse:
                 // Project mouse into world (simplified - uses camera front direction)
-                lookTarget = camera.getPosition() + camera.getFront() * 5.0f;
+                lookTarget = camera.getPosition() + camera.getForward() * 5.0f;
                 break;
         }
         ikSystem.setLookAtTarget(lookTarget);

--- a/src/scene/Camera.h
+++ b/src/scene/Camera.h
@@ -67,7 +67,7 @@ public:
     glm::mat4 getProjectionMatrix() const;
 
     glm::vec3 getPosition() const { return position_; }
-    glm::vec3 getFront() const { return front_; }
+    glm::vec3 getForward() const { return front_; }
     glm::vec3 getRight() const { return right_; }
     glm::vec3 getUp() const { return up_; }
 


### PR DESCRIPTION
## Summary
Renamed the `Camera::getFront()` method to `Camera::getForward()` to improve code clarity and better reflect the semantic meaning of the returned vector. This is a straightforward refactoring that updates the method name and all call sites.

## Changes
- Renamed `Camera::getFront()` to `Camera::getForward()` in the Camera class header
- Updated call site in `UBOUpdater::update()` when building the light buffer
- Updated call site in `GuiIKTab::render()` when calculating the look-at target for IK debugging

## Rationale
The method name `getForward()` more clearly communicates that this returns the forward direction vector of the camera, which is more intuitive than `getFront()`. This improves code readability without changing any functionality.

https://claude.ai/code/session_019g1H5gJhRPYFZaHtuKZLYv