### PR TITLE
Integrate ECS-based lighting system with renderer

### DIFF
--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -513,6 +513,8 @@ bool Renderer::render(const Camera& camera) {
         uboConfig.hdrEnabled = hdrEnabled;
         uboConfig.maxSnowHeight = MAX_SNOW_HEIGHT;
         uboConfig.lightCullRadius = lightCullRadius;
+        uboConfig.ecsWorld = ecsWorld_;
+        uboConfig.deltaTime = timing.deltaTime;
         auto uboResult = UBOUpdater::update(*systems_, frameSync_.currentIndex(), camera, uboConfig);
         lastSunIntensity = uboResult.sunIntensity;
         // Track bandwidth: main UBO + dynamic UBO copy + snow + cloudShadow + lights

--- a/src/core/Renderer.h
+++ b/src/core/Renderer.h
@@ -24,6 +24,10 @@
 // Forward declarations
 class PhysicsWorld;
 
+namespace ecs {
+class World;
+}
+
 namespace Loading {
     class AsyncSystemLoader;
 }
@@ -175,6 +179,10 @@ public:
     PerformanceToggles& getPerformanceToggles() { return perfToggles; }
     const PerformanceToggles& getPerformanceToggles() const { return perfToggles; }
 
+    // ECS integration for light updates
+    void setECSWorld(ecs::World* world) { ecsWorld_ = world; }
+    ecs::World* getECSWorld() const { return ecsWorld_; }
+
 #ifdef JPH_DEBUG_RENDERER
     // Update physics debug visualization (call before render)
     void updatePhysicsDebug(PhysicsWorld& physics, const glm::vec3& cameraPos);
@@ -274,6 +282,10 @@ private:
 
     // Dynamic lights
     float lightCullRadius = 100.0f;        // Radius from camera for light culling
+
+    // ECS world for light updates
+    ecs::World* ecsWorld_ = nullptr;
+    float lastDeltaTime_ = 0.016f;         // For flicker animation
 
     // GUI rendering callback
     GuiRenderCallback guiRenderCallback;

--- a/src/core/updaters/UBOUpdater.cpp
+++ b/src/core/updaters/UBOUpdater.cpp
@@ -11,6 +11,8 @@
 #include "SceneManager.h"
 #include "controls/EnvironmentControlSubsystem.h"
 #include "Camera.h"
+#include "lighting/LightSystem.h"
+#include "ecs/World.h"
 
 UBOUpdater::Result UBOUpdater::update(
     RendererSystems& systems,
@@ -72,8 +74,22 @@ UBOUpdater::Result UBOUpdater::update(
     // Update light buffer with camera-based culling
     LightBuffer lightBuffer{};
     glm::mat4 viewProj = camera.getProjectionMatrix() * camera.getViewMatrix();
-    systems.scene().getLightManager().buildLightBuffer(
-        lightBuffer, camera.getPosition(), camera.getForward(), viewProj, config.lightCullRadius);
+
+    // Use ECS lights if available, otherwise fall back to legacy LightManager
+    if (config.ecsWorld) {
+        // Update flicker animation for all lights with LightFlickerComponent
+        ecs::light::updateFlicker(*config.ecsWorld, config.deltaTime);
+
+        // Build light buffer from ECS with frustum culling
+        ecs::light::buildLightBuffer(
+            *config.ecsWorld, lightBuffer,
+            camera.getPosition(), camera.getForward(),
+            viewProj, config.lightCullRadius);
+    } else {
+        // Fallback to legacy LightManager
+        systems.scene().getLightManager().buildLightBuffer(
+            lightBuffer, camera.getPosition(), camera.getForward(), viewProj, config.lightCullRadius);
+    }
     systems.globalBuffers().updateLightBuffer(frameIndex, lightBuffer);
 
     // Calculate sun screen position (pure) and update post-process (state mutation)

--- a/src/core/updaters/UBOUpdater.h
+++ b/src/core/updaters/UBOUpdater.h
@@ -19,6 +19,10 @@
 class Camera;
 class RendererSystems;
 
+namespace ecs {
+class World;
+}
+
 class UBOUpdater {
 public:
     // Configuration for UBO updates
@@ -30,6 +34,8 @@ public:
         bool hdrEnabled = true;
         float maxSnowHeight = 0.3f;
         float lightCullRadius = 100.0f;
+        ecs::World* ecsWorld = nullptr;  // Optional: ECS world for light updates
+        float deltaTime = 0.016f;         // For flicker animation
     };
 
     // Output data from UBO update (for state that needs to be tracked)

--- a/src/scene/Application.cpp
+++ b/src/scene/Application.cpp
@@ -423,6 +423,11 @@ bool Application::init(const std::string& title, int width, int height) {
     // Initialize ECS world with scene entities
     initECS();
 
+    // Wire up ECS world for lighting
+    renderer_->setECSWorld(&ecsWorld_);
+    renderer_->getSystems().scene().setECSWorld(&ecsWorld_);
+    renderer_->getSystems().scene().initializeECSLights();
+
     // Initialize GUI system via factory
     {
         INIT_PROFILE_PHASE("GUI");

--- a/src/scene/SceneManager.h
+++ b/src/scene/SceneManager.h
@@ -6,6 +6,7 @@
 #include "SceneBuilder.h"
 #include "Light.h"
 #include "PhysicsSystem.h"
+#include "ecs/World.h"
 
 // Centralized scene management - handles visual objects, physics bodies, and lighting
 class SceneManager {
@@ -56,9 +57,16 @@ public:
     SceneBuilder& getSceneBuilder() { return *sceneBuilder; }
     const SceneBuilder& getSceneBuilder() const { return *sceneBuilder; }
 
-    // Light management
+    // Light management (deprecated - use ECS lights)
     LightManager& getLightManager() { return lightManager; }
     const LightManager& getLightManager() const { return lightManager; }
+
+    // ECS light management
+    void setECSWorld(ecs::World* world) { ecsWorld_ = world; }
+    ecs::Entity getOrbLightEntity() const { return orbLightEntity_; }
+
+    // Reinitialize lights with ECS (call after setECSWorld)
+    void initializeECSLights();
 
     // Orb light position (updated by physics)
     void setOrbLightPosition(const glm::vec3& position) { orbLightPosition = position; }
@@ -98,4 +106,10 @@ private:
 
     // Orb light position (follows emissive orb physics object)
     glm::vec3 orbLightPosition = glm::vec3(2.0f, 1.3f, 0.0f);
+
+    // ECS light integration
+    ecs::World* ecsWorld_ = nullptr;
+    ecs::Entity orbLightEntity_ = ecs::NullEntity;
+    ecs::Entity blueLightEntity_ = ecs::NullEntity;
+    ecs::Entity greenLightEntity_ = ecs::NullEntity;
 };


### PR DESCRIPTION
## Summary
This PR integrates the ECS-based lighting system with the renderer, enabling dynamic light management through ECS entities while maintaining backward compatibility with the legacy LightManager. The renderer now passes delta time and ECS world references to the UBO updater, which uses them to build light buffers from ECS components and animate light flicker effects.

## Key Changes

- **Renderer Integration**: Added `ecsWorld_` member and `setECSWorld()`/`getECSWorld()` methods to Renderer to wire up ECS world references
- **UBO Configuration**: Extended `UBOUpdater::Config` to include `ecsWorld` pointer and `deltaTime` for light animation
- **Light Buffer Building**: Modified `UBOUpdater::update()` to conditionally use ECS light system (`ecs::light::buildLightBuffer()` and `ecs::light::updateFlicker()`) when ECS world is available, with fallback to legacy LightManager
- **SceneManager ECS Support**: 
  - Added `setECSWorld()` and `initializeECSLights()` methods
  - Refactored `initializeSceneLights()` to create ECS light entities (torch and point lights) instead of legacy Light objects
  - Updated orb light position tracking to use ECS Transform components when available
  - Maintained legacy LightManager as fallback when ECS world is unavailable
- **Application Initialization**: Wired up ECS world to renderer and scene manager during initialization

## Implementation Details

- Light flicker animation is now driven by delta time passed through UBO config
- Orb light position updates from physics are applied to both ECS Transform and legacy LightManager for compatibility
- The system gracefully degrades to legacy lighting if ECS world is not initialized
- Three scene lights are created: a flickering torch (orb light) and two static point lights (blue and green)
- Forward declarations added to avoid circular dependencies between Renderer, UBOUpdater, and ECS World

## Backward Compatibility
The legacy LightManager remains functional and is used as a fallback when the ECS world is not available, ensuring existing code paths continue to work.

https://claude.ai/code/session_01MKFVce18YEZa5BTAdbyXwM