### PR TITLE
Implement Nanite-style visibility buffer rendering pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(unofficial-openfbx CONFIG REQUIRED)
 find_package(lodepng CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(EnTT CONFIG REQUIRED)
+find_package(meshoptimizer CONFIG REQUIRED)
 
 find_path(STB_INCLUDE_DIRS "stb_image.h")
 
@@ -81,6 +82,7 @@ set(SOURCES
     src/core/passes/ShadowPassResources.cpp
     src/core/passes/WaterPasses.cpp
     src/core/passes/HDRPass.cpp
+    src/core/passes/VisBufferPasses.cpp
     src/core/passes/HDRPassRecorder.cpp
     src/core/passes/HDRPassResources.cpp
     src/core/passes/SceneObjectsDrawable.cpp
@@ -175,6 +177,10 @@ set(SOURCES
     # GPU Culling
     src/core/GPUSceneBuffer.cpp
     src/culling/GPUCullPass.cpp
+    src/visibility/VisibilityBuffer.cpp
+    src/visibility/MeshClusterBuilder.cpp
+    src/visibility/TwoPassCuller.cpp
+    src/visibility/GPUMaterialBuffer.cpp
     # Lighting
     src/lighting/FroxelSystem.cpp
     src/lighting/ShadowSystem.cpp
@@ -305,6 +311,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/terrain
     ${CMAKE_CURRENT_SOURCE_DIR}/src/terrain/virtual_texture
     ${CMAKE_CURRENT_SOURCE_DIR}/src/vegetation
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/visibility
     ${CMAKE_CURRENT_SOURCE_DIR}/src/water
     ${CMAKE_CURRENT_SOURCE_DIR}/generated
     ${CMAKE_CURRENT_SOURCE_DIR}  # For shaders/bindings.h
@@ -326,6 +333,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     lodepng
     nlohmann_json::nlohmann_json
     EnTT::EnTT
+    meshoptimizer::meshoptimizer
 )
 
 # Enable Jolt Physics debug renderer for visualization
@@ -768,6 +776,13 @@ set(SHADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/bloom_upsample_compute.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/bloom_spd.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/godrays_compute.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/visbuf.vert.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/visbuf.frag.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/visbuf_debug.vert.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/visbuf_debug.frag.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/visbuf_resolve.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/cluster_cull.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/cluster_select.comp.spv
 )
 
 set(TERRAIN_SHADER_FILES
@@ -835,6 +850,7 @@ if(SHADER_COMPILE_CMD)
         hiz_downsample.comp
         debug_line.vert debug_line.frag
         loading.vert loading.frag
+        visbuf_debug.vert
     )
 
     foreach(SHADER ${SIMPLE_SHADERS})
@@ -874,6 +890,11 @@ if(SHADER_COMPILE_CMD)
         hiz_culling.comp
         scene_cull.comp
         bloom_compute.comp bloom_upsample_compute.comp bloom_spd.comp godrays_compute.comp
+        visbuf.vert visbuf.frag
+        visbuf_debug.frag
+        visbuf_resolve.comp
+        cluster_cull.comp
+        cluster_select.comp
     )
 
     foreach(SHADER ${SHADERS_WITH_BINDINGS})

--- a/docs/NANITE_COMPARISON.md
+++ b/docs/NANITE_COMPARISON.md
@@ -1,0 +1,273 @@
+# Engine vs. Nanite: Architectural Review
+
+A comparison of this engine's rendering architecture against Unreal Engine 5's Nanite virtualized geometry system, based on actual source code review.
+
+## Overview
+
+Nanite decomposes all static geometry into ~128-triangle **clusters** organized in a **DAG**, then performs per-cluster LOD selection, culling, and rasterization entirely on the GPU. Materials are evaluated after visibility is determined via a **visibility buffer**.
+
+This engine has implemented the core architectural skeleton of a Nanite-like pipeline: mesh clustering with DAG hierarchy, GPU-driven LOD selection, two-pass occlusion culling, normal cone backface culling, and a visibility buffer with compute material resolve. The comparison below evaluates how each subsystem compares to Nanite's production implementation.
+
+---
+
+## 1. Geometry Representation
+
+| Aspect | This Engine | Nanite |
+|---|---|---|
+| **Cluster format** | `MeshCluster`: 64-128 triangles, bounding sphere, AABB, normal cone, DAG links (`MeshClusterBuilder.h:22-51`) | ~128 triangles, bounding sphere with monotonic error, DAG links |
+| **Hierarchy** | DAG built via `buildWithDAG()` — spatial grouping (2-4 clusters/group), meshoptimizer simplification (`MeshClusterBuilder.h:120-122`) | DAG via METIS graph partitioning, boundary-locked edge collapse |
+| **Error metric** | Per-cluster `error` and `parentError` in object space, projected to screen in `cluster_select.comp` | Per-cluster/group object-space error, projected via bounding sphere |
+| **Global buffers** | `GPUClusterBuffer` — single vertex/index/cluster SSBO for all meshes (`MeshClusterBuilder.h:169-227`) | Global vertex/index pages with GPU-resident page table |
+| **Vertex format** | 60 bytes/vertex (vec3 pos, vec3 normal, vec2 uv, vec4 tangent, vec4 color) | ~14.4 bytes/triangle (quantized positions, no stored tangents) |
+| **Partitioning** | Spatial grouping heuristic (`groupClustersSpatially`) | METIS graph partitioning minimizing edge-cut |
+
+**What's implemented**: The engine has the fundamental cluster+DAG representation. `MeshClusterBuilder::build()` creates flat clusters; `buildWithDAG()` iteratively groups and simplifies into coarser parents using meshoptimizer. `GPUClusterBuffer` manages global SSBOs for all clustered meshes.
+
+**Gaps vs. Nanite**:
+- **Partitioning quality**: Spatial grouping vs. METIS graph partitioning. METIS minimizes boundary edges between clusters, which directly determines crack-free LOD transition quality. Spatial grouping is a reasonable approximation but produces more boundary edges.
+- **Boundary-locked simplification**: Nanite locks vertices shared between clusters during edge collapse, ensuring adjacent LOD levels share boundary vertices exactly. The engine uses meshoptimizer's generic simplification — it doesn't lock boundary vertices, which can introduce T-junctions at LOD transitions.
+- **Compression**: 60 bytes/vertex vs ~14.4 bytes/triangle. Nanite quantizes positions relative to cluster bounds, derives tangents in the pixel shader, and uses specialized index encoding. The engine stores full uncompressed attributes.
+- **Error monotonicity**: Nanite ensures error metrics are strictly monotonic through the DAG by taking bounding sphere unions at each level. The engine stores `error` and `parentError` but the monotonicity guarantee depends on the simplification producing increasing error at each level — not explicitly enforced.
+
+---
+
+## 2. LOD System
+
+### Cluster DAG LOD Selection
+
+**File**: `shaders/cluster_select.comp`
+
+The engine implements Nanite's DAG-cut LOD selection on the GPU:
+
+```
+selected = myScreenError <= threshold && parentScreenError > threshold
+```
+
+Each compute thread evaluates one cluster. Screen-space error projection (`projectErrorToScreen` in `cull_compute_common.glsl:96-111`) uses the standard formula: `(objectError * screenHeight * 0.5) / clipW`. Default threshold is 1.0 pixel (`TwoPassCuller.h:228`).
+
+Leaf handling: leaves are selected when reached (`!parentErrorOk || myErrorOk`), internal nodes only when they're on the cut (`myErrorOk && !parentErrorOk`).
+
+**What matches Nanite**: Core selection algorithm, screen-space error projection, configurable pixel threshold.
+
+**Gaps**:
+- **Traversal strategy**: The engine dispatches one thread per cluster in the entire DAG and each thread independently evaluates its selection criterion. Nanite uses a **persistent-thread work queue** traversal — starting from root nodes and recursively enqueuing children — which avoids evaluating clusters deep in the hierarchy that will never be reached. For deep DAGs this is significantly more efficient.
+- **Instance support**: The engine uses `meshId` as a crude instance index (`cluster_select.comp:91`). Nanite handles millions of instances — each (cluster, instance) pair is independently evaluated.
+
+### Terrain LOD (CBT)
+
+**Files**: `shaders/terrain/terrain_subdivision.comp`, `src/terrain/TerrainCBT.h`
+
+This has no Nanite equivalent and is a strength. Concurrent Binary Tree adaptive subdivision with:
+- Screen-space edge length metric with curvature adaptation
+- Split/merge hysteresis (`SPLIT_THRESHOLD`, `MERGE_THRESHOLD`)
+- Temporal spreading for deep triangles across frames
+- Inline frustum culling
+- Tile cache integration (high-res tiles near camera, coarse fallback far)
+
+Nanite explicitly doesn't target heightmap terrain — its cluster topology assumes arbitrary meshes.
+
+### Tree LOD
+
+**Files**: `shaders/tree_impostor_cull.comp`, `shaders/tree_cell_cull.comp`
+
+Two-tier: spatial cell culling → per-tree screen-space error LOD with geometry/impostor/culled tiers. Smooth blend via `smoothstep`, temporal coherence modes, visibility bit cache. This is a specialized LOD system for vegetation that Nanite also doesn't handle well (foliage is one of Nanite's known limitations).
+
+### LOD Transitions
+
+**File**: `shaders/dither_common.glsl`
+
+Interleaved Gradient Noise dithered crossfade with temporal variant for TAA. This is the standard approach when LOD levels don't share boundary vertices. Nanite avoids needing transitions entirely because boundary locking guarantees watertight seams between adjacent LOD levels.
+
+---
+
+## 3. Culling
+
+### Two-Pass Occlusion Culling
+
+**Files**: `src/visibility/TwoPassCuller.h`, `shaders/cluster_cull.comp`
+
+This directly implements Nanite's two-pass approach:
+
+**Pass 1** (`passIndex == 0`): Test clusters that were visible last frame (`prevVisibleClusters[]`). High hit rate — most clusters visible last frame are still visible. Render these, build Hi-Z pyramid from resulting depth.
+
+**Pass 2** (`passIndex == 1`): Test remaining clusters against the new Hi-Z. Catches newly visible clusters (disocclusion from camera movement).
+
+Double-buffered visible cluster lists (`visibleClusterBuffers_` / `prevVisibleClusterBuffers_`) with `swapBuffers()` at end of frame.
+
+**What matches Nanite**: The overall two-pass strategy, temporal visible list ping-pong, per-pass indirect draw generation.
+
+**Gaps**:
+- **Pass 2 skip set**: `cluster_cull.comp:123-126` iterates all clusters in pass 2 rather than skipping those already tested in pass 1. Nanite tracks which clusters were tested vs. untested to avoid redundant work.
+
+### Per-Cluster Culling Tests
+
+**File**: `shaders/cluster_cull.comp:112-209`
+
+Each thread performs in sequence:
+1. **Sphere frustum test** (`isSphereInFrustum`) — fast rejection
+2. **AABB frustum test** (`isAABBInFrustum`) — precise test on all 6 planes
+3. **Hi-Z occlusion test** (`hizOcclusionTestAABB`) — project AABB to screen rect, choose mip level covering ~2x2 texels, sample Hi-Z center, compare depth
+4. **Normal cone backface test** (`dot(viewDir, worldConeAxis) > coneAngle`) — reject entire cluster if all normals face away
+
+Output: `VkDrawIndexedIndirectCommand` via subgroup-batched atomics, plus visible cluster ID for next frame.
+
+**What matches Nanite**: All four test types match (frustum sphere/AABB, Hi-Z occlusion, normal cone backface). Subgroup ballot batching reduces atomic contention by ~32x.
+
+**Gaps**:
+- **Hi-Z sampling**: Single center-point sample of the projected AABB rectangle. Nanite samples multiple points or uses conservative bounds. A single center sample can miss occluders that don't cover the AABB center.
+- **AABB transform**: `cluster_cull.comp:150-155` transforms only min/max corners and takes component-wise min/max. This is only correct for axis-aligned transforms. For rotated instances, the 8-corner AABB should be transformed and re-bounded. The Hi-Z common code (`hiz_occlusion_common.glsl:20-53`) does correctly transform all 8 corners for the screen-space projection.
+
+### Hi-Z Pyramid
+
+**Files**: `src/postprocess/HiZSystem.h`, `shaders/hiz_downsample.comp`
+
+- Format: `R32_SFLOAT`, reversed-Z (min of 2x2 = farthest = conservative for occlusion)
+- Per-mip compute dispatch with push constants
+- Edge handling for odd-sized source mips
+
+This is solid. The `MipChainBuilder` with per-mip views and the reversed-Z convention are correct.
+
+### Per-Object Culling (Legacy Path)
+
+**Files**: `src/culling/GPUCullPass.h`, `shaders/scene_cull.comp`
+
+Separate system for non-clustered objects: per-object sphere+AABB frustum test, Hi-Z occlusion, indirect draw generation. Max 8192 objects. This coexists with the cluster path.
+
+---
+
+## 4. Rasterization
+
+### Visibility Buffer
+
+**Files**: `src/visibility/VisibilityBuffer.h`, `shaders/visbuf.vert`, `shaders/visbuf.frag`, `shaders/visbuf_resolve.comp`
+
+**Phase 1 — V-Buffer Rasterization** (hardware):
+- Render target: `R32_UINT` (32-bit unsigned integer)
+- Packing: `(instanceId << 23) | (triangleId & 0x7FFFFF)` — 9 bits instance (512 max), 23 bits triangle (~8M max)
+- Vertex shader: minimal transform via push constants (`model`, `instanceId`, `triangleOffset`)
+- Fragment shader: packs `gl_PrimitiveID + triangleOffset` with `instanceId`
+- Alpha test support for masked materials (foliage)
+
+**Phase 2 — Compute Material Resolve** (`visbuf_resolve.comp`):
+- 8x8 workgroups
+- Unpacks instanceId + triangleId from V-buffer
+- Fetches 3 vertex indices from global index SSBO
+- Fetches vertex data from global vertex SSBO (`PackedVertex`: pos+u, normal+v, tangent, color)
+- Reconstructs world position from instance transform
+- Computes perspective-correct barycentrics (screen-space projection + 1/w correction)
+- Interpolates normals and UVs
+- Evaluates simplified directional light PBR
+- Writes to RGBA16F HDR output
+
+**What matches Nanite**: Two-phase architecture (rasterize IDs → resolve materials), global vertex/index SSBOs, per-pixel barycentric reconstruction, decoupled geometry/material evaluation.
+
+**Gaps**:
+- **V-buffer width**: Now 64-bit (R32G32_UINT). Full 32-bit instanceId and 32-bit triangleId per pixel — no packing limits. Nanite uses a different 64-bit layout (30-bit depth + 27-bit cluster + 7-bit triangle) that integrates depth testing into the atomic write for software rasterization. The engine's layout doesn't embed depth, which would need to change when adding a software rasterizer.
+- **Software rasterizer**: Not implemented. This is Nanite's biggest performance win — a compute shader that does scan-line rasterization with 64-bit atomic compare-and-swap, ~3x faster than hardware for sub-pixel triangles (which are 90%+ of clusters in a Nanite scene). The engine uses hardware rasterization exclusively.
+- **Material sort/binning**: The resolve shader evaluates materials per-pixel via a material SSBO lookup. Nanite classifies pixels into 64x64 tiles by material, then dispatches a per-material full-screen pass that evaluates only relevant tiles. This tile-based approach is more efficient for scenes with many diverse materials.
+
+---
+
+## 5. Draw Call Architecture
+
+| Aspect | This Engine | Nanite |
+|---|---|---|
+| **Cluster path** | `cluster_select.comp` → `cluster_cull.comp` → `VkDrawIndexedIndirectCommand[]` → hardware rasterize | DAG traversal → cluster cull → raster bin sort → software/hardware rasterize dispatch |
+| **Object path** | `GPUSceneBuffer` → `scene_cull.comp` → `vkCmdDrawIndexedIndirectCount` | N/A (everything is clusters) |
+| **Instance limit** | ~4B (full 32-bit V-buffer channel) for cluster path; 8192 for object path | 16M instances |
+| **Subgroup optimization** | Yes — ballot + broadcast for batched atomics in all cull shaders | Yes — similar wave-level batching |
+
+**What matches Nanite**: The cluster pipeline (LOD select → cull → indirect draw) is the correct sequence. Subgroup-batched atomics throughout. Global vertex/index buffers.
+
+**Gaps**:
+- **Two separate paths**: The engine maintains both a cluster path (`TwoPassCuller` + `VisibilityBuffer`) and an object path (`GPUCullPass` + `GPUSceneBuffer`). Nanite has a single unified cluster path. The dual-path adds complexity and the non-cluster path becomes the bottleneck.
+- **Per-draw push constants**: The V-buffer rasterization pass uses push constants per draw (`model`, `instanceId`, `triangleOffset`). Nanite avoids per-draw CPU state by fetching all instance data from SSBOs using the indirect draw's `firstInstance` field.
+
+---
+
+## 6. Streaming
+
+| Aspect | This Engine | Nanite |
+|---|---|---|
+| **Terrain** | Tile-based streaming with tile cache, async transfer, load/unload radii (`TerrainTileCache.h`) | N/A for terrain |
+| **Mesh data** | `GPUClusterBuffer` — fully resident | Page-based streaming, only visible clusters loaded, SSD-optimized |
+| **Textures** | `AsyncTextureUploader` with non-blocking uploads | Virtual texturing (separate system) |
+| **Virtual textures** | Implemented: 8192px virtual, 128px tiles, 2048px cache, 6 mip levels (`VirtualTextureSystem.h`) | Similar |
+
+**Engine strengths**: The terrain tile cache (high-res tiles near camera in a 2D texture array, per-tile metadata, cooperative loading with yield callback) and virtual texture system are well-designed streaming systems. The `AsyncTransferManager` with dedicated transfer queue is the right pattern.
+
+**Gap**: Mesh cluster data is fully resident in GPU memory. Nanite streams cluster pages on demand — the hierarchy metadata is always resident but actual vertex/index data is loaded per-page as needed. This is essential for billion-triangle scenes but not needed at the engine's current scale.
+
+---
+
+## 7. Shadows
+
+| Aspect | This Engine | Nanite |
+|---|---|---|
+| **Approach** | 4-cascade CSM, 2048x2048 per cascade, lambda PSSM splits (`ShadowSystem.h`) | Virtual Shadow Maps (16K x 16K virtual, page-based, ~300px/m near camera) |
+| **Per-cascade culling** | Compute callback before each cascade for GPU culling | Reuses cluster cull/rasterize from light perspective |
+| **Dynamic lights** | Point (cubemap) + spot (2D) shadow arrays, 1024x1024, max 8 lights | VSMs for all light types |
+
+**Gap**: Virtual Shadow Maps are tightly coupled to the cluster pipeline — they rasterize the same clusters from the light's perspective into a virtual page table. The engine's CSM is the traditional approach. VSMs would require the cluster rasterization pipeline to be reusable from arbitrary viewpoints.
+
+---
+
+## Summary: What's Implemented vs. Nanite
+
+| Nanite Feature | Engine Status | Key File(s) |
+|---|---|---|
+| Mesh clustering (64-128 tri) | **Implemented** | `MeshClusterBuilder.h` |
+| DAG hierarchy + simplification | **Implemented** (meshoptimizer, spatial grouping) | `MeshClusterBuilder::buildWithDAG()` |
+| GPU DAG LOD selection | **Implemented** | `cluster_select.comp` |
+| Screen-space error projection | **Implemented** | `cull_compute_common.glsl:96-111` |
+| Two-pass temporal occlusion culling | **Implemented** | `TwoPassCuller.h`, `cluster_cull.comp` |
+| Hi-Z pyramid | **Implemented** | `HiZSystem.h`, `hiz_downsample.comp` |
+| Normal cone backface culling | **Implemented** | `cluster_cull.comp:170-178` |
+| Visibility buffer | **Implemented** (32-bit) | `VisibilityBuffer.h`, `visbuf.frag` |
+| Compute material resolve | **Implemented** (full PBR + material buffer) | `visbuf_resolve.comp` |
+| Subgroup-batched atomics | **Implemented** | All cull shaders |
+| Global vertex/index SSBOs | **Implemented** | `GPUClusterBuffer` |
+| METIS graph partitioning | **Not implemented** — spatial grouping instead | — |
+| Boundary-locked simplification | **Not implemented** — generic meshoptimizer | — |
+| Software rasterizer | **Not implemented** | — |
+| 64-bit visibility buffer | **Done** — R32G32_UINT (instanceId, triangleId) | — |
+| Material tile classification | **Not implemented** — per-pixel material lookup | — |
+| Cluster streaming | **Not implemented** — fully resident | — |
+| Virtual shadow maps | **Not implemented** — CSM | — |
+| Top-down DAG traversal | **Implemented** — multi-pass ping-pong | `cluster_select.comp` |
+
+---
+
+## Remaining Gaps: Priority Order
+
+### 1. Software Rasterizer (highest impact)
+Nanite's biggest performance innovation. A compute shader performing scan-line rasterization with 64-bit atomic compare-and-swap. For sub-pixel triangles (which dominate at Nanite detail levels), this is ~3x faster than hardware rasterization because it avoids 2x2 quad overhead. Would require upgrading V-buffer to 64-bit and implementing a per-cluster size classifier to route small clusters to the software path and large clusters to hardware.
+
+### 2. Boundary-Locked Simplification
+The current meshoptimizer simplification can introduce T-junctions between adjacent LOD levels, causing visible cracks at LOD transitions. Nanite locks boundary vertices (those shared between clusters in a group) during edge collapse, guaranteeing watertight seams. This requires identifying shared boundary vertices before simplification and passing them as locked constraints.
+
+### 3. METIS Graph Partitioning
+Spatial grouping produces more boundary edges than graph partitioning, reducing the quality of the LOD hierarchy (more constrained vertices means less simplification freedom). Integrating METIS (or meshoptimizer's `meshopt_buildMeshlets` which does something similar) for initial cluster construction would improve both cluster quality and simplification ratios.
+
+### 4. Persistent-Thread DAG Traversal
+The current flat dispatch (one thread per cluster in the entire DAG) evaluates every cluster in the hierarchy regardless of whether it will be reached. Nanite uses a work-queue approach starting from root nodes, only descending into children when the parent error exceeds the threshold. For deep hierarchies this avoids significant wasted compute.
+
+### 5. Material Tile Classification
+The resolve shader evaluates materials per-pixel via SSBO lookup with texture array sampling and Cook-Torrance PBR. This works correctly but Nanite's tile classification (64x64 pixel tiles binned by material → per-material fullscreen dispatch) would reduce divergence for scenes with many distinct materials.
+
+### 6. 64-bit V-Buffer + Instance Scalability — DONE
+The V-buffer is now R32G32_UINT (64-bit): R = instanceId, G = triangleId, both full 32-bit. The previous 9-bit/23-bit packing is gone. Note: Nanite's 64-bit layout embeds depth (30-bit depth + 27-bit cluster + 7-bit triangle) to enable atomic depth testing in the software rasterizer. Adding depth would require repacking when the software rasterizer is implemented.
+
+### 7. Cluster Streaming (scale-dependent)
+Only needed when total geometry exceeds GPU memory budget. The `AsyncTransferManager` and tile cache patterns could be extended to stream cluster pages.
+
+### 8. Virtual Shadow Maps (optional)
+Would replace CSM with per-page shadow allocation reusing the cluster pipeline from the light's perspective. Only makes sense after the cluster pipeline is the primary rendering path.
+
+---
+
+## Conclusion
+
+The engine has already implemented the core Nanite architecture: cluster DAG representation, GPU LOD selection via screen-space error, two-pass temporal occlusion culling, normal cone backface culling, and a visibility buffer with compute material resolve. This is significantly further along than a traditional renderer.
+
+The remaining gaps fall into two categories: **quality** (boundary-locked simplification, METIS partitioning — needed for crack-free LOD transitions) and **performance at scale** (software rasterizer, persistent-thread traversal, streaming). The 64-bit V-buffer is now implemented (R32G32_UINT with full 32-bit instance/triangle IDs). The software rasterizer is the single largest performance gap and the primary reason Nanite achieves its headline numbers. The simplification quality is the most important correctness gap.

--- a/docs/NANITE_TECHNIQUES_PLAN.md
+++ b/docs/NANITE_TECHNIQUES_PLAN.md
@@ -1,0 +1,481 @@
+# Nanite Techniques Applied to Non-Terrain Geometry
+
+This document describes how Unreal Engine 5's Nanite virtualized geometry techniques can be applied to the non-terrain rendering systems in this engine. Each section maps a Nanite concept to our existing infrastructure, identifies what we already have, and details what needs to be built.
+
+## Background: What Nanite Does
+
+Nanite is a virtualized geometry system that renders arbitrarily complex meshes at near-constant GPU cost. Its core ideas are:
+
+1. **Cluster-based mesh representation** — meshes split into ~128-triangle clusters organized in a DAG (directed acyclic graph) for hierarchical LOD
+2. **GPU-driven cluster selection** — a compute shader walks the DAG and selects the appropriate LOD clusters based on screen-space error
+3. **Two-phase occlusion culling** — last frame's depth culls most clusters; a second pass catches disoccluded geometry
+4. **Visibility buffer rendering** — rasterize cluster ID + triangle ID per pixel, then shade in a deferred fullscreen pass
+5. **Software rasterization** — clusters whose triangles project to sub-pixel size are rasterized via compute shader (avoids hardware raster inefficiency on tiny triangles)
+
+---
+
+## Current State
+
+### What's built
+
+| Component | Status | Location |
+|---|---|---|
+| Mesh clustering (64-tri clusters) | Built | `MeshClusterBuilder.h/.cpp` |
+| Cluster DAG with meshoptimizer simplification | Built | `MeshClusterBuilder::buildWithDAG()` |
+| GPU cluster buffer (global vertex/index SSBOs) | Built | `GPUClusterBuffer` |
+| GPU DAG LOD selection compute shader | Built | `shaders/cluster_select.comp` |
+| Two-pass occlusion culler (LOD select + cull + indirect) | Built | `TwoPassCuller.h/.cpp`, `shaders/cluster_cull.comp` |
+| Normal cone backface culling | Built | `cluster_cull.comp:170-178` |
+| V-buffer render target (R32G32_UINT) | Built | `VisibilityBuffer.h/.cpp` |
+| V-buffer raster pipeline (visbuf.vert/frag) | Built | `shaders/visbuf.vert`, `shaders/visbuf.frag` |
+| Compute material resolve (PBR + lights) | Built | `shaders/visbuf_resolve.comp` |
+| Material texture array (sampler2DArray) | Built | `VisibilityBuffer::buildMaterialTextureArray()` |
+| GPU material buffer (per-material PBR data) | Built | `GPUMaterialBuffer` |
+| Hi-Z depth pyramid | Built | `HiZSystem`, `shaders/hiz_downsample.comp` |
+
+### What's broken: the integration
+
+The individual subsystems exist but are not properly integrated into the rendering pipeline. The current state is a broken hybrid:
+
+1. **HDR pass** (priority 30) renders sky, terrain, rocks, trees, grass, water, weather, debug lines — everything. It begins an `R16G16B16A16_SFLOAT` render pass, clears color+depth, and draws all registered `IHDRDrawable` implementations inline.
+
+2. **V-buffer raster** (priority 31) renders ECS scene objects into a **separate** R32G32_UINT render target with its own render pass and framebuffer. It uses `VisBufferPasses::executeRasterPass()` which does immediate per-cluster draws with push constants.
+
+3. **V-buffer resolve** (priority 28) runs a compute shader that reads the V-buffer, reconstructs geometry, evaluates PBR, and tries to `imageStore` the result **into the HDR color image**. This requires layout transitions (SHADER_READ_ONLY → GENERAL → SHADER_READ_ONLY) and depth comparison against the HDR depth buffer.
+
+4. `SceneObjectsDrawable` has a `visBufferActive` flag that skips ECS objects in the HDR pass when V-buffer is enabled. But rocks, trees, and everything else still render in HDR.
+
+5. `TwoPassCuller` is built but **not wired** into the rendering pipeline. V-buffer raster does immediate draws instead of consuming indirect draw buffers from the culler.
+
+**Problems:**
+- The resolve compute shader writes into an image owned by a different render pass, requiring fragile layout transition hacks
+- Two separate depth buffers (V-buffer owns one, HDR owns one) with no shared depth testing
+- Only ECS scene objects go through V-buffer; rocks and other static meshes bypass it entirely
+- TwoPassCuller output (indirect draw buffers) is not consumed by anything
+- Per-cluster push constants instead of GPU-driven indirect draws
+
+---
+
+## What We Already Have (pre-Nanite)
+
+| Existing System | Nanite Parallel | Location |
+|---|---|---|
+| GPU frustum culling (compute) | Cluster culling dispatch | `shaders/scene_cull.comp`, `GPUSceneBuffer` |
+| Hi-Z depth pyramid | Occlusion culling input | `HiZSystem` |
+| `vkCmdDrawIndexedIndirectCount` | GPU-driven draw submission | `SceneObjectsDrawable::recordSceneObjectsIndirect` |
+| Tree impostor LOD with dither cross-fade | LOD transitions | `TreeLODSystem`, `dither_common.glsl` |
+| SSBO instance data + atomic draw count | GPU scene buffer pattern | `GPUSceneBuffer` (8192 max objects) |
+| Per-object AABB + bounding sphere | Bounds for culling | `Mesh::AABB`, `GPUCullObjectData` |
+| Impostor Hi-Z occlusion culling | Two-phase culling (partial) | `ImpostorCullSystem`, `tree_impostor_cull.comp` |
+
+---
+
+## Phase 1: Mesh Clustering
+
+### Goal
+Split every static mesh into clusters of ~64–128 triangles with precomputed bounding information and a simplification error metric.
+
+### Status: DONE
+
+`MeshClusterBuilder` implements this. `build()` creates flat clusters; `buildWithDAG()` builds the full hierarchy. `GPUClusterBuffer` manages global vertex/index SSBOs.
+
+### Runtime data structures
+
+```cpp
+struct MeshCluster {
+    glm::vec4 boundingSphere;   // xyz center, w radius
+    glm::vec4 normalCone;       // xyz cone axis, w cos(half-angle)
+    glm::vec4 aabbMin;
+    glm::vec4 aabbMax;
+    float maxError;             // object-space simplification error
+    uint32_t firstIndex;        // into global index buffer
+    uint32_t indexCount;         // triangle count * 3
+    uint32_t lodLevel;          // hierarchy depth
+};
+```
+
+### Applicable Systems
+
+| System | Current Geometry | Cluster Benefit |
+|---|---|---|
+| Scene objects (ECS) | Individual meshes, 1 cull entry each | Fine-grained culling for complex meshes |
+| Rocks (`ScatterSystem`) | Procedural `createRock()` | Hundreds of instances; cluster LOD removes distant detail |
+| Trees (`TreeSystem`) | Branch meshes + leaf instances | Branch geometry benefits from cluster LOD instead of hard impostor switch |
+| Catmull-Clark (`CatmullClarkSystem`) | Subdivision surfaces | High poly output; clusters enable progressive detail |
+| Skinned characters | Skeletal meshes | Partial — clusters work for static parts; animated parts need per-frame bounds update |
+
+---
+
+## Phase 2: Cluster DAG for Hierarchical LOD
+
+### Goal
+Build a DAG where groups of clusters at level N simplify into a parent cluster at level N+1. The GPU walks the DAG at runtime and selects the coarsest level that satisfies a screen-space error threshold.
+
+### Status: DONE (offline tool + compute shader)
+
+`MeshClusterBuilder::buildWithDAG()` builds the hierarchy. `cluster_select.comp` does GPU LOD selection. `TwoPassCuller` orchestrates the dispatch.
+
+### Runtime DAG node
+
+```cpp
+struct ClusterDAGNode {
+    MeshCluster cluster;
+    uint32_t parentIndex;           // UINT32_MAX for root
+    uint32_t firstChildIndex;       // into children array
+    uint32_t childCount;            // 0 for leaf nodes
+    float parentError;              // error of parent cluster
+};
+```
+
+### GPU LOD selection (`shaders/cluster_select.comp`)
+
+```glsl
+float screenError = projectError(node.cluster.maxError, node.cluster.boundingSphere, viewProj, screenHeight);
+float parentScreenError = projectError(node.parentError, node.cluster.boundingSphere, viewProj, screenHeight);
+bool shouldRender = (screenError <= errorThreshold) && (parentScreenError > errorThreshold);
+```
+
+### Integration with Existing LOD Systems
+
+**Trees**: The current hard switch between full geometry and billboard impostor (`TreeLODState::Level`) would become a smooth continuum. The cluster DAG naturally produces coarser representations at distance. Impostors remain as the ultimate LOD level beyond the DAG's coarsest cluster — the impostor becomes the "root" of the DAG for each tree archetype.
+
+**Rocks**: Currently rendered at full detail regardless of distance. The DAG gives rocks automatic distance-based simplification with no additional per-system logic.
+
+**Scene objects**: The same system handles all static meshes uniformly, replacing the current per-object `GPUCullObjectData` with per-cluster entries.
+
+---
+
+## Phase 3: Two-Phase Occlusion Culling
+
+### Goal
+Use last frame's depth buffer to reject occluded clusters before rasterization, then catch newly-visible clusters in a second pass.
+
+### Status: Built (`TwoPassCuller`), NOT INTEGRATED
+
+`TwoPassCuller` implements the full two-pass pipeline (LOD select → cull pass 1 → Hi-Z rebuild → cull pass 2) and produces indirect draw buffers. But nothing consumes those buffers yet — `VisBufferPasses` does immediate per-cluster draws with push constants instead.
+
+### Approach
+
+We already have the `HiZSystem` producing a depth pyramid. The current `scene_cull.comp` has a `enableHiZ` uniform but only performs frustum culling. This phase activates occlusion culling.
+
+**Pass 1 — Cull against previous frame's Hi-Z**:
+
+1. After cluster LOD selection, run `cluster_cull.comp`:
+   - Frustum test (existing sphere + AABB logic)
+   - Backface cluster culling using normal cone vs camera direction
+   - **Hi-Z occlusion test**: project cluster bounding sphere to screen-space rect, sample the Hi-Z pyramid at the appropriate mip, compare max depth
+2. Surviving clusters go into the indirect draw buffer
+3. Rasterize visible clusters → update depth buffer → rebuild Hi-Z pyramid
+
+**Pass 2 — Catch disoccluded geometry**:
+
+1. Re-run culling on clusters that were **occluded in pass 1** but test against the **new** Hi-Z from pass 1's rasterization
+2. Clusters that now pass get appended to the draw buffer
+3. Rasterize the additional clusters
+
+**Integration**: This extends the existing `FrameGraph` with two new nodes at the start of the HDR stage:
+
+```
+Level 0: Compute (terrain LOD, grass sim, weather, cluster select + cull pass 1)
+Level 1: Shadow, Froxel, WaterGBuffer, Cluster raster pass 1 (parallel)
+Level 1.5: Hi-Z rebuild + Cluster cull pass 2
+Level 2: Cluster raster pass 2 + HDR main scene
+```
+
+**What changes in existing code**:
+- `HiZSystem` currently runs in the post stage. It needs to also run mid-frame after pass 1
+- `scene_cull.comp` gains Hi-Z sampling logic (the binding `BINDING_SCENE_CULL_HIZ` already exists but is unused)
+- `GPUSceneBuffer` grows a "deferred" indirect buffer for pass 2 results
+
+---
+
+## Phase 4: Visibility Buffer Integration
+
+### Goal
+Make the V-buffer the primary rendering path for opaque static geometry. The V-buffer raster and resolve replace the forward shading that currently happens for these objects in the HDR pass. Non-V-buffer systems (terrain, water, grass, sky, particles) continue rendering in the HDR pass.
+
+### Status: Partially built, poorly integrated
+
+The V-buffer raster pipeline, resolve compute shader, material texture array, and GPU material buffer all work individually. The integration into the frame graph is the problem — the V-buffer currently runs as a secondary overlay that tries to composite into the HDR pass's render targets via compute `imageStore`.
+
+### Target architecture
+
+The V-buffer raster pass and the HDR render pass share the same depth buffer. The V-buffer rasters first into its uint target while also writing depth. Then the HDR render pass begins with `loadOp = eLoad` on depth (preserving V-buffer depth writes) and `loadOp = eClear` on color. Non-V-buffer drawables render into HDR as before. Finally the resolve compute shader reads the V-buffer and writes resolved materials into the HDR color target.
+
+This means V-buffer objects participate in depth testing against HDR objects naturally — no separate depth comparison needed in the resolve shader.
+
+### Frame graph pass ordering
+
+```
+Compute [100] ──> Shadow [50], Froxel [50], WaterGBuffer [40]
+                      │
+              ┌───────┴────────┐
+              v                v
+     ClusterSelect [92]   (other compute)
+              │
+              v
+     ClusterCull [91]
+              │
+              v
+     VisBufferRaster [35]     ← writes uint V-buffer + shared depth
+              │
+              v
+     HDR [30]                  ← loads depth (preserves V-buffer writes), clears color
+              │                  renders: sky, terrain, rocks*, trees*, grass, water, weather
+              v
+     VisBufferResolve [28]     ← compute: reads V-buffer, imageStore to HDR color
+              │
+              v
+     HiZ [15], SSR [20], Bloom [10], etc.
+              │
+              v
+     PostProcess [0]
+```
+
+*Rocks and trees move to V-buffer path incrementally (see Phase 6).
+
+### Step-by-step integration plan
+
+**Step 1: Share the depth buffer**
+
+The V-buffer raster pass and the HDR pass must use the **same** depth image. Currently they each own separate depth attachments.
+
+- `PostProcessSystem` owns the HDR depth image (`hdrDepthImage`, D32_SFLOAT)
+- `VisibilityBuffer` owns a separate depth image (`depthImage_`, D32_SFLOAT)
+- Change: `VisibilityBuffer` stops creating its own depth image. Instead, it receives the HDR depth image/view at init (or via a setter) and uses it in its framebuffer
+- The V-buffer render pass attachment description for depth uses `loadOp = eClear`, `storeOp = eStore`, `finalLayout = eDepthStencilAttachmentOptimal` (not READ_ONLY, because HDR needs to continue writing to it)
+- The HDR render pass depth attachment changes to `loadOp = eLoad` (not eClear) so V-buffer depth writes are preserved
+- Both passes write to the same depth image — standard Vulkan depth testing handles visibility between V-buffer and HDR objects
+
+**Step 2: V-buffer raster runs before HDR**
+
+Already the case (priority 31 vs 30) but the dependency graph needs updating:
+
+- `VisBufferRaster` depends on: Compute, Shadow (for shadow maps if needed)
+- `HDR` depends on: `VisBufferRaster` (needs shared depth populated), Shadow, Froxel, WaterGBuffer
+- This ensures V-buffer depth writes are complete before HDR begins
+
+In `FrameGraphBuilder.cpp`:
+```cpp
+// V-buffer raster must complete before HDR (shared depth buffer)
+if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
+    frameGraph.addDependency(computeIds.compute, visBufferIds.raster);
+    frameGraph.addDependency(visBufferIds.raster, hdr);  // HDR loads V-buffer depth
+}
+```
+
+**Step 3: HDR clears color only, loads depth**
+
+The HDR render pass in `PostProcessSystem::createRenderPass()` currently clears both color and depth. When V-buffer is active:
+
+- Color: `loadOp = eClear` (still clear — V-buffer objects haven't written color yet, only IDs)
+- Depth: `loadOp = eLoad` (preserve V-buffer raster depth writes)
+
+This can be a separate render pass variant, or the `VisibilityBuffer` can set a flag that `PostProcessSystem` checks when creating the render pass.
+
+HDR drawables (sky, terrain, grass, water, rocks*) render as before. Their fragments are depth-tested against V-buffer geometry naturally via the shared depth buffer — no special logic needed.
+
+**Step 4: Resolve writes to HDR color**
+
+The resolve compute shader runs after HDR (priority 28). At this point:
+- HDR color is in `SHADER_READ_ONLY_OPTIMAL` (set by HDR render pass `finalLayout`)
+- V-buffer uint image is in `SHADER_READ_ONLY_OPTIMAL` (set by V-buffer render pass `finalLayout`)
+- Shared depth is in `DEPTH_STENCIL_READ_ONLY_OPTIMAL` (set by HDR render pass `finalLayout`)
+
+The resolve pass needs:
+- V-buffer image: transition to `GENERAL` for storage image read
+- HDR color image: transition to `GENERAL` for `imageStore`
+- Depth: already in `READ_ONLY`, just needs memory dependency for sampling
+
+After dispatch:
+- HDR color: transition back to `SHADER_READ_ONLY_OPTIMAL` for post-processing
+
+The resolve shader no longer needs to compare V-buffer depth against HDR depth — the shared depth buffer already resolved visibility during rasterization. The depth comparison code in `visbuf_resolve.comp` can be removed.
+
+**Step 5: Remove duplicate rendering**
+
+Once depth is shared, `SceneObjectsDrawable::visBufferActive` correctly skips ECS objects in HDR. V-buffer resolve writes their shaded output to the HDR color image. Other HDR drawables (sky, terrain, etc.) render normally and coexist via shared depth.
+
+**Step 6: Wire TwoPassCuller indirect draws**
+
+Replace the immediate per-cluster draws in `VisBufferPasses::executeRasterPass()` with indirect draws from `TwoPassCuller`:
+
+- Add `ClusterSelect` and `ClusterCull` as compute passes in the frame graph (before `VisBufferRaster`)
+- `TwoPassCuller::recordLODSelection()` → populates selected cluster buffer
+- `TwoPassCuller::recordCullPass()` → populates indirect draw buffer
+- `VisBufferRaster` binds the cluster vertex/index buffer and calls `vkCmdDrawIndexedIndirectCount` using TwoPassCuller's indirect buffer + draw count buffer
+- Push constants are eliminated — the vertex shader reads instance data from SSBO using `gl_InstanceIndex` or `gl_DrawID`
+
+### What this replaces
+
+- The current `shader.vert`/`shader.frag` pipeline with push constants per object (for V-buffer objects)
+- Material sorting in `SceneObjectsDrawable` (no longer needed — all materials resolved in one compute pass)
+- Per-object descriptor set switches (material textures accessed via bindless array)
+- The separate V-buffer depth image
+- The depth comparison hack in `visbuf_resolve.comp`
+- Per-cluster immediate draw calls (replaced by indirect draws from TwoPassCuller)
+
+### Prerequisite — Bindless textures
+
+- Requires `VK_EXT_descriptor_indexing` (widely supported)
+- Create a single large descriptor array of all material textures
+- Each cluster references a material index; the resolve shader indexes into the texture array
+- This replaces the current pattern of per-material descriptor set binding
+
+### V-buffer vs HDR pass ownership
+
+| System | Renders in | Reason |
+|---|---|---|
+| Scene objects (ECS static) | V-buffer | Standard opaque meshes |
+| Rocks | V-buffer (Phase 6.1) | Static procedural meshes |
+| Tree branches | V-buffer (Phase 6.2) | Static per-frame (wind applied in resolve) |
+| Catmull-Clark surfaces | V-buffer (Phase 6.4) | High poly, benefits from cluster LOD |
+| Sky | HDR pass | Fullscreen, no geometry benefit |
+| Terrain | HDR pass | Own LOD system (CBT), heightmap-based |
+| Grass | HDR pass | Compute-generated, stochastic density |
+| Water | HDR pass | FFT displacement, custom shading model |
+| Tree leaves | HDR pass | Instanced billboards with per-leaf attributes |
+| Tree impostors | HDR pass | Billboard with atlas sampling |
+| Skinned characters | HDR pass (for now) | Needs skeleton transform |
+| Particles/weather | HDR pass | Alpha blended, low poly |
+
+---
+
+## Phase 5: Software Rasterization for Small Clusters
+
+### Goal
+Clusters that project to very small screen area (triangles < ~4 pixels) are inefficient to rasterize with hardware (poor quad occupancy). A compute shader can rasterize these more efficiently.
+
+### Approach
+
+During cluster culling, classify each visible cluster:
+- **Large clusters** (projected area > threshold): hardware rasterize via indirect draw
+- **Small clusters** (projected area < threshold): software rasterize via compute shader
+
+**Software rasterizer** (`shaders/cluster_sw_raster.comp`):
+1. Each workgroup processes one small cluster
+2. Transform vertices to screen space
+3. For each triangle, compute 2D bounding box
+4. Rasterize pixels using edge function tests
+5. Atomic depth test + write to visibility buffer (`imageAtomicMin` on a uint64 image encoding depth + visibility ID)
+
+**Why this matters for our scene**: Rocks and tree branches at distance produce many sub-pixel triangles. Currently these burn rasterizer throughput for minimal visual contribution. The software path handles them in compute alongside the cluster culling passes.
+
+---
+
+## Phase 6: Per-System Application Details
+
+### 6.1 Rocks (`ScatterSystem`)
+
+**Current state**: Procedural `createRock()` meshes, rendered as individual `Renderable` objects via `SceneObjectsDrawable` in the HDR pass. Own descriptor sets for rock textures. No LOD.
+
+**Migration to V-buffer**:
+1. Cluster each rock archetype's mesh via `MeshClusterBuilder::buildWithDAG()`
+2. Upload clusters to `GPUClusterBuffer` alongside scene object clusters
+3. Add rock instances to the V-buffer instance buffer (transform + material index)
+4. Rock materials go into `GPUMaterialBuffer`; rock textures into the material texture array
+5. Remove rock rendering from `SceneObjectsDrawable` (delete the `resources_.rocks` block)
+6. Rocks now participate in cluster LOD selection and two-pass occlusion culling automatically
+
+**Expected improvement**: Rocks currently have no LOD. With the DAG, a rock at 500m renders perhaps 4-8 triangles instead of hundreds. With occlusion culling, rocks behind terrain ridges are fully skipped.
+
+### 6.2 Trees (`TreeSystem` + `TreeLODSystem`)
+
+**Current state**: Two discrete LOD levels — full branch geometry or billboard impostor. Cross-fade uses IGN dithering. Leaves have GPU frustum culling with spatial cells.
+
+**Nanite application**:
+1. Cluster the branch mesh per tree archetype
+2. Build a DAG hierarchy per archetype with progressive simplification
+3. At the coarsest DAG level (just a few clusters), transition to the existing impostor system
+4. The hard Full→Impostor switch becomes: Full clusters → Coarse clusters → Impostor
+5. Leaf instances remain in their existing compute-culled pipeline (they're points/billboards, not mesh geometry)
+6. Per-tree cluster selection allows partial trees to simplify — far side of a tree canopy can be coarser than the near side
+
+**Integration detail**: `TreeLODState` currently tracks `FullDetail / Impostor / Blending`. Add a `Clustered` level that uses the DAG. The blend factor drives the DAG error threshold — as blend increases, the error threshold rises and coarser clusters are selected, until the impostor takes over.
+
+### 6.3 Scene Objects (ECS Entities)
+
+**Current state**: `GPUSceneBuffer` collects up to 8192 objects. Compute shader frustum culls and emits indirect draw commands. Push constants carry per-object PBR params. When `visBufferActive` is true, ECS objects skip the HDR pass and render through V-buffer instead.
+
+**Nanite application**:
+1. Replace per-object entries with per-cluster entries in `GPUSceneBuffer`
+2. The `GPUCullObjectData` struct adds cluster-specific fields (normal cone, DAG parent/child links, error metric)
+3. The `MAX_GPU_SCENE_OBJECTS` limit (8192) becomes a cluster limit — increase to 64K–256K
+4. The compute cull shader gains the DAG traversal, normal cone culling, and Hi-Z occlusion test
+5. Per-instance data (`GPUSceneInstanceData`) stays as-is — clusters share their object's instance data via `objectIndex`
+6. With visibility buffer rendering, push constants and per-material descriptor switching are eliminated — the resolve pass handles all materials
+
+### 6.4 Catmull-Clark Subdivision Surfaces
+
+**Current state**: CPU or GPU subdivision producing high-poly output rendered conventionally.
+
+**Nanite application**: Subdivision surfaces naturally produce massive triangle counts. Clustering the output and building a DAG means the subdivision can target maximum quality, and the DAG handles LOD. At distance, a subdivided mesh might render as just its base cage triangles.
+
+### 6.5 Skinned Characters
+
+**Current state**: Skeletal animation with bone matrices, individual draw calls.
+
+**Nanite application** (partial):
+- Cluster the mesh, but cluster bounds must be updated per-frame after skinning (compute pass)
+- Simpler alternative: apply Nanite clustering only to **static attachments** (armor, weapons, accessories) while the body mesh uses a traditional LOD chain
+- The visibility buffer can include skinned clusters if the resolve shader applies bone transforms during attribute interpolation
+
+---
+
+## Phase 7: Streaming and Memory Management
+
+### Goal
+Virtualized geometry means only resident clusters need GPU memory. Clusters are streamed on demand.
+
+### Approach
+
+1. **Cluster pool**: A large pre-allocated GPU buffer holding cluster index data. Clusters are loaded/evicted like virtual texture tiles.
+2. **Residency feedback**: After cluster selection, the compute shader flags which clusters are needed. A readback pass identifies missing clusters for async loading.
+3. **Integration with `AsyncTransferManager`**: Use the existing dedicated transfer queue for background cluster uploads.
+4. **Fallback**: If a cluster isn't resident, render its parent (coarser LOD). The DAG guarantees a parent is always available (loaded eagerly at init).
+
+This mirrors how `TerrainTileCache` and `VirtualTextureSystem` manage terrain tile residency — the same pattern applied to mesh geometry.
+
+---
+
+## Implementation Order and Dependencies
+
+```
+Phase 1: Mesh Clustering .......................... DONE
+   ↓
+Phase 2: Cluster DAG + GPU LOD Selection .......... DONE
+   ↓
+Phase 4: V-Buffer Integration ..................... IN PROGRESS
+   Step 1: Share depth buffer between V-buffer and HDR
+   Step 2: Fix frame graph ordering (V-buffer raster → HDR → resolve)
+   Step 3: HDR loads depth instead of clearing it
+   Step 4: Proper resolve barriers (V-buffer + HDR color)
+   Step 5: Remove duplicate rendering paths
+   Step 6: Wire TwoPassCuller indirect draws
+   ↓                              ↓
+Phase 3: Two-Phase Occlusion    Phase 6.1-6.2: Apply to rocks & trees
+   ↓                              ↓
+Phase 6.3-6.4: Scene objects    Phase 6.3-6.4: Catmull-Clark & subdivision
+   ↓
+Phase 5: Software Rasterization (optimization, can defer)
+   ↓
+Phase 7: Streaming (optimization, can defer)
+```
+
+Phase 4 integration is the current blocker. Steps 1-3 (shared depth) are the critical path — once V-buffer and HDR share a depth buffer, the fragile layout transition hacks and depth comparison code in the resolve shader go away. Step 6 (TwoPassCuller) eliminates the per-cluster push constant draws.
+
+Each step produces a working renderer. After step 3, V-buffer objects are visible and depth-correct against HDR objects. After step 6, rendering is fully GPU-driven.
+
+---
+
+## Vulkan Feature Requirements
+
+| Feature | Used For | Availability |
+|---|---|---|
+| `VK_EXT_descriptor_indexing` | Bindless textures in visibility resolve | Vulkan 1.2 core |
+| `vkCmdDrawIndexedIndirectCount` | Variable-length indirect draws | Already used |
+| `VK_KHR_shader_atomic_int64` | Software rasterizer depth test | Wide support on desktop |
+| `VK_EXT_shader_image_atomic_int64` | Visibility buffer atomic writes | Phase 5 only |
+| Compute shader SSBOs | DAG traversal, cluster culling | Already used throughout |
+
+No features beyond what desktop Vulkan 1.2+ provides. The engine already uses indirect count draws and compute SSBOs extensively.

--- a/shaders/bindings.h
+++ b/shaders/bindings.h
@@ -499,6 +499,32 @@
 #define BINDING_TERRAIN_SCREEN_SHADOW     31   // Terrain set: screen-space shadow buffer
 
 // =============================================================================
+// Visibility Buffer Descriptor Set (compute resolve pass)
+// =============================================================================
+#define BINDING_VISBUF_VISIBILITY          0   // Visibility buffer (uimage2D, RG32UI — 64-bit)
+#define BINDING_VISBUF_DEPTH               1   // Depth buffer (sampler2D)
+#define BINDING_VISBUF_HDR_OUTPUT          2   // HDR output (image2D, RGBA16F)
+#define BINDING_VISBUF_VERTEX_BUFFER       3   // Global vertex buffer (SSBO)
+#define BINDING_VISBUF_INDEX_BUFFER        4   // Global index buffer (SSBO)
+#define BINDING_VISBUF_INSTANCE_BUFFER     5   // Instance data (SSBO)
+#define BINDING_VISBUF_MATERIAL_BUFFER     6   // Material data (SSBO)
+#define BINDING_VISBUF_UNIFORMS            7   // Resolve uniforms (UBO)
+#define BINDING_VISBUF_TEXTURE_ARRAY       8   // Material texture array (sampler2DArray)
+#define BINDING_VISBUF_HDR_DEPTH           9   // HDR pass depth buffer (sampler2D) for depth comparison
+#define BINDING_VISBUF_LIGHT_BUFFER        10  // Dynamic light SSBO for multi-light resolve
+
+// Visibility Buffer Raster Pass (GPU-driven indirect draws)
+#define BINDING_VISBUF_RASTER_DRAW_DATA    2   // Per-draw data SSBO (instanceId, triangleOffset)
+#define BINDING_VISBUF_RASTER_INSTANCES    3   // Instance transforms SSBO (from GPUSceneBuffer)
+
+// Cluster Cull Compute (additional output alongside indirect commands)
+#define BINDING_CLUSTER_CULL_DRAW_DATA    10   // Per-draw data SSBO output (parallel to indirect commands)
+
+// Visibility Buffer Debug Visualization (fullscreen pass)
+#define BINDING_VISBUF_DEBUG_INPUT         0   // Visibility buffer input (usampler2D)
+#define BINDING_VISBUF_DEBUG_DEPTH_INPUT   1   // Depth buffer input (sampler2D)
+
+// =============================================================================
 // C++ Type-Safe Wrappers
 // =============================================================================
 #ifdef __cplusplus
@@ -885,6 +911,23 @@ constexpr uint32_t SHADOW_RESOLVE_UNIFORMS = BINDING_SHADOW_RESOLVE_UNIFORMS;
 constexpr uint32_t SCREEN_SHADOW           = BINDING_SCREEN_SHADOW;
 constexpr uint32_t GRASS_SCREEN_SHADOW     = BINDING_GRASS_SCREEN_SHADOW;
 constexpr uint32_t TERRAIN_SCREEN_SHADOW   = BINDING_TERRAIN_SCREEN_SHADOW;
+
+// Visibility Buffer
+constexpr uint32_t VISBUF_VISIBILITY       = BINDING_VISBUF_VISIBILITY;
+constexpr uint32_t VISBUF_DEPTH            = BINDING_VISBUF_DEPTH;
+constexpr uint32_t VISBUF_HDR_OUTPUT       = BINDING_VISBUF_HDR_OUTPUT;
+constexpr uint32_t VISBUF_VERTEX_BUFFER    = BINDING_VISBUF_VERTEX_BUFFER;
+constexpr uint32_t VISBUF_INDEX_BUFFER     = BINDING_VISBUF_INDEX_BUFFER;
+constexpr uint32_t VISBUF_INSTANCE_BUFFER  = BINDING_VISBUF_INSTANCE_BUFFER;
+constexpr uint32_t VISBUF_MATERIAL_BUFFER  = BINDING_VISBUF_MATERIAL_BUFFER;
+constexpr uint32_t VISBUF_UNIFORMS         = BINDING_VISBUF_UNIFORMS;
+constexpr uint32_t VISBUF_HDR_DEPTH        = BINDING_VISBUF_HDR_DEPTH;
+constexpr uint32_t VISBUF_LIGHT_BUFFER     = BINDING_VISBUF_LIGHT_BUFFER;
+constexpr uint32_t VISBUF_RASTER_DRAW_DATA = BINDING_VISBUF_RASTER_DRAW_DATA;
+constexpr uint32_t VISBUF_RASTER_INSTANCES = BINDING_VISBUF_RASTER_INSTANCES;
+constexpr uint32_t CLUSTER_CULL_DRAW_DATA  = BINDING_CLUSTER_CULL_DRAW_DATA;
+constexpr uint32_t VISBUF_DEBUG_INPUT      = BINDING_VISBUF_DEBUG_INPUT;
+constexpr uint32_t VISBUF_DEBUG_DEPTH_INPUT = BINDING_VISBUF_DEBUG_DEPTH_INPUT;
 
 } // namespace Bindings
 

--- a/shaders/cluster_cull.comp
+++ b/shaders/cluster_cull.comp
@@ -1,0 +1,219 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_KHR_shader_subgroup_ballot : require
+
+#include "bindings.glsl"
+#include "cull_compute_common.glsl"
+#include "hiz_occlusion_common.glsl"
+#include "instancing_common.glsl"
+
+// Cluster culling compute shader
+// Phase 4: Two-pass occlusion culling for mesh clusters
+//
+// Pass 1: Test clusters from previous frame's visible set (fast path)
+// Pass 2: Test remaining clusters against newly built Hi-Z (catch newly visible)
+//
+// Each thread processes one cluster. Visible clusters write indirect draw commands.
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+// Cluster metadata buffer (must match C++ MeshCluster layout)
+struct ClusterData {
+    vec4 boundingSphere;    // xyz = center (object space), w = radius
+    vec3 aabbMin;
+    float _pad0;
+    vec3 aabbMax;
+    float _pad1;
+    vec3 coneAxis;
+    float coneAngle;        // cos(half-angle)
+    uint firstIndex;
+    uint indexCount;
+    uint firstVertex;
+    uint meshId;
+    float parentError;      // object-space error of parent cluster
+    float error;            // object-space error of this cluster
+    uint lodLevel;
+    uint parentIndex;       // index of parent (0xFFFFFFFF for root)
+    uint firstChildIndex;   // index of first child
+    uint childCount;        // number of children (0 = leaf)
+    uint _pad2;
+    uint _pad3;
+};
+
+layout(std430, binding = 0) readonly buffer ClusterBuffer {
+    ClusterData clusters[];
+};
+
+// Per-instance transforms
+struct InstanceTransform {
+    mat4 model;
+    vec4 materialParams;
+    vec4 emissiveColor;
+    uint pbrFlags;
+    float alphaTestThreshold;
+    float hueShift;
+    float _pad;
+};
+
+layout(std430, binding = 1) readonly buffer InstanceBuffer {
+    InstanceTransform instances[];
+};
+
+// Output: indirect draw commands
+layout(std430, binding = 2) writeonly buffer IndirectBuffer {
+    DrawIndexedIndirectCommand commands[];
+};
+
+// Output: draw count (atomic)
+layout(std430, binding = 3) buffer DrawCountBuffer {
+    uint drawCount;
+};
+
+// Output: visible cluster IDs (for next frame's pass 1)
+layout(std430, binding = 4) writeonly buffer VisibleClusterBuffer {
+    uint visibleClusters[];
+};
+
+// Output: visible cluster count
+layout(std430, binding = 5) buffer VisibleCountBuffer {
+    uint visibleCount;
+};
+
+// Culling uniforms
+layout(std140, binding = 6) uniform CullUniforms {
+    mat4 viewMatrix;
+    mat4 projMatrix;
+    mat4 viewProjMatrix;
+    vec4 frustumPlanes[6];
+    vec4 cameraPosition;
+    vec4 screenParams;      // width, height, 1/width, 1/height
+    vec4 depthParams;       // near, far, numMipLevels, unused
+    uint clusterCount;
+    uint instanceCount;
+    uint enableHiZ;         // 0 = frustum only, 1 = frustum + Hi-Z
+    uint maxDrawCommands;
+    uint passIndex;         // 0 = pass 1 (previous visible), 1 = pass 2 (remaining)
+    uint _pad0, _pad1, _pad2;
+} cull;
+
+// Hi-Z pyramid for occlusion testing
+layout(binding = 7) uniform sampler2D hiZPyramid;
+
+// Previous frame's visibility (for pass 2: skip already-tested clusters)
+layout(std430, binding = 8) readonly buffer PrevVisibleBuffer {
+    uint prevVisibleClusters[];
+};
+
+layout(std430, binding = 9) readonly buffer PrevVisibleCountBuffer {
+    uint prevVisibleCount;
+};
+
+// Per-draw data output (parallel to indirect commands, indexed by gl_DrawID in raster shader)
+struct DrawData {
+    uint instanceId;
+    uint triangleOffset;    // firstIndex / 3 (global triangle index for resolve)
+};
+
+layout(std430, binding = BINDING_CLUSTER_CULL_DRAW_DATA) writeonly buffer DrawDataBuffer {
+    DrawData drawData[];
+};
+
+void main() {
+    uint threadIdx = gl_GlobalInvocationID.x;
+
+    // Determine which cluster to test based on pass
+    uint clusterIdx;
+    if (cull.passIndex == 0u) {
+        // Pass 1: test clusters that were visible last frame
+        if (threadIdx >= prevVisibleCount) return;
+        clusterIdx = prevVisibleClusters[threadIdx];
+        if (clusterIdx >= cull.clusterCount) return;
+    } else {
+        // Pass 2: test all clusters (skip previously tested in a full implementation)
+        if (threadIdx >= cull.clusterCount) return;
+        clusterIdx = threadIdx;
+    }
+
+    ClusterData cluster = clusters[clusterIdx];
+
+    // For now, use instance 0 transform (multi-instance would iterate)
+    // In a full implementation, each (cluster, instance) pair is a draw
+    uint instanceIdx = cluster.meshId;  // Use meshId as instance index for now
+    if (instanceIdx >= cull.instanceCount) return;
+
+    mat4 model = instances[instanceIdx].model;
+
+    // Transform bounding sphere to world space
+    vec3 worldCenter = (model * vec4(cluster.boundingSphere.xyz, 1.0)).xyz;
+    float worldRadius = cluster.boundingSphere.w * length(vec3(model[0][0], model[1][0], model[2][0]));
+
+    // Frustum culling (sphere test)
+    vec4 planes[6];
+    for (int i = 0; i < 6; i++) planes[i] = cull.frustumPlanes[i];
+
+    if (!isSphereInFrustum(worldCenter, worldRadius, planes)) {
+        return;
+    }
+
+    // Transform AABB to world space (handles rotation/non-uniform scale correctly)
+    vec3 aabbMin, aabbMax;
+    transformAABB(model, cluster.aabbMin, cluster.aabbMax, aabbMin, aabbMax);
+
+    if (!isAABBInFrustum(planes, aabbMin, aabbMax)) {
+        return;
+    }
+
+    // Hi-Z occlusion test
+    if (cull.enableHiZ != 0u) {
+        uint maxMip = uint(cull.depthParams.z);
+        if (!hizOcclusionTestAABB(aabbMin, aabbMax, hiZPyramid,
+                                   cull.viewProjMatrix, cull.screenParams, maxMip)) {
+            return;  // Occluded
+        }
+    }
+
+    // Backface cluster culling (optional, based on normal cone)
+    if (cluster.coneAngle > 0.0) {
+        vec3 worldConeAxis = normalize(mat3(model) * cluster.coneAxis);
+        vec3 viewDir = normalize(worldCenter - cull.cameraPosition.xyz);
+        // If all normals face away from the camera, skip the cluster
+        if (dot(viewDir, worldConeAxis) > cluster.coneAngle) {
+            return;
+        }
+    }
+
+    // Cluster is visible! Write indirect draw command using subgroup batched atomics
+    uvec4 activeMask = subgroupBallot(true);
+    uint activeCount = subgroupBallotBitCount(activeMask);
+    uint laneOffset = subgroupBallotExclusiveBitCount(activeMask);
+
+    uint baseIdx = 0;
+    if (subgroupElect()) {
+        baseIdx = atomicAdd(drawCount, activeCount);
+    }
+    baseIdx = subgroupBroadcastFirst(baseIdx);
+
+    uint drawIdx = baseIdx + laneOffset;
+    if (drawIdx < cull.maxDrawCommands) {
+        commands[drawIdx].indexCount = cluster.indexCount;
+        commands[drawIdx].instanceCount = 1;
+        commands[drawIdx].firstIndex = cluster.firstIndex;
+        commands[drawIdx].vertexOffset = int(cluster.firstVertex);
+        commands[drawIdx].firstInstance = 0;
+
+        // Per-draw data for raster shader (indexed by gl_DrawID)
+        drawData[drawIdx].instanceId = instanceIdx;
+        drawData[drawIdx].triangleOffset = cluster.firstIndex / 3u;
+    }
+
+    // Record as visible for next frame's pass 1
+    uint visBaseIdx = 0;
+    if (subgroupElect()) {
+        visBaseIdx = atomicAdd(visibleCount, activeCount);
+    }
+    visBaseIdx = subgroupBroadcastFirst(visBaseIdx);
+
+    uint visIdx = visBaseIdx + laneOffset;
+    visibleClusters[visIdx] = clusterIdx;
+}

--- a/shaders/cluster_cull.comp
+++ b/shaders/cluster_cull.comp
@@ -200,9 +200,9 @@ void main() {
         commands[drawIdx].instanceCount = 1;
         commands[drawIdx].firstIndex = cluster.firstIndex;
         commands[drawIdx].vertexOffset = int(cluster.firstVertex);
-        commands[drawIdx].firstInstance = 0;
+        commands[drawIdx].firstInstance = drawIdx;  // Encodes draw index for gl_InstanceIndex in raster shader
 
-        // Per-draw data for raster shader (indexed by gl_DrawID)
+        // Per-draw data for raster shader (indexed by gl_InstanceIndex)
         drawData[drawIdx].instanceId = instanceIdx;
         drawData[drawIdx].triangleOffset = cluster.firstIndex / 3u;
     }

--- a/shaders/cluster_select.comp
+++ b/shaders/cluster_select.comp
@@ -1,0 +1,181 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+
+#include "bindings.glsl"
+#include "cull_compute_common.glsl"
+
+// Cluster DAG LOD selection compute shader — top-down traversal
+//
+// Processes one level of the DAG per dispatch. The CPU dispatches once per
+// DAG level, ping-ponging between input/output node buffers:
+//
+//   Pass 0: evaluate root clusters (CPU-seeded)
+//   Pass 1: evaluate children from pass 0
+//   Pass N: evaluate children from pass N-1
+//
+// For each input node:
+//   - If screen error <= threshold (or leaf): SELECT for rendering
+//   - If screen error > threshold: PUSH children into next-pass buffer
+//
+// This avoids the flat dispatch problem where every cluster in the DAG is
+// evaluated even if its ancestors already pass the error test.
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+// Cluster metadata (must match C++ MeshCluster and cluster_cull.comp ClusterData)
+struct ClusterData {
+    vec4 boundingSphere;    // xyz = center (object space), w = radius
+    vec3 aabbMin;
+    float _pad0;
+    vec3 aabbMax;
+    float _pad1;
+    vec3 coneAxis;
+    float coneAngle;
+    uint firstIndex;
+    uint indexCount;
+    uint firstVertex;
+    uint meshId;
+    float parentError;      // object-space error of parent cluster
+    float error;            // object-space error of this cluster
+    uint lodLevel;
+    uint parentIndex;       // index of parent (0xFFFFFFFF for root)
+    uint firstChildIndex;
+    uint childCount;        // 0 = leaf
+    uint _pad2;
+    uint _pad3;
+};
+
+layout(std430, binding = 0) readonly buffer ClusterBuffer {
+    ClusterData clusters[];
+};
+
+// Per-instance transforms (same as cluster_cull.comp)
+struct InstanceTransform {
+    mat4 model;
+    vec4 materialParams;
+    vec4 emissiveColor;
+    uint pbrFlags;
+    float alphaTestThreshold;
+    float hueShift;
+    float _pad;
+};
+
+layout(std430, binding = 1) readonly buffer InstanceBuffer {
+    InstanceTransform instances[];
+};
+
+// Output: selected cluster indices for culling (accumulated across all passes)
+layout(std430, binding = 2) writeonly buffer SelectedClusterBuffer {
+    uint selectedClusters[];
+};
+
+// Output: selected cluster count (atomic, accumulated across all passes)
+layout(std430, binding = 3) buffer SelectedCountBuffer {
+    uint selectedCount;
+};
+
+// Selection uniforms
+layout(std140, binding = 4) uniform SelectUniforms {
+    mat4 viewProjMatrix;
+    vec4 screenParams;      // width, height, 1/width, 1/height
+    uint totalClusterCount; // total clusters in the DAG (for bounds checking)
+    uint instanceCount;
+    float errorThreshold;   // max acceptable screen-space error in pixels (e.g. 1.0)
+    uint maxSelectedClusters;
+} sel;
+
+// Input: cluster indices to evaluate this pass
+layout(std430, binding = 5) readonly buffer InputNodeBuffer {
+    uint inputNodes[];
+};
+
+// Input: number of nodes to evaluate this pass
+layout(std430, binding = 6) readonly buffer InputNodeCountBuffer {
+    uint inputNodeCount;
+};
+
+// Output: child cluster indices for the next pass
+layout(std430, binding = 7) writeonly buffer OutputNodeBuffer {
+    uint outputNodes[];
+};
+
+// Output: count of child nodes for the next pass (atomic)
+layout(std430, binding = 8) buffer OutputNodeCountBuffer {
+    uint outputNodeCount;
+};
+
+void main() {
+    uint threadIdx = gl_GlobalInvocationID.x;
+
+    // Read node count from SSBO (set by CPU for first pass, by prev pass otherwise)
+    if (threadIdx >= inputNodeCount) return;
+
+    uint clusterIdx = inputNodes[threadIdx];
+    if (clusterIdx >= sel.totalClusterCount) return;
+
+    ClusterData cluster = clusters[clusterIdx];
+
+    // Use meshId as instance index
+    uint instanceIdx = cluster.meshId;
+    if (instanceIdx >= sel.instanceCount) return;
+
+    mat4 model = instances[instanceIdx].model;
+
+    // Transform bounding sphere to world space for error projection
+    vec3 worldCenter = (model * vec4(cluster.boundingSphere.xyz, 1.0)).xyz;
+    float scaleApprox = length(vec3(model[0][0], model[1][0], model[2][0]));
+    float worldRadius = cluster.boundingSphere.w * scaleApprox;
+    float worldError = cluster.error * scaleApprox;
+
+    vec4 worldSphere = vec4(worldCenter, worldRadius);
+    float screenHeight = sel.screenParams.y;
+
+    // Project this cluster's error to screen space
+    float myScreenError = projectErrorToScreen(worldError, worldSphere,
+                                                sel.viewProjMatrix, screenHeight);
+
+    bool isLeaf = (cluster.childCount == 0);
+    bool errorOk = (myScreenError <= sel.errorThreshold);
+
+    if (errorOk || isLeaf) {
+        // This cluster is detailed enough (or finest available) — select it
+        uvec4 selectMask = subgroupBallot(true);
+        uint selectCount = subgroupBallotBitCount(selectMask);
+        uint selectOffset = subgroupBallotExclusiveBitCount(selectMask);
+
+        uint selectBase = 0;
+        if (subgroupElect()) {
+            selectBase = atomicAdd(selectedCount, selectCount);
+        }
+        selectBase = subgroupBroadcastFirst(selectBase);
+
+        uint outIdx = selectBase + selectOffset;
+        if (outIdx < sel.maxSelectedClusters) {
+            selectedClusters[outIdx] = clusterIdx;
+        }
+    } else {
+        // Error too large — push children for next pass
+        // Each thread may push a different number of children, so we can't
+        // use the simple subgroup ballot pattern. Use per-thread atomics,
+        // but batch the total across the subgroup for efficiency.
+        uint myChildCount = cluster.childCount;
+        uint totalChildren = subgroupAdd(myChildCount);
+
+        uint subgroupBase = 0;
+        if (subgroupElect()) {
+            subgroupBase = atomicAdd(outputNodeCount, totalChildren);
+        }
+        subgroupBase = subgroupBroadcastFirst(subgroupBase);
+
+        // Compute this thread's offset within the subgroup allocation
+        uint myOffset = subgroupExclusiveAdd(myChildCount);
+        uint writePos = subgroupBase + myOffset;
+
+        for (uint c = 0; c < myChildCount; c++) {
+            outputNodes[writePos + c] = cluster.firstChildIndex + c;
+        }
+    }
+}

--- a/shaders/hiz_culling.comp
+++ b/shaders/hiz_culling.comp
@@ -5,10 +5,14 @@
 
 #include "bindings.glsl"
 #include "instancing_common.glsl"
+#include "hiz_occlusion_common.glsl"
 
 // Hi-Z Occlusion Culling Compute Shader
 // Performs frustum culling followed by hierarchical z-buffer occlusion culling
 // Outputs visible objects to an indirect draw buffer
+//
+// This shader is used by HiZSystem for its own culling pipeline.
+// The occlusion test logic is shared with scene_cull.comp via hiz_occlusion_common.glsl.
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -58,12 +62,6 @@ layout(std430, binding = BINDING_HIZ_CULL_COUNT) buffer DrawCountBuffer {
 // Hi-Z pyramid texture
 layout(binding = BINDING_HIZ_CULL_PYRAMID) uniform sampler2D hiZPyramid;
 
-// Frustum culling test for AABB using shared utility
-// Returns true if the AABB is completely outside the frustum (culled)
-bool frustumCullAABB(vec3 aabbMin, vec3 aabbMax) {
-    return !isAABBInFrustum(uniforms.frustumPlanes, aabbMin, aabbMax);
-}
-
 // Frustum culling test for bounding sphere (faster but less precise)
 bool frustumCullSphere(vec3 center, float radius) {
     for (int i = 0; i < 6; i++) {
@@ -73,114 +71,6 @@ bool frustumCullSphere(vec3 center, float radius) {
         }
     }
     return false;  // At least partially visible
-}
-
-// Project AABB to screen space and get bounding rectangle
-// Returns: xy = min screen coord, zw = max screen coord (in pixels)
-vec4 projectAABBToScreen(vec3 aabbMin, vec3 aabbMax) {
-    // Project all 8 corners
-    vec3 corners[8];
-    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
-    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
-    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
-    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
-    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
-    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
-    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
-    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
-
-    vec2 minScreen = vec2(1e10);
-    vec2 maxScreen = vec2(-1e10);
-    float closestZ = 1.0;  // Closest depth (largest value in reversed-Z)
-
-    for (int i = 0; i < 8; i++) {
-        vec4 clipPos = uniforms.viewProjMatrix * vec4(corners[i], 1.0);
-
-        // Handle behind camera
-        if (clipPos.w <= 0.0) {
-            // Corner is behind camera, expand to full screen
-            return vec4(0.0, 0.0, uniforms.screenParams.x, uniforms.screenParams.y);
-        }
-
-        // Perspective divide
-        vec3 ndc = clipPos.xyz / clipPos.w;
-
-        // Convert to screen coordinates
-        vec2 screen = (ndc.xy * 0.5 + 0.5) * uniforms.screenParams.xy;
-
-        minScreen = min(minScreen, screen);
-        maxScreen = max(maxScreen, screen);
-
-        // Track closest depth (for reversed-Z, closest = largest value)
-        closestZ = max(closestZ, ndc.z);
-    }
-
-    // Clamp to screen bounds
-    minScreen = max(minScreen, vec2(0.0));
-    maxScreen = min(maxScreen, uniforms.screenParams.xy);
-
-    return vec4(minScreen, maxScreen);
-}
-
-// Get the closest (maximum in reversed-Z) depth value of the AABB
-float getClosestDepth(vec3 aabbMin, vec3 aabbMax) {
-    // Project all 8 corners and find closest
-    vec3 corners[8];
-    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
-    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
-    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
-    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
-    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
-    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
-    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
-    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
-
-    float closestZ = 0.0;  // Farthest in reversed-Z
-
-    for (int i = 0; i < 8; i++) {
-        vec4 clipPos = uniforms.viewProjMatrix * vec4(corners[i], 1.0);
-        if (clipPos.w > 0.0) {
-            float ndcZ = clipPos.z / clipPos.w;
-            closestZ = max(closestZ, ndcZ);
-        }
-    }
-
-    return closestZ;
-}
-
-// Hi-Z occlusion test
-// Returns true if object is occluded (should be culled)
-bool hiZOcclusionTest(vec3 aabbMin, vec3 aabbMax) {
-    // Project AABB to screen
-    vec4 screenRect = projectAABBToScreen(aabbMin, aabbMax);
-
-    // Check if completely off screen
-    if (screenRect.x >= screenRect.z || screenRect.y >= screenRect.w) {
-        return true;  // Culled (off screen)
-    }
-
-    // Calculate the size of the projected rectangle
-    vec2 rectSize = screenRect.zw - screenRect.xy;
-
-    // Choose mip level based on rectangle size
-    // We want a mip where the rect covers roughly 2x2 texels
-    float maxDim = max(rectSize.x, rectSize.y);
-    float mipLevel = max(0.0, log2(maxDim) - 1.0);
-    mipLevel = min(mipLevel, uniforms.depthParams.z - 1.0);
-
-    // Sample Hi-Z at the center of the rectangle
-    vec2 centerUV = (screenRect.xy + screenRect.zw) * 0.5 * uniforms.screenParams.zw;
-
-    // Sample the Hi-Z pyramid
-    float hiZDepth = textureLod(hiZPyramid, centerUV, mipLevel).r;
-
-    // Get closest depth of the AABB
-    float objectDepth = getClosestDepth(aabbMin, aabbMax);
-
-    // In reversed-Z: larger depth = closer to camera
-    // Object is occluded if its closest point is farther than the Hi-Z depth
-    // (objectDepth < hiZDepth means object is behind what's in the depth buffer)
-    return objectDepth < hiZDepth;
 }
 
 void main() {
@@ -197,22 +87,23 @@ void main() {
     vec3 aabbMax = obj.aabbMax.xyz;
 
     // Step 1: Frustum culling (fast rejection)
-    // Use sphere test first for quick rejection
     vec3 sphereCenter = obj.boundingSphere.xyz;
     float sphereRadius = obj.boundingSphere.w;
 
     if (frustumCullSphere(sphereCenter, sphereRadius)) {
-        return;  // Culled by frustum (sphere)
+        return;
     }
 
-    // More precise AABB frustum test
-    if (frustumCullAABB(aabbMin, aabbMax)) {
-        return;  // Culled by frustum (AABB)
+    if (!isAABBInFrustum(uniforms.frustumPlanes, aabbMin, aabbMax)) {
+        return;
     }
 
     // Step 2: Hi-Z occlusion culling (if enabled)
     if (uniforms.enableHiZ != 0) {
-        if (hiZOcclusionTest(aabbMin, aabbMax)) {
+        float maxMip = uniforms.depthParams.z - 1.0;
+        if (hizOcclusionTestAABB(aabbMin, aabbMax, hiZPyramid,
+                                 uniforms.viewProjMatrix,
+                                 uniforms.screenParams, maxMip)) {
             return;  // Occluded
         }
     }

--- a/shaders/hiz_occlusion_common.glsl
+++ b/shaders/hiz_occlusion_common.glsl
@@ -1,0 +1,122 @@
+// Shared Hi-Z occlusion culling functions
+// Used by scene_cull.comp, hiz_culling.comp, and tree_impostor_cull.comp
+//
+// Requirements: caller must provide:
+//   - uniform sampler2D hiZPyramid  (the Hi-Z depth pyramid)
+//   - mat4 viewProjMatrix           (current frame view-projection)
+//   - vec4 screenParams             (x=width, y=height, z=1/width, w=1/height)
+//   - float hiZMaxMipLevel          (max valid mip level, e.g. numMipLevels - 1)
+//
+// Usage: #include "hiz_occlusion_common.glsl"
+
+#ifndef HIZ_OCCLUSION_COMMON_GLSL
+#define HIZ_OCCLUSION_COMMON_GLSL
+
+// Project an AABB to a screen-space bounding rectangle.
+// Returns vec4(minScreen.xy, maxScreen.xy) in pixels.
+// If any corner is behind the camera, returns full screen rect.
+vec4 hizProjectAABBToScreen(vec3 aabbMin, vec3 aabbMax,
+                            mat4 viewProjMat, vec4 scrParams) {
+    vec3 corners[8];
+    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
+    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
+    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
+    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
+    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
+    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
+    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
+    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
+
+    vec2 minScreen = vec2(1e10);
+    vec2 maxScreen = vec2(-1e10);
+
+    for (int i = 0; i < 8; i++) {
+        vec4 clipPos = viewProjMat * vec4(corners[i], 1.0);
+
+        // Corner behind camera — conservatively expand to full screen
+        if (clipPos.w <= 0.0) {
+            return vec4(0.0, 0.0, scrParams.x, scrParams.y);
+        }
+
+        vec3 ndc = clipPos.xyz / clipPos.w;
+        vec2 screen = (ndc.xy * 0.5 + 0.5) * scrParams.xy;
+
+        minScreen = min(minScreen, screen);
+        maxScreen = max(maxScreen, screen);
+    }
+
+    // Clamp to screen bounds
+    minScreen = max(minScreen, vec2(0.0));
+    maxScreen = min(maxScreen, scrParams.xy);
+
+    return vec4(minScreen, maxScreen);
+}
+
+// Get the closest depth of an AABB (maximum in reversed-Z = nearest to camera).
+float hizGetClosestDepth(vec3 aabbMin, vec3 aabbMax, mat4 viewProjMat) {
+    vec3 corners[8];
+    corners[0] = vec3(aabbMin.x, aabbMin.y, aabbMin.z);
+    corners[1] = vec3(aabbMax.x, aabbMin.y, aabbMin.z);
+    corners[2] = vec3(aabbMin.x, aabbMax.y, aabbMin.z);
+    corners[3] = vec3(aabbMax.x, aabbMax.y, aabbMin.z);
+    corners[4] = vec3(aabbMin.x, aabbMin.y, aabbMax.z);
+    corners[5] = vec3(aabbMax.x, aabbMin.y, aabbMax.z);
+    corners[6] = vec3(aabbMin.x, aabbMax.y, aabbMax.z);
+    corners[7] = vec3(aabbMax.x, aabbMax.y, aabbMax.z);
+
+    float closestZ = 0.0; // Farthest in reversed-Z
+
+    for (int i = 0; i < 8; i++) {
+        vec4 clipPos = viewProjMat * vec4(corners[i], 1.0);
+        if (clipPos.w > 0.0) {
+            float ndcZ = clipPos.z / clipPos.w;
+            closestZ = max(closestZ, ndcZ);
+        }
+    }
+
+    return closestZ;
+}
+
+// Hi-Z occlusion test for an AABB.
+// Returns true if the object is occluded (should be culled).
+// Uses reversed-Z: larger depth = closer to camera.
+bool hizOcclusionTestAABB(vec3 aabbMin, vec3 aabbMax,
+                          sampler2D hiZPyr, mat4 viewProjMat,
+                          vec4 scrParams, float maxMipLevel) {
+    // Project AABB to screen
+    vec4 screenRect = hizProjectAABBToScreen(aabbMin, aabbMax, viewProjMat, scrParams);
+
+    // Off screen
+    if (screenRect.x >= screenRect.z || screenRect.y >= screenRect.w) {
+        return true;
+    }
+
+    // Choose mip level: we want the rect to cover roughly 2x2 texels
+    vec2 rectSize = screenRect.zw - screenRect.xy;
+    float maxDim = max(rectSize.x, rectSize.y);
+    float mipLevel = max(0.0, log2(maxDim) - 1.0);
+    mipLevel = min(mipLevel, maxMipLevel);
+
+    // Sample Hi-Z at all 4 corners of the projected rectangle.
+    // A single center sample can miss occluders that don't cover the AABB center,
+    // leading to false culling. Sampling 4 corners and taking the min (farthest
+    // in reversed-Z) is conservative: we only cull if the entire region is occluded.
+    vec2 minUV = screenRect.xy * scrParams.zw;
+    vec2 maxUV = screenRect.zw * scrParams.zw;
+
+    float d0 = textureLod(hiZPyr, vec2(minUV.x, minUV.y), mipLevel).r;
+    float d1 = textureLod(hiZPyr, vec2(maxUV.x, minUV.y), mipLevel).r;
+    float d2 = textureLod(hiZPyr, vec2(minUV.x, maxUV.y), mipLevel).r;
+    float d3 = textureLod(hiZPyr, vec2(maxUV.x, maxUV.y), mipLevel).r;
+
+    // Reversed-Z: min = farthest depth = most conservative for occlusion
+    float hiZDepth = min(min(d0, d1), min(d2, d3));
+
+    // Get closest depth of the AABB
+    float objectDepth = hizGetClosestDepth(aabbMin, aabbMax, viewProjMat);
+
+    // Reversed-Z: objectDepth < hiZDepth means object is behind the depth buffer
+    return objectDepth < hiZDepth;
+}
+
+#endif // HIZ_OCCLUSION_COMMON_GLSL

--- a/shaders/scene_cull.comp
+++ b/shaders/scene_cull.comp
@@ -1,11 +1,16 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
 
 // Scene Object GPU Culling Compute Shader
-// Performs frustum culling on scene objects and generates indirect draw commands
+// Performs frustum culling + Hi-Z occlusion culling on scene objects
+// and generates indirect draw commands via subgroup-batched atomics.
 
 #include "bindings.glsl"
+#include "instancing_common.glsl"
+#include "hiz_occlusion_common.glsl"
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -20,15 +25,6 @@ struct CullObjectData {
     int vertexOffset;      // Vertex offset
 };
 
-// Output: Indirect draw command
-struct DrawIndexedIndirectCommand {
-    uint indexCount;
-    uint instanceCount;
-    uint firstIndex;
-    int vertexOffset;
-    uint firstInstance;
-};
-
 // Culling uniforms
 layout(std140, binding = BINDING_SCENE_CULL_UNIFORMS) uniform CullUniforms {
     mat4 viewMatrix;
@@ -37,8 +33,9 @@ layout(std140, binding = BINDING_SCENE_CULL_UNIFORMS) uniform CullUniforms {
     vec4 frustumPlanes[6];     // Frustum planes (xyz=normal, w=distance)
     vec4 cameraPosition;       // xyz = camera pos, w = unused
     vec4 screenParams;         // x = width, y = height, z = 1/width, w = 1/height
+    vec4 depthParams;          // x = near, y = far, z = numMipLevels, w = unused
     uint objectCount;          // Number of objects to cull
-    uint enableHiZ;            // 1 = use Hi-Z (future), 0 = frustum only
+    uint enableHiZ;            // 1 = use Hi-Z occlusion, 0 = frustum only
     uint maxDrawCommands;      // Output buffer capacity
     uint padding;
 } cullUniforms;
@@ -58,33 +55,14 @@ layout(std430, binding = BINDING_SCENE_CULL_COUNT) buffer DrawCountBuffer {
     uint drawCount;
 };
 
-// Optional: Hi-Z pyramid for occlusion culling (future)
+// Hi-Z pyramid for occlusion culling
 layout(binding = BINDING_SCENE_CULL_HIZ) uniform sampler2D hiZPyramid;
 
-// Test if sphere is inside frustum
+// Frustum test using bounding sphere (fast early rejection)
 bool frustumCullSphere(vec3 center, float radius) {
     for (int i = 0; i < 6; ++i) {
         float dist = dot(cullUniforms.frustumPlanes[i].xyz, center) + cullUniforms.frustumPlanes[i].w;
         if (dist < -radius) {
-            return true;  // Culled
-        }
-    }
-    return false;  // Visible
-}
-
-// Test if AABB is inside frustum (more precise than sphere test)
-bool frustumCullAABB(vec3 aabbMin, vec3 aabbMax) {
-    for (int i = 0; i < 6; ++i) {
-        vec4 plane = cullUniforms.frustumPlanes[i];
-
-        // Find the positive vertex (furthest along plane normal)
-        vec3 pVertex = vec3(
-            plane.x >= 0.0 ? aabbMax.x : aabbMin.x,
-            plane.y >= 0.0 ? aabbMax.y : aabbMin.y,
-            plane.z >= 0.0 ? aabbMax.z : aabbMin.z
-        );
-
-        if (dot(plane.xyz, pVertex) + plane.w < 0.0) {
             return true;  // Culled
         }
     }
@@ -100,33 +78,72 @@ void main() {
 
     CullObjectData obj = objects[objectIdx];
 
-    // Frustum culling using sphere first (fast rejection)
+    // Step 1: Frustum culling — sphere test (fast rejection)
     vec3 sphereCenter = obj.boundingSphere.xyz;
     float sphereRadius = obj.boundingSphere.w;
 
     if (frustumCullSphere(sphereCenter, sphereRadius)) {
-        return;  // Culled by sphere test
+        return;
     }
 
-    // Optional: More precise AABB test for objects that passed sphere test
+    // Step 2: Frustum culling — precise AABB test
     vec3 aabbMin = obj.aabbMin.xyz;
     vec3 aabbMax = obj.aabbMax.xyz;
 
-    if (frustumCullAABB(aabbMin, aabbMax)) {
-        return;  // Culled by AABB test
+    if (!isAABBInFrustum(cullUniforms.frustumPlanes, aabbMin, aabbMax)) {
+        return;
     }
 
-    // Object is visible - add to indirect draw buffer
-    uint drawIdx = atomicAdd(drawCount, 1);
-
-    if (drawIdx < cullUniforms.maxDrawCommands) {
-        DrawIndexedIndirectCommand cmd;
-        cmd.indexCount = obj.indexCount;
-        cmd.instanceCount = 1;
-        cmd.firstIndex = obj.firstIndex;
-        cmd.vertexOffset = obj.vertexOffset;
-        cmd.firstInstance = obj.objectIndex;  // gl_InstanceIndex in vertex shader
-
-        commands[drawIdx] = cmd;
+    // Step 3: Hi-Z occlusion culling
+    if (cullUniforms.enableHiZ != 0u) {
+        float maxMip = cullUniforms.depthParams.z - 1.0;
+        if (hizOcclusionTestAABB(aabbMin, aabbMax, hiZPyramid,
+                                 cullUniforms.viewProjMatrix,
+                                 cullUniforms.screenParams, maxMip)) {
+            return;  // Occluded
+        }
     }
+
+    // Object is visible — use subgroup operations to batch atomic updates
+    uvec4 activeMask = subgroupBallot(true);
+    uint activeCount = subgroupBallotBitCount(activeMask);
+    uint laneOffset = subgroupBallotExclusiveBitCount(activeMask);
+
+    uint baseIdx = 0;
+    uint slotsAllocated = 0;
+    if (subgroupElect()) {
+        uint expected = drawCount;
+        while (true) {
+            uint available = (expected >= cullUniforms.maxDrawCommands)
+                ? 0
+                : cullUniforms.maxDrawCommands - expected;
+            slotsAllocated = min(activeCount, available);
+            if (slotsAllocated == 0) {
+                baseIdx = expected;
+                break;
+            }
+            uint desired = expected + slotsAllocated;
+            uint actual = atomicCompSwap(drawCount, expected, desired);
+            if (actual == expected) {
+                baseIdx = expected;
+                break;
+            }
+            expected = actual;
+        }
+    }
+    baseIdx = subgroupBroadcastFirst(baseIdx);
+    slotsAllocated = subgroupBroadcastFirst(slotsAllocated);
+    uint drawIdx = baseIdx + laneOffset;
+
+    // Only write if we got a valid slot within bounds
+    if (laneOffset >= slotsAllocated) {
+        return;
+    }
+
+    // Write indirect draw command
+    commands[drawIdx].indexCount = obj.indexCount;
+    commands[drawIdx].instanceCount = 1;
+    commands[drawIdx].firstIndex = obj.firstIndex;
+    commands[drawIdx].vertexOffset = obj.vertexOffset;
+    commands[drawIdx].firstInstance = obj.objectIndex;  // gl_InstanceIndex in vertex shader
 }

--- a/shaders/scene_instance_common.glsl
+++ b/shaders/scene_instance_common.glsl
@@ -20,8 +20,8 @@ struct SceneInstance {
     vec4 emissiveColor;      // rgb=emissive color, a=unused
     uint pbrFlags;           // PBR texture flags bitmask
     float alphaTestThreshold;
-    float _pad0;
-    float _pad1;
+    float hueShift;
+    uint materialId;         // Index into material buffer
 };
 
 // Instance buffer (readonly for vertex/fragment shaders)

--- a/shaders/visbuf.frag
+++ b/shaders/visbuf.frag
@@ -1,0 +1,32 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
+// Visibility buffer fragment shader (GPU-driven indirect draws)
+// Writes (instanceID, triangleID) into a 64-bit (R32G32_UINT) render target
+//
+// Output format:
+//   R (uint32) = instanceId + 1  (full 32-bit range)
+//   G (uint32) = triangleId + 1  (full 32-bit range)
+//
+// +1 bias: (0, 0) is reserved as the background sentinel (no geometry).
+// triangleId = gl_PrimitiveID + triangleOffset (from vertex shader)
+
+layout(location = 0) flat in uint inInstanceId;
+layout(location = 1) in vec2 inTexCoord;
+layout(location = 2) flat in uint inTriangleOffset;
+
+// Optional: diffuse texture for alpha testing (transparent objects)
+layout(binding = BINDING_DIFFUSE_TEX) uniform sampler2D diffuseTexture;
+
+layout(location = 0) out uvec2 outVisibility;
+
+void main() {
+    uint triangleId = uint(gl_PrimitiveID) + inTriangleOffset;
+
+    // 64-bit V-buffer: no bit packing — full 32-bit per channel
+    // +1 bias so (0,0) remains the background sentinel
+    outVisibility = uvec2(inInstanceId + 1u, triangleId + 1u);
+}

--- a/shaders/visbuf.vert
+++ b/shaders/visbuf.vert
@@ -1,0 +1,57 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+#extension GL_ARB_shader_draw_parameters : require
+
+#include "bindings.glsl"
+#include "ubo_common.glsl"
+
+// Visibility buffer vertex shader (GPU-driven indirect draws)
+// Uses gl_DrawID to index into per-draw data buffer written by cluster_cull.comp
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;     // unused but must match vertex layout
+layout(location = 2) in vec2 inTexCoord;   // passed for alpha testing
+layout(location = 3) in vec4 inTangent;    // unused
+layout(location = 6) in vec4 inColor;      // unused
+
+// Per-draw data from cluster culling (parallel to indirect commands)
+struct DrawData {
+    uint instanceId;
+    uint triangleOffset;
+};
+
+layout(std430, binding = BINDING_VISBUF_RASTER_DRAW_DATA) readonly buffer DrawDataBuffer {
+    DrawData drawData[];
+};
+
+// Instance transforms from GPUSceneBuffer
+struct InstanceTransform {
+    mat4 model;
+    vec4 materialParams;
+    vec4 emissiveColor;
+    uint pbrFlags;
+    float alphaTestThreshold;
+    float hueShift;
+    float _pad;
+};
+
+layout(std430, binding = BINDING_VISBUF_RASTER_INSTANCES) readonly buffer InstanceBuffer {
+    InstanceTransform instances[];
+};
+
+layout(location = 0) flat out uint outInstanceId;
+layout(location = 1) out vec2 outTexCoord;
+layout(location = 2) flat out uint outTriangleOffset;
+
+void main() {
+    DrawData dd = drawData[gl_DrawIDARB];
+    mat4 model = instances[dd.instanceId].model;
+
+    vec4 worldPos = model * vec4(inPosition, 1.0);
+    gl_Position = ubo.proj * ubo.view * worldPos;
+
+    outInstanceId = dd.instanceId;
+    outTexCoord = inTexCoord;
+    outTriangleOffset = dd.triangleOffset;
+}

--- a/shaders/visbuf.vert
+++ b/shaders/visbuf.vert
@@ -1,13 +1,15 @@
 #version 450
 
 #extension GL_GOOGLE_include_directive : require
-#extension GL_ARB_shader_draw_parameters : require
 
 #include "bindings.glsl"
 #include "ubo_common.glsl"
 
 // Visibility buffer vertex shader (GPU-driven indirect draws)
-// Uses gl_DrawID to index into per-draw data buffer written by cluster_cull.comp
+//
+// Uses gl_InstanceIndex as the draw index (set via firstInstance in indirect commands).
+// This is the standard workaround for gl_DrawID — works on all Vulkan implementations
+// including MoltenVK which lacks shaderDrawParameters.
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;     // unused but must match vertex layout
@@ -45,7 +47,7 @@ layout(location = 1) out vec2 outTexCoord;
 layout(location = 2) flat out uint outTriangleOffset;
 
 void main() {
-    DrawData dd = drawData[gl_DrawIDARB];
+    DrawData dd = drawData[gl_InstanceIndex];
     mat4 model = instances[dd.instanceId].model;
 
     vec4 worldPos = model * vec4(inPosition, 1.0);

--- a/shaders/visbuf_debug.frag
+++ b/shaders/visbuf_debug.frag
@@ -1,0 +1,98 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+
+// Visibility buffer debug visualization fragment shader
+// Colors pixels by instance ID and triangle ID for verification
+// Reads R32G32_UINT V-buffer: R=instanceId+1, G=triangleId+1 (0=background)
+
+layout(binding = BINDING_VISBUF_DEBUG_INPUT) uniform usampler2D visibilityBuffer;
+layout(binding = BINDING_VISBUF_DEBUG_DEPTH_INPUT) uniform sampler2D depthBuffer;
+
+layout(location = 0) in vec2 inTexCoord;
+layout(location = 0) out vec4 outColor;
+
+// Hash function for consistent coloring
+vec3 hashColor(uint id) {
+    // PCG hash for good distribution
+    uint state = id * 747796405u + 2891336453u;
+    uint word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+    uint hash = (word >> 22u) ^ word;
+
+    float r = float((hash >> 0u) & 0xFFu) / 255.0;
+    float g = float((hash >> 8u) & 0xFFu) / 255.0;
+    float b = float((hash >> 16u) & 0xFFu) / 255.0;
+
+    // Boost saturation for better visibility
+    return mix(vec3(0.5), vec3(r, g, b), 0.8) * 0.8 + 0.2;
+}
+
+// LOD level color ramp (blue=LOD0 -> green=LOD1 -> yellow=LOD2 -> red=LOD3+)
+vec3 lodColor(uint lodLevel) {
+    if (lodLevel == 0u) return vec3(0.2, 0.4, 1.0);   // Blue - highest detail
+    if (lodLevel == 1u) return vec3(0.2, 1.0, 0.4);   // Green
+    if (lodLevel == 2u) return vec3(1.0, 1.0, 0.2);   // Yellow
+    return vec3(1.0, 0.3, 0.2);                        // Red - coarsest
+}
+
+layout(push_constant) uniform DebugPushConstants {
+    uint mode;  // 0=instance, 1=triangle, 2=mixed, 3=cluster, 4=cluster+instance, 5=depth
+    float _pad0, _pad1, _pad2;
+} debugParams;
+
+void main() {
+    uvec4 packed = texture(visibilityBuffer, inTexCoord);
+
+    // (0, 0) means no geometry was written (background)
+    if (packed.r == 0u && packed.g == 0u) {
+        if (debugParams.mode == 5u) {
+            // Depth mode: show depth buffer for background
+            float depth = texture(depthBuffer, inTexCoord).r;
+            outColor = vec4(vec3(depth), 1.0);
+        } else {
+            outColor = vec4(0.05, 0.05, 0.1, 1.0);
+        }
+        return;
+    }
+
+    // 64-bit V-buffer: separate channels, -1 to undo bias
+    uint instanceId = packed.r - 1u;
+    uint triangleId = packed.g - 1u;
+
+    // Approximate cluster ID from triangle ID (clusters are ~64 triangles)
+    uint clusterId = triangleId / 64u;
+
+    if (debugParams.mode == 0u) {
+        // Color by instance ID
+        outColor = vec4(hashColor(instanceId), 1.0);
+    } else if (debugParams.mode == 1u) {
+        // Color by triangle ID
+        outColor = vec4(hashColor(triangleId), 1.0);
+    } else if (debugParams.mode == 2u) {
+        // Mixed: blend instance and triangle coloring
+        vec3 instColor = hashColor(instanceId);
+        vec3 triColor = hashColor(triangleId);
+        outColor = vec4(mix(instColor, triColor, 0.5), 1.0);
+    } else if (debugParams.mode == 3u) {
+        // Cluster coloring: hash of approximate cluster ID
+        // Each cluster gets a unique color, making cluster boundaries visible
+        outColor = vec4(hashColor(clusterId), 1.0);
+    } else if (debugParams.mode == 4u) {
+        // Cluster + instance: combine instance tint with cluster pattern
+        // This shows both which object and which cluster within that object
+        vec3 instColor = hashColor(instanceId);
+        vec3 clusterColor = hashColor(clusterId);
+        outColor = vec4(mix(instColor, clusterColor, 0.6), 1.0);
+    } else if (debugParams.mode == 5u) {
+        // Depth visualization (linearized)
+        float depth = texture(depthBuffer, inTexCoord).r;
+        // Simple linearization for visualization
+        float linearDepth = 1.0 / (1.0 - depth + 0.001);
+        float normalized = clamp(linearDepth / 100.0, 0.0, 1.0);
+        outColor = vec4(vec3(1.0 - normalized), 1.0);
+    } else {
+        outColor = vec4(hashColor(instanceId ^ triangleId), 1.0);
+    }
+}

--- a/shaders/visbuf_debug.vert
+++ b/shaders/visbuf_debug.vert
@@ -1,0 +1,13 @@
+#version 450
+
+// Fullscreen triangle vertex shader for visibility buffer debug visualization
+// Generates a fullscreen triangle without any vertex input
+
+layout(location = 0) out vec2 outTexCoord;
+
+void main() {
+    // Generate fullscreen triangle using gl_VertexIndex
+    // Vertex 0: (-1, -1), Vertex 1: (3, -1), Vertex 2: (-1, 3)
+    outTexCoord = vec2((gl_VertexIndex << 1) & 2, gl_VertexIndex & 2);
+    gl_Position = vec4(outTexCoord * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/shaders/visbuf_resolve.comp
+++ b/shaders/visbuf_resolve.comp
@@ -1,0 +1,313 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "bindings.glsl"
+#include "lighting_common.glsl"
+
+// Visibility buffer material resolve compute shader
+// Reads the visibility buffer, reconstructs world position via barycentrics,
+// fetches vertex attributes, evaluates material, and writes to HDR output.
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+// Visibility buffer (R32G32_UINT — R=instanceId+1, G=triangleId+1; 0=background)
+layout(binding = BINDING_VISBUF_VISIBILITY, rg32ui) uniform readonly uimage2D visibilityBuffer;
+
+// Depth buffer for position reconstruction
+layout(binding = BINDING_VISBUF_DEPTH) uniform sampler2D depthBuffer;
+
+// HDR output
+layout(binding = BINDING_VISBUF_HDR_OUTPUT, rgba16f) uniform writeonly image2D hdrOutput;
+
+// Vertex data (global vertex buffer as SSBO)
+struct PackedVertex {
+    vec4 positionAndU;    // xyz = position, w = texCoord.x
+    vec4 normalAndV;      // xyz = normal,   w = texCoord.y
+    vec4 tangent;         // xyzw = tangent (w = handedness)
+    vec4 color;           // vertex color
+};
+
+layout(std430, binding = BINDING_VISBUF_VERTEX_BUFFER) readonly buffer VertexBuffer {
+    PackedVertex vertices[];
+};
+
+// Index buffer (global)
+layout(std430, binding = BINDING_VISBUF_INDEX_BUFFER) readonly buffer IndexBuffer {
+    uint indices[];
+};
+
+// Instance data
+struct InstanceData {
+    mat4 model;
+    vec4 materialParams;  // roughness, metallic, emissiveIntensity, opacity
+    vec4 emissiveColor;
+    uint pbrFlags;
+    float alphaTestThreshold;
+    float hueShift;
+    uint materialId;      // index into material buffer
+};
+
+layout(std430, binding = BINDING_VISBUF_INSTANCE_BUFFER) readonly buffer InstanceBuffer {
+    InstanceData instances[];
+};
+
+// GPU Material data
+struct GPUMaterial {
+    vec4 baseColor;         // RGB + alpha
+    float roughness;
+    float metallic;
+    float normalScale;
+    float aoStrength;
+    uint albedoTexIndex;    // UINT32_MAX = no texture
+    uint normalTexIndex;    // UINT32_MAX = no texture
+    uint roughnessMetallicTexIndex; // UINT32_MAX = no texture
+    uint flags;             // reserved
+};
+
+layout(std430, binding = BINDING_VISBUF_MATERIAL_BUFFER) readonly buffer MaterialBuffer {
+    GPUMaterial materials[];
+};
+
+// Resolve uniforms
+layout(std140, binding = BINDING_VISBUF_UNIFORMS) uniform ResolveUniforms {
+    mat4 invViewProj;
+    mat4 viewMatrix;
+    mat4 projMatrix;
+    vec4 cameraPosition;
+    vec4 screenParams;    // width, height, 1/width, 1/height
+    vec4 lightDirection;  // xyz = sun direction, w = intensity
+    uint instanceCount;
+    uint materialCount;
+    uint _pad1, _pad2;
+} resolveUniforms;
+
+// Texture array for material textures (UNORM - sRGB sources linearized during blit)
+layout(binding = BINDING_VISBUF_TEXTURE_ARRAY) uniform sampler2DArray materialTextures;
+
+// Dynamic light buffer for multiple point/spot lights
+#define DYNAMIC_LIGHT_BUFFER_BINDING BINDING_VISBUF_LIGHT_BUFFER
+#include "dynamic_lights_common.glsl"
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+// Compute barycentric coordinates for a point in a triangle (screen space)
+vec3 computeBarycentrics(vec2 p, vec2 a, vec2 b, vec2 c) {
+    vec2 v0 = c - a;
+    vec2 v1 = b - a;
+    vec2 v2 = p - a;
+
+    float dot00 = dot(v0, v0);
+    float dot01 = dot(v0, v1);
+    float dot02 = dot(v0, v2);
+    float dot11 = dot(v1, v1);
+    float dot12 = dot(v1, v2);
+
+    float invDenom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+
+    return vec3(1.0 - u - v, v, u);
+}
+
+// Cook-Torrance specular BRDF
+vec3 evaluateBRDF(vec3 N, vec3 V, vec3 L, vec3 baseColor, float roughness, float metallic) {
+    vec3 H = normalize(V + L);
+
+    float NoV = max(dot(N, V), 0.001);
+    float NoL = max(dot(N, L), 0.0);
+    float NoH = max(dot(N, H), 0.0);
+    float VoH = max(dot(V, H), 0.0);
+
+    // F0: dielectric = 0.04, metal = baseColor
+    vec3 F0 = mix(vec3(F0_DIELECTRIC), baseColor, metallic);
+
+    // Specular BRDF: D * V * F
+    float D = D_GGX(NoH, roughness);
+    float Vis = V_SmithGGX(NoV, NoL, roughness);
+    vec3 F = F_Schlick(VoH, F0);
+
+    vec3 specular = D * Vis * F;
+
+    // Diffuse: metals have no diffuse
+    vec3 kD = (vec3(1.0) - F) * (1.0 - metallic);
+    vec3 diffuse = kD * baseColor / PI;
+
+    return (diffuse + specular) * NoL;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+void main() {
+    ivec2 pixelCoord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 imageSize = imageSize(visibilityBuffer);
+
+    if (pixelCoord.x >= imageSize.x || pixelCoord.y >= imageSize.y) {
+        return;
+    }
+
+    uvec2 packed = imageLoad(visibilityBuffer, pixelCoord).rg;
+
+    // Background pixel - no V-buffer data, preserve existing HDR content
+    // (0, 0) is the clear/sentinel value
+    if (packed.r == 0u && packed.g == 0u) {
+        return;
+    }
+
+    // 64-bit V-buffer: separate channels, -1 to undo the +1 bias from raster pass
+    uint instanceId = packed.r - 1u;
+    uint triangleId = packed.g - 1u;
+
+    // No depth comparison needed — V-buffer and HDR pass share the same depth buffer.
+    // Visibility between V-buffer objects and HDR objects (terrain, trees, water)
+    // is resolved by hardware depth testing during rasterization.
+
+    // Fetch triangle indices
+    uint i0 = indices[triangleId * 3u + 0u];
+    uint i1 = indices[triangleId * 3u + 1u];
+    uint i2 = indices[triangleId * 3u + 2u];
+
+    // Fetch instance and material data
+    InstanceData inst = instances[instanceId];
+
+    // Look up material (fallback to defaults if materialId is invalid)
+    uint matId = inst.materialId;
+    vec4 matBaseColor = vec4(0.8, 0.8, 0.8, 1.0);
+    float matRoughness = inst.materialParams.x;
+    float matMetallic = inst.materialParams.y;
+    float matNormalScale = 1.0;
+    uint albedoTexIdx = 0xFFFFFFFFu;
+    uint normalTexIdx = 0xFFFFFFFFu;
+    uint roughMetalTexIdx = 0xFFFFFFFFu;
+
+    if (matId < resolveUniforms.materialCount) {
+        GPUMaterial mat = materials[matId];
+        matBaseColor = mat.baseColor;
+        matRoughness = mat.roughness;
+        matMetallic = mat.metallic;
+        matNormalScale = mat.normalScale;
+        albedoTexIdx = mat.albedoTexIndex;
+        normalTexIdx = mat.normalTexIndex;
+        roughMetalTexIdx = mat.roughnessMetallicTexIndex;
+    }
+
+    // Transform vertex positions to world space
+    vec3 p0 = (inst.model * vec4(vertices[i0].positionAndU.xyz, 1.0)).xyz;
+    vec3 p1 = (inst.model * vec4(vertices[i1].positionAndU.xyz, 1.0)).xyz;
+    vec3 p2 = (inst.model * vec4(vertices[i2].positionAndU.xyz, 1.0)).xyz;
+
+    // Project triangle vertices to screen space for barycentric computation
+    mat4 viewProj = resolveUniforms.projMatrix * resolveUniforms.viewMatrix;
+    vec4 sp0 = viewProj * vec4(p0, 1.0);
+    vec4 sp1 = viewProj * vec4(p1, 1.0);
+    vec4 sp2 = viewProj * vec4(p2, 1.0);
+
+    vec2 ss0 = sp0.xy / sp0.w;
+    vec2 ss1 = sp1.xy / sp1.w;
+    vec2 ss2 = sp2.xy / sp2.w;
+
+    // Current pixel in NDC
+    vec2 screenUV = (vec2(pixelCoord) + 0.5) * resolveUniforms.screenParams.zw;
+    vec2 ndc = screenUV * 2.0 - 1.0;
+
+    // Perspective-correct barycentrics
+    vec3 bary = computeBarycentrics(ndc, ss0, ss1, ss2);
+
+    float w0 = 1.0 / sp0.w;
+    float w1 = 1.0 / sp1.w;
+    float w2 = 1.0 / sp2.w;
+    float wInterp = bary.x * w0 + bary.y * w1 + bary.z * w2;
+    bary = vec3(bary.x * w0, bary.y * w1, bary.z * w2) / wInterp;
+
+    // Interpolate vertex attributes
+    vec3 normal = normalize(
+        bary.x * vertices[i0].normalAndV.xyz +
+        bary.y * vertices[i1].normalAndV.xyz +
+        bary.z * vertices[i2].normalAndV.xyz
+    );
+
+    vec2 texCoord = bary.x * vec2(vertices[i0].positionAndU.w, vertices[i0].normalAndV.w) +
+                    bary.y * vec2(vertices[i1].positionAndU.w, vertices[i1].normalAndV.w) +
+                    bary.z * vec2(vertices[i2].positionAndU.w, vertices[i2].normalAndV.w);
+
+    vec3 worldPos = bary.x * p0 + bary.y * p1 + bary.z * p2;
+
+    // Transform normal to world space
+    mat3 normalMatrix = mat3(inst.model);
+    normal = normalize(normalMatrix * normal);
+
+    // Sample textures if available
+    vec3 baseColor = matBaseColor.rgb;
+    float roughness = matRoughness;
+    float metallic = matMetallic;
+
+    if (albedoTexIdx != 0xFFFFFFFFu) {
+        vec4 texColor = texture(materialTextures, vec3(texCoord, float(albedoTexIdx)));
+        // Texture data is already linear: sRGB sources are linearized during blit to UNORM array
+        baseColor *= texColor.rgb;
+    }
+
+    if (roughMetalTexIdx != 0xFFFFFFFFu) {
+        // Green = roughness, Blue = metallic (glTF convention)
+        vec4 rm = texture(materialTextures, vec3(texCoord, float(roughMetalTexIdx)));
+        roughness = rm.g;
+        metallic = rm.b;
+    }
+
+    // Normal mapping
+    if (normalTexIdx != 0xFFFFFFFFu) {
+        // Interpolate tangent
+        vec4 tangent = normalize(
+            bary.x * vertices[i0].tangent +
+            bary.y * vertices[i1].tangent +
+            bary.z * vertices[i2].tangent
+        );
+        vec3 T = normalize(normalMatrix * tangent.xyz);
+        vec3 B = cross(normal, T) * tangent.w;
+
+        vec3 normalMap = texture(materialTextures, vec3(texCoord, float(normalTexIdx))).rgb;
+        normalMap = normalMap * 2.0 - 1.0;
+        normalMap.xy *= matNormalScale;
+        normal = normalize(T * normalMap.x + B * normalMap.y + normal * normalMap.z);
+    }
+
+    // Apply vertex color tint
+    vec3 vertexColor = bary.x * vertices[i0].color.rgb +
+                       bary.y * vertices[i1].color.rgb +
+                       bary.z * vertices[i2].color.rgb;
+    // Only apply if vertex color is non-white (avoid darkening untinted meshes)
+    if (dot(vertexColor, vertexColor) > 0.01) {
+        baseColor *= vertexColor;
+    }
+
+    // PBR lighting
+    vec3 V = normalize(resolveUniforms.cameraPosition.xyz - worldPos);
+    vec3 L = normalize(resolveUniforms.lightDirection.xyz);
+    float lightIntensity = resolveUniforms.lightDirection.w;
+
+    // Direct lighting via Cook-Torrance BRDF (sun/directional)
+    vec3 directLight = evaluateBRDF(normal, V, L, baseColor, roughness, metallic) * lightIntensity;
+
+    // Dynamic point/spot lights
+    vec3 dynamicLight = calculateAllDynamicLightsPBRNoShadow(
+        normal, V, worldPos, baseColor, roughness, metallic);
+
+    // Ambient (hemisphere approximation)
+    float NoUp = dot(normal, vec3(0.0, 1.0, 0.0)) * 0.5 + 0.5;
+    vec3 skyColor = mix(vec3(0.05, 0.05, 0.08), vec3(0.12, 0.15, 0.2), NoUp);
+    vec3 ambient = baseColor * skyColor * (1.0 - metallic);
+
+    vec3 finalColor = directLight + dynamicLight + ambient;
+
+    // Emissive
+    float emissiveIntensity = inst.materialParams.z;
+    if (emissiveIntensity > 0.0) {
+        finalColor += inst.emissiveColor.rgb * emissiveIntensity;
+    }
+
+    imageStore(hdrOutput, pixelCoord, vec4(finalColor, 1.0));
+}

--- a/src/core/FrameDataBuilder.cpp
+++ b/src/core/FrameDataBuilder.cpp
@@ -109,7 +109,9 @@ RenderResources FrameDataBuilder::buildRenderResources(
     resources.hdrFramebuffer = systems.postProcess().getHDRFramebuffer();
     resources.hdrExtent = systems.postProcess().getExtent();
     resources.hdrColorView = systems.postProcess().getHDRColorView();
+    resources.hdrColorImage = systems.postProcess().getHDRColorImage();
     resources.hdrDepthView = systems.postProcess().getHDRDepthView();
+    resources.hdrDepthImage = systems.postProcess().getHDRDepthImage();
 
     // Shadow resources (from ShadowSystem)
     resources.shadowRenderPass = systems.shadow().getShadowRenderPass();

--- a/src/core/GPUSceneBuffer.cpp
+++ b/src/core/GPUSceneBuffer.cpp
@@ -126,7 +126,7 @@ int32_t GPUSceneBuffer::addObject(const Renderable& renderable) {
     instance.pbrFlags = renderable.pbrFlags;
     instance.alphaTestThreshold = renderable.alphaTestThreshold;
     instance.hueShift = renderable.hueShift;
-    instance._pad1 = 0.0f;
+    instance.materialId = renderable.materialId;
 
     instances_.push_back(instance);
 

--- a/src/core/GPUSceneBuffer.h
+++ b/src/core/GPUSceneBuffer.h
@@ -37,7 +37,7 @@ struct alignas(16) GPUSceneInstanceData {
     uint32_t pbrFlags;            // 4 bytes, offset 96
     float alphaTestThreshold;     // 4 bytes, offset 100
     float hueShift;               // 4 bytes, offset 104
-    float _pad1;                  // 4 bytes, offset 108
+    uint32_t materialId;          // 4 bytes, offset 108 (index into material buffer)
     // Total: 112 bytes per instance
 };
 static_assert(sizeof(GPUSceneInstanceData) == 112, "GPUSceneInstanceData size mismatch with shader");

--- a/src/core/Mesh.h
+++ b/src/core/Mesh.h
@@ -136,8 +136,9 @@ public:
     // Release GPU resources without destroying CPU data (for dynamic meshes that need re-upload)
     void releaseGPUResources();
 
-    // Access to vertex data for physics collision shapes
+    // Access to vertex/index data for physics collision shapes and V-buffer global buffers
     const std::vector<Vertex>& getVertices() const { return vertices; }
+    const std::vector<uint32_t>& getIndices() const { return indices; }
 
     // Get local-space bounding box
     const AABB& getBounds() const { return bounds; }

--- a/src/core/RenderContext.h
+++ b/src/core/RenderContext.h
@@ -22,7 +22,9 @@ struct RenderResources {
     VkFramebuffer hdrFramebuffer = VK_NULL_HANDLE;
     VkExtent2D hdrExtent = {0, 0};
     VkImageView hdrColorView = VK_NULL_HANDLE;
+    VkImage hdrColorImage = VK_NULL_HANDLE;
     VkImageView hdrDepthView = VK_NULL_HANDLE;
+    VkImage hdrDepthImage = VK_NULL_HANDLE;
 
     // Shadow resources (from ShadowSystem)
     VkRenderPass shadowRenderPass = VK_NULL_HANDLE;

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -609,7 +609,9 @@ void Renderer::createHDRPassRecorder() {
         sceneRes.treeRenderer = systems_->treeRenderer();
         sceneRes.treeLOD = systems_->treeLOD();
         sceneRes.impostorCull = systems_->impostorCull();
-        sceneRes.visBufferActive = systems_->hasVisibilityBuffer();
+        // V-buffer active = false for now — traditional scene object rendering
+        // until V-buffer pipeline is fully bootstrapped (culler + fallback draws)
+        sceneRes.visBufferActive = false;
 
         hdrPassRecorder_->registerDrawable(
             std::make_unique<SceneObjectsDrawable>(sceneRes),

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -609,6 +609,7 @@ void Renderer::createHDRPassRecorder() {
         sceneRes.treeRenderer = systems_->treeRenderer();
         sceneRes.treeLOD = systems_->treeLOD();
         sceneRes.impostorCull = systems_->impostorCull();
+        sceneRes.visBufferActive = systems_->hasVisibilityBuffer();
 
         hdrPassRecorder_->registerDrawable(
             std::make_unique<SceneObjectsDrawable>(sceneRes),

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -609,9 +609,7 @@ void Renderer::createHDRPassRecorder() {
         sceneRes.treeRenderer = systems_->treeRenderer();
         sceneRes.treeLOD = systems_->treeLOD();
         sceneRes.impostorCull = systems_->impostorCull();
-        // V-buffer active = false for now — traditional scene object rendering
-        // until V-buffer pipeline is fully bootstrapped (culler + fallback draws)
-        sceneRes.visBufferActive = false;
+        sceneRes.visBufferActive = systems_->hasVisibilityBuffer();
 
         hdrPassRecorder_->registerDrawable(
             std::make_unique<SceneObjectsDrawable>(sceneRes),

--- a/src/core/Renderer.cpp
+++ b/src/core/Renderer.cpp
@@ -609,7 +609,7 @@ void Renderer::createHDRPassRecorder() {
         sceneRes.treeRenderer = systems_->treeRenderer();
         sceneRes.treeLOD = systems_->treeLOD();
         sceneRes.impostorCull = systems_->impostorCull();
-        sceneRes.visBufferActive = systems_->hasVisibilityBuffer();
+        sceneRes.visBufferActive = false;  // V-buffer resolve not yet proven — keep traditional path
 
         hdrPassRecorder_->registerDrawable(
             std::make_unique<SceneObjectsDrawable>(sceneRes),

--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -628,17 +628,15 @@ std::vector<Loading::SystemInitTask> Renderer::buildInitTasks(const InitContext&
                 vbInfo.raiiDevice = ctxPtr->raiiDevice;
                 vbInfo.graphicsQueue = ctxPtr->graphicsQueue;
                 vbInfo.commandPool = ctxPtr->commandPool;
-                // Share HDR depth buffer — V-buffer raster writes depth first,
-                // HDR pass loads it (loadOp=eLoad) to preserve V-buffer depth writes
-                vbInfo.sharedDepthImage = systems_->postProcess().getHDRDepthImage();
-                vbInfo.sharedDepthView = systems_->postProcess().getHDRDepthView();
+                // Use own depth buffer for now — depth sharing requires
+                // a working V-buffer pipeline (culler bootstrap + fallback draws).
+                // Once the V-buffer reliably produces output, enable shared depth
+                // via setDepthLoadOnHDRPass(true) and pass sharedDepthImage/View.
                 vbInfo.hasShaderDrawParameters = vulkanContext_->hasShaderDrawParameters();
                 auto visBuf = VisibilityBuffer::create(vbInfo);
                 if (visBuf) {
                     systems_->setVisibilityBuffer(std::move(visBuf));
-                    // Tell PostProcessSystem to load depth (not clear) in HDR pass
-                    systems_->postProcess().setDepthLoadOnHDRPass(true);
-                    SDL_Log("VisibilityBuffer: Initialized with shared HDR depth buffer");
+                    SDL_Log("VisibilityBuffer: Initialized (own depth buffer, non-interfering)");
                 }
             }
 

--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -628,18 +628,13 @@ std::vector<Loading::SystemInitTask> Renderer::buildInitTasks(const InitContext&
                 vbInfo.raiiDevice = ctxPtr->raiiDevice;
                 vbInfo.graphicsQueue = ctxPtr->graphicsQueue;
                 vbInfo.commandPool = ctxPtr->commandPool;
-                // Share HDR depth buffer — V-buffer raster writes depth first,
-                // HDR pass loads it (loadOp=eLoad) so terrain/sky depth-test
-                // correctly against V-buffer objects.
-                vbInfo.sharedDepthImage = systems_->postProcess().getHDRDepthImage();
-                vbInfo.sharedDepthView = systems_->postProcess().getHDRDepthView();
+                // Own depth buffer for now — V-buffer runs non-interfering alongside
+                // traditional rendering until the resolve compute pass is proven working.
                 vbInfo.hasShaderDrawParameters = vulkanContext_->hasShaderDrawParameters();
                 auto visBuf = VisibilityBuffer::create(vbInfo);
                 if (visBuf) {
                     systems_->setVisibilityBuffer(std::move(visBuf));
-                    // Tell PostProcessSystem to load depth (not clear) in HDR pass
-                    systems_->postProcess().setDepthLoadOnHDRPass(true);
-                    SDL_Log("VisibilityBuffer: Initialized with shared HDR depth buffer");
+                    SDL_Log("VisibilityBuffer: Initialized (own depth, non-interfering)");
                 }
             }
 

--- a/src/core/RendererInitPhases.cpp
+++ b/src/core/RendererInitPhases.cpp
@@ -722,8 +722,9 @@ std::vector<Loading::SystemInitTask> Renderer::buildInitTasks(const InitContext&
             }
 
             // Two-pass GPU culler for Nanite-style occlusion + LOD selection
-            // Requires shaderDrawParameters (gl_DrawID) for GPU-driven V-buffer rendering
-            if (vulkanContext_->hasShaderDrawParameters()) {
+            // Uses gl_InstanceIndex (via firstInstance) instead of gl_DrawID,
+            // so shaderDrawParameters is NOT required — works on MoltenVK too.
+            {
                 TwoPassCuller::InitInfo cullerInfo{};
                 cullerInfo.device = ctxPtr->device;
                 cullerInfo.allocator = ctxPtr->allocator;
@@ -739,9 +740,6 @@ std::vector<Loading::SystemInitTask> Renderer::buildInitTasks(const InitContext&
                     systems_->setTwoPassCuller(std::move(twoPassCuller));
                     SDL_Log("TwoPassCuller: Initialized for GPU-driven cluster culling");
                 }
-            } else {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "TwoPassCuller: Skipped - shaderDrawParameters not supported");
             }
 
             // Profiler

--- a/src/core/RendererSystems.h
+++ b/src/core/RendererSystems.h
@@ -70,6 +70,8 @@ class CloudShadowSystem;
 class HiZSystem;
 class GPUSceneBuffer;
 class GPUCullPass;
+class GPUClusterBuffer;
+class TwoPassCuller;
 class WaterSystem;
 class WaterDisplacement;
 class FlowMapGenerator;
@@ -94,6 +96,8 @@ class BilateralGridSystem;
 class ScreenSpaceShadowSystem;
 class GodRaysSystem;
 class DeferredTerrainObjects;
+class VisibilityBuffer;
+class GPUMaterialBuffer;
 struct EnvironmentSettings;
 struct TerrainConfig;
 
@@ -285,12 +289,32 @@ public:
     const GPUCullPass& gpuCullPass() const { return *gpuCullPass_; }
     bool hasGPUCullPass() const { return gpuCullPass_ != nullptr; }
     void setGPUCullPass(std::unique_ptr<GPUCullPass> pass);
+    GPUClusterBuffer* gpuClusterBuffer() { return gpuClusterBuffer_.get(); }
+    const GPUClusterBuffer* gpuClusterBuffer() const { return gpuClusterBuffer_.get(); }
+    bool hasGPUClusterBuffer() const { return gpuClusterBuffer_ != nullptr; }
+    void setGPUClusterBuffer(std::unique_ptr<GPUClusterBuffer> buffer);
+    TwoPassCuller* twoPassCuller() { return twoPassCuller_.get(); }
+    const TwoPassCuller* twoPassCuller() const { return twoPassCuller_.get(); }
+    bool hasTwoPassCuller() const { return twoPassCuller_ != nullptr; }
+    void setTwoPassCuller(std::unique_ptr<TwoPassCuller> culler);
 
     // Screen-space shadow buffer
     ScreenSpaceShadowSystem* screenSpaceShadow() { return screenSpaceShadowSystem_.get(); }
     const ScreenSpaceShadowSystem* screenSpaceShadow() const { return screenSpaceShadowSystem_.get(); }
     bool hasScreenSpaceShadow() const { return screenSpaceShadowSystem_ != nullptr; }
     void setScreenSpaceShadow(std::unique_ptr<ScreenSpaceShadowSystem> system);
+
+    // Visibility buffer
+    VisibilityBuffer* visibilityBuffer() { return visibilityBuffer_.get(); }
+    const VisibilityBuffer* visibilityBuffer() const { return visibilityBuffer_.get(); }
+    bool hasVisibilityBuffer() const { return visibilityBuffer_ != nullptr; }
+    void setVisibilityBuffer(std::unique_ptr<VisibilityBuffer> system);
+
+    // GPU material buffer
+    GPUMaterialBuffer* gpuMaterialBuffer() { return gpuMaterialBuffer_.get(); }
+    const GPUMaterialBuffer* gpuMaterialBuffer() const { return gpuMaterialBuffer_.get(); }
+    bool hasGPUMaterialBuffer() const { return gpuMaterialBuffer_ != nullptr; }
+    void setGPUMaterialBuffer(std::unique_ptr<GPUMaterialBuffer> buffer);
 
     // Scene and resources
     SceneManager& scene() { return *sceneManager_; }
@@ -562,9 +586,15 @@ private:
     std::unique_ptr<HiZSystem> hiZSystem_;
     std::unique_ptr<GPUSceneBuffer> gpuSceneBuffer_;
     std::unique_ptr<GPUCullPass> gpuCullPass_;
+    std::unique_ptr<GPUClusterBuffer> gpuClusterBuffer_;
+    std::unique_ptr<TwoPassCuller> twoPassCuller_;
 
     // Screen-space shadow buffer
     std::unique_ptr<ScreenSpaceShadowSystem> screenSpaceShadowSystem_;
+
+    // Visibility buffer rendering
+    std::unique_ptr<VisibilityBuffer> visibilityBuffer_;
+    std::unique_ptr<GPUMaterialBuffer> gpuMaterialBuffer_;
 
     // Infrastructure (needed throughout)
     std::unique_ptr<SceneManager> sceneManager_;

--- a/src/core/Texture.h
+++ b/src/core/Texture.h
@@ -33,6 +33,9 @@ public:
 
     VkImageView getImageView() const { return imageView; }
     VkSampler getSampler() const { return sampler; }
+    VkImage getImage() const { return image; }
+    int getWidth() const { return width; }
+    int getHeight() const { return height; }
 
 private:
     bool loadInternal(const std::string& path, VmaAllocator allocator, VkDevice device,

--- a/src/core/passes/SceneObjectsDrawable.h
+++ b/src/core/passes/SceneObjectsDrawable.h
@@ -53,6 +53,7 @@ public:
         TreeRenderer* treeRenderer = nullptr;
         TreeLODSystem* treeLOD = nullptr;
         ImpostorCullSystem* impostorCull = nullptr;
+        bool visBufferActive = false;
     };
 
     explicit SceneObjectsDrawable(const Resources& resources);

--- a/src/core/passes/VisBufferPasses.cpp
+++ b/src/core/passes/VisBufferPasses.cpp
@@ -1,0 +1,504 @@
+#include "VisBufferPasses.h"
+#include "RendererSystems.h"
+#include "RenderContext.h"
+#include "Profiler.h"
+#include "PostProcessSystem.h"
+#include "GPUSceneBuffer.h"
+#include "VisibilityBuffer.h"
+#include "GPUMaterialBuffer.h"
+#include "GlobalBufferManager.h"
+#include "SceneManager.h"
+#include "scene/SceneBuilder.h"
+#include "npc/NPCSimulation.h"
+#include "Mesh.h"
+#include "MaterialRegistry.h"
+#include "MeshClusterBuilder.h"
+#include "TwoPassCuller.h"
+
+#include <algorithm>
+#include <unordered_set>
+#include <unordered_map>
+
+namespace VisBufferPasses {
+
+// ============================================================================
+// Persistent cluster state (survives across frames)
+// ============================================================================
+
+struct ClusterState {
+    bool built = false;
+
+    // Clustered mesh data (CPU-side, kept for reference)
+    std::unordered_map<const Mesh*, ClusteredMesh> clusteredMeshes;
+
+    uint32_t totalDrawCommands = 0;
+};
+
+// Static cluster state - persists across frames
+static ClusterState s_clusterState;
+
+// ============================================================================
+// Build clusters from scene meshes (called once lazily)
+// ============================================================================
+
+static bool buildClusterState(RendererSystems& systems) {
+    auto* visBuf = systems.visibilityBuffer();
+    auto* clusterBuf = systems.gpuClusterBuffer();
+    if (!visBuf || !clusterBuf) return false;
+
+    const auto& sceneObjects = systems.scene().getRenderables();
+    SceneBuilder& sceneBuilder = systems.scene().getSceneBuilder();
+    size_t playerIndex = sceneBuilder.getPlayerObjectIndex();
+    bool hasCharacter = sceneBuilder.hasCharacter();
+    const NPCSimulation* npcSim = sceneBuilder.getNPCSimulation();
+
+    // Collect unique meshes from renderable scene objects (excluding player/NPCs)
+    std::unordered_set<const Mesh*> meshSet;
+    for (size_t i = 0; i < sceneObjects.size(); ++i) {
+        if (hasCharacter && i == playerIndex) continue;
+        if (npcSim) {
+            bool isNPC = false;
+            const auto& npcData = npcSim->getData();
+            for (size_t npcIdx = 0; npcIdx < npcData.count(); ++npcIdx) {
+                if (i == npcData.renderableIndices[npcIdx]) {
+                    isNPC = true;
+                    break;
+                }
+            }
+            if (isNPC) continue;
+        }
+        if (sceneObjects[i].mesh) {
+            meshSet.insert(sceneObjects[i].mesh);
+        }
+    }
+
+    if (meshSet.empty()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "VisBufferPasses: No meshes to cluster");
+        return false;
+    }
+
+    // Build clusters for each unique mesh
+    MeshClusterBuilder builder;
+    builder.setTargetClusterSize(64);
+
+    uint32_t meshId = 0;
+    std::vector<std::pair<const Mesh*, const ClusteredMesh*>> meshClusterPairs;
+
+    for (const Mesh* mesh : meshSet) {
+        const auto& vertices = mesh->getVertices();
+        const auto& indices = mesh->getIndices();
+
+        if (vertices.empty() || indices.empty()) {
+            meshId++;
+            continue;
+        }
+
+        // Build clusters with DAG hierarchy for LOD
+        ClusteredMesh clustered = builder.buildWithDAG(vertices, indices, meshId);
+
+        SDL_Log("VisBufferPasses: Mesh %u clustered: %u clusters, %u triangles, %u DAG levels",
+                meshId, clustered.totalClusters, clustered.totalTriangles, clustered.dagLevels);
+
+        // Upload to GPUClusterBuffer
+        uint32_t baseCluster = clusterBuf->uploadMesh(clustered);
+        if (baseCluster == UINT32_MAX) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "VisBufferPasses: Failed to upload mesh %u to GPUClusterBuffer", meshId);
+            meshId++;
+            continue;
+        }
+
+        s_clusterState.clusteredMeshes[mesh] = std::move(clustered);
+        meshClusterPairs.push_back({mesh, &s_clusterState.clusteredMeshes[mesh]});
+        meshId++;
+    }
+
+    if (meshClusterPairs.empty()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VisBufferPasses: No meshes successfully clustered");
+        return false;
+    }
+
+    // Build the packed vertex/index buffer for resolve from cluster data
+    // This ensures triangleIds in the raster output match the resolve buffer
+    visBuf->buildGlobalBuffersFromClusters(meshClusterPairs);
+
+    // Count total draw commands (leaf clusters x instances)
+    uint32_t totalDraws = 0;
+    for (size_t i = 0; i < sceneObjects.size(); ++i) {
+        if (hasCharacter && i == playerIndex) continue;
+        if (npcSim) {
+            bool isNPC = false;
+            const auto& npcData = npcSim->getData();
+            for (size_t npcIdx = 0; npcIdx < npcData.count(); ++npcIdx) {
+                if (i == npcData.renderableIndices[npcIdx]) {
+                    isNPC = true;
+                    break;
+                }
+            }
+            if (isNPC) continue;
+        }
+        const auto& obj = sceneObjects[i];
+        if (!obj.mesh) continue;
+        auto it = s_clusterState.clusteredMeshes.find(obj.mesh);
+        if (it == s_clusterState.clusteredMeshes.end()) continue;
+        for (const auto& cluster : it->second.clusters) {
+            if (cluster.lodLevel == 0) totalDraws++;
+        }
+    }
+
+    s_clusterState.totalDrawCommands = totalDraws;
+    s_clusterState.built = true;
+
+    SDL_Log("VisBufferPasses: Cluster state built: %u draw commands from %zu meshes",
+            totalDraws, meshClusterPairs.size());
+    return true;
+}
+
+// ============================================================================
+// Raster pass: Draw scene objects into the V-buffer
+// ============================================================================
+
+// ============================================================================
+// Cull pass: Run TwoPassCuller compute to produce indirect draw commands
+// ============================================================================
+
+static void executeCullPass(FrameGraph::RenderContext& ctx, RendererSystems& systems) {
+    RenderContext* renderCtx = static_cast<RenderContext*>(ctx.userData);
+    if (!renderCtx) return;
+
+    auto* culler = systems.twoPassCuller();
+    if (!culler || !culler->hasDescriptorSets()) return;
+
+    VkCommandBuffer cmd = renderCtx->cmd;
+    uint32_t frameIndex = renderCtx->frameIndex;
+
+    auto* clusterBuf = systems.gpuClusterBuffer();
+    if (!clusterBuf) return;
+
+    systems.profiler().beginGpuZone(cmd, "VisBufferCull");
+
+    // Update culling uniforms
+    glm::vec4 frustumPlanes[6];
+    // Extract frustum planes from view-projection matrix
+    glm::mat4 vp = renderCtx->frame.projection * renderCtx->frame.view;
+    for (int i = 0; i < 3; ++i) {
+        frustumPlanes[i * 2 + 0] = glm::vec4(
+            vp[0][3] + vp[0][i], vp[1][3] + vp[1][i],
+            vp[2][3] + vp[2][i], vp[3][3] + vp[3][i]);
+        frustumPlanes[i * 2 + 1] = glm::vec4(
+            vp[0][3] - vp[0][i], vp[1][3] - vp[1][i],
+            vp[2][3] - vp[2][i], vp[3][3] - vp[3][i]);
+    }
+    // Normalize planes
+    for (int i = 0; i < 6; ++i) {
+        float len = glm::length(glm::vec3(frustumPlanes[i]));
+        if (len > 0.0f) frustumPlanes[i] /= len;
+    }
+
+    uint32_t instanceCount = systems.hasGPUSceneBuffer()
+        ? systems.gpuSceneBuffer().getObjectCount() : 0;
+
+    culler->updateUniforms(frameIndex,
+        renderCtx->frame.view, renderCtx->frame.projection,
+        renderCtx->frame.cameraPosition,
+        frustumPlanes,
+        clusterBuf->getTotalClusters(), instanceCount,
+        renderCtx->frame.nearPlane, renderCtx->frame.farPlane, 0);
+
+    // Run pass 1 (frustum cull previous frame's visible clusters)
+    culler->recordPass1(cmd, frameIndex);
+
+    systems.profiler().endGpuZone(cmd, "VisBufferCull");
+}
+
+// ============================================================================
+// Raster pass: GPU-driven indirect draws from TwoPassCuller output
+// ============================================================================
+
+static void executeRasterPass(FrameGraph::RenderContext& ctx, RendererSystems& systems) {
+    RenderContext* renderCtx = static_cast<RenderContext*>(ctx.userData);
+    if (!renderCtx) return;
+
+    auto* visBuf = systems.visibilityBuffer();
+    if (!visBuf) return;
+
+    // Skip if raster pipeline wasn't created (shaderDrawParameters unavailable)
+    if (visBuf->getRasterPipeline() == VK_NULL_HANDLE) return;
+
+    VkCommandBuffer cmd = renderCtx->cmd;
+    uint32_t frameIndex = renderCtx->frameIndex;
+
+    systems.profiler().beginGpuZone(cmd, "VisBufferRaster");
+
+    // Lazily build cluster state on first frame
+    if (!s_clusterState.built && systems.hasGPUClusterBuffer()) {
+        buildClusterState(systems);
+    }
+
+    // Lazily build material texture array and re-upload material indices
+    if (!visBuf->hasTextureArray()) {
+        const auto& registry = systems.scene().getSceneBuilder().getMaterialRegistry();
+        if (visBuf->buildMaterialTextureArray(registry)) {
+            if (systems.hasGPUMaterialBuffer()) {
+                systems.gpuMaterialBuffer()->uploadFromRegistry(registry, *visBuf);
+            }
+        }
+    }
+
+    // Lazily wire TwoPassCuller with external buffers
+    auto* culler = systems.twoPassCuller();
+    auto* clusterBuf = systems.gpuClusterBuffer();
+    if (culler && clusterBuf && !culler->hasDescriptorSets() && systems.hasGPUSceneBuffer()) {
+        auto& sceneBuffer = systems.gpuSceneBuffer();
+        uint32_t objCount = std::max(sceneBuffer.getObjectCount(), 1u);
+        std::vector<VkBuffer> instanceBuffers;
+        uint32_t framesInFlight = systems.globalBuffers().getFramesInFlight();
+        for (uint32_t fi = 0; fi < framesInFlight; ++fi) {
+            instanceBuffers.push_back(sceneBuffer.getInstanceBuffer(fi));
+        }
+        culler->setExternalBuffers(
+            clusterBuf->getClusterBuffer(),
+            clusterBuf->getTotalClusters() * sizeof(MeshCluster),
+            instanceBuffers,
+            objCount * sizeof(GPUSceneInstanceData));
+    }
+
+    // Lazily create raster descriptor sets (with DrawData and Instance SSBOs)
+    if (!visBuf->hasRasterDescriptorSets()) {
+        const auto& uboBuffers = systems.globalBuffers().getUniformBuffers();
+        VkDeviceSize uboSize = systems.globalBuffers().getUniformBufferSize();
+
+        std::vector<VkBuffer> drawDataBuffers;
+        VkDeviceSize drawDataSize = 0;
+        std::vector<VkBuffer> instanceBuffers;
+        VkDeviceSize instanceSize = 0;
+
+        if (culler && systems.hasGPUSceneBuffer()) {
+            auto& sceneBuffer = systems.gpuSceneBuffer();
+            uint32_t objCount = std::max(sceneBuffer.getObjectCount(), 1u);
+            drawDataSize = culler->getDrawDataBufferSize();
+            instanceSize = objCount * sizeof(GPUSceneInstanceData);
+
+            uint32_t framesInFlight = systems.globalBuffers().getFramesInFlight();
+            for (uint32_t fi = 0; fi < framesInFlight; ++fi) {
+                drawDataBuffers.push_back(culler->getPass1DrawDataBuffer(fi));
+                instanceBuffers.push_back(sceneBuffer.getInstanceBuffer(fi));
+            }
+        }
+
+        visBuf->createRasterDescriptorSets(uboBuffers, uboSize,
+            drawDataBuffers, drawDataSize, instanceBuffers, instanceSize);
+    }
+
+    if (!visBuf->hasRasterDescriptorSets() || !visBuf->hasGlobalBuffers()) {
+        systems.profiler().endGpuZone(cmd, "VisBufferRaster");
+        return;
+    }
+
+    if (!clusterBuf) {
+        systems.profiler().endGpuZone(cmd, "VisBufferRaster");
+        return;
+    }
+
+    vk::CommandBuffer vkCmd(cmd);
+
+    // Begin V-buffer render pass
+    VkExtent2D extent = visBuf->getExtent();
+
+    std::array<VkClearValue, 2> clearValues{};
+    clearValues[0].color.uint32[0] = 0;
+    clearValues[1].depthStencil = {1.0f, 0};
+
+    VkRenderPassBeginInfo rpBeginInfo{};
+    rpBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    rpBeginInfo.renderPass = visBuf->getRenderPass();
+    rpBeginInfo.framebuffer = visBuf->getFramebuffer();
+    rpBeginInfo.renderArea.offset = {0, 0};
+    rpBeginInfo.renderArea.extent = extent;
+    rpBeginInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
+    rpBeginInfo.pClearValues = clearValues.data();
+
+    vkCmdBeginRenderPass(cmd, &rpBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+
+    // Bind raster pipeline
+    vkCmd.bindPipeline(vk::PipelineBindPoint::eGraphics,
+                        vk::Pipeline(visBuf->getRasterPipeline()));
+
+    // Set dynamic viewport and scissor
+    vk::Viewport viewport{0.0f, 0.0f,
+                           static_cast<float>(extent.width),
+                           static_cast<float>(extent.height),
+                           0.0f, 1.0f};
+    vkCmd.setViewport(0, viewport);
+
+    vk::Rect2D scissor{{0, 0}, {extent.width, extent.height}};
+    vkCmd.setScissor(0, scissor);
+
+    // Bind raster descriptor set (UBO + texture + DrawData + Instances)
+    VkDescriptorSet rasterDescSet = visBuf->getRasterDescriptorSet(frameIndex);
+    vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+                              vk::PipelineLayout(visBuf->getRasterPipelineLayout()),
+                              0, vk::DescriptorSet(rasterDescSet), {});
+
+    // Bind GPUClusterBuffer vertex/index buffers
+    vk::Buffer vertexBuffers[] = {vk::Buffer(clusterBuf->getVertexBuffer())};
+    vk::DeviceSize offsets[] = {0};
+    vkCmd.bindVertexBuffers(0, vertexBuffers, offsets);
+    vkCmd.bindIndexBuffer(vk::Buffer(clusterBuf->getIndexBuffer()), 0, vk::IndexType::eUint32);
+
+    // GPU-driven indirect draw from TwoPassCuller pass 1 output
+    if (culler && culler->hasDescriptorSets()) {
+        if (culler->supportsDrawIndirectCount()) {
+            // GPU-driven draw count: only draws commands actually written by cull shader
+            vkCmdDrawIndexedIndirectCount(cmd,
+                culler->getPass1IndirectBuffer(frameIndex), 0,
+                culler->getPass1DrawCountBuffer(frameIndex), 0,
+                culler->getMaxDrawCommands(),
+                sizeof(VkDrawIndexedIndirectCommand));
+        } else {
+            // Fallback: draw all slots (unused slots zeroed by cull pass clear)
+            vkCmdDrawIndexedIndirect(cmd,
+                culler->getPass1IndirectBuffer(frameIndex), 0,
+                culler->getMaxDrawCommands(),
+                sizeof(VkDrawIndexedIndirectCommand));
+        }
+    }
+
+    vkCmdEndRenderPass(cmd);
+
+    systems.profiler().endGpuZone(cmd, "VisBufferRaster");
+}
+
+// ============================================================================
+// Resolve pass: Compute shader material evaluation
+// ============================================================================
+
+static void executeResolvePass(FrameGraph::RenderContext& ctx, RendererSystems& systems) {
+    RenderContext* renderCtx = static_cast<RenderContext*>(ctx.userData);
+    if (!renderCtx) return;
+
+    auto* visBuf = systems.visibilityBuffer();
+    if (!visBuf) return;
+
+    VkCommandBuffer cmd = renderCtx->cmd;
+    uint32_t frameIndex = renderCtx->frameIndex;
+
+    systems.profiler().beginGpuZone(cmd, "VisBufferResolve");
+
+    // Bind external buffers to the resolve pass
+    {
+        VisibilityBuffer::ResolveBuffers resolveBuffers{};
+
+        // Global vertex/index buffers from V-buffer system
+        if (visBuf->hasGlobalBuffers()) {
+            resolveBuffers.vertexBuffer = visBuf->getGlobalVertexBuffer();
+            resolveBuffers.vertexBufferSize = visBuf->getGlobalVertexBufferSize();
+            resolveBuffers.indexBuffer = visBuf->getGlobalIndexBuffer();
+            resolveBuffers.indexBufferSize = visBuf->getGlobalIndexBufferSize();
+        }
+
+        // Instance buffer from GPUSceneBuffer
+        if (systems.hasGPUSceneBuffer()) {
+            auto& sceneBuffer = systems.gpuSceneBuffer();
+            resolveBuffers.instanceBuffer = sceneBuffer.getInstanceBuffer(frameIndex);
+            uint32_t count = std::max(sceneBuffer.getObjectCount(), 1u);
+            resolveBuffers.instanceBufferSize = count * sizeof(GPUSceneInstanceData);
+        }
+
+        // Material buffer from GPUMaterialBuffer
+        if (systems.hasGPUMaterialBuffer()) {
+            auto* matBuf = systems.gpuMaterialBuffer();
+            resolveBuffers.materialBuffer = matBuf->getBuffer();
+            resolveBuffers.materialBufferSize = matBuf->getBufferSize();
+            resolveBuffers.materialCount = matBuf->getMaterialCount();
+        }
+
+        // Material texture array (albedo textures)
+        if (visBuf->hasTextureArray()) {
+            resolveBuffers.textureArrayView = visBuf->getTextureArrayView();
+            resolveBuffers.textureArraySampler = visBuf->getTextureArraySampler();
+        }
+
+        // HDR color image for layout transitions (resolve writes to it via imageStore)
+        resolveBuffers.hdrColorImage = renderCtx->resources.hdrColorImage;
+
+        // Dynamic light buffer for multi-light resolve
+        const auto& lightBuffers = systems.globalBuffers().getLightBuffers();
+        if (frameIndex < lightBuffers.size()) {
+            resolveBuffers.lightBuffer = lightBuffers[frameIndex];
+            resolveBuffers.lightBufferSize = systems.globalBuffers().getLightBufferSize();
+        }
+
+        visBuf->setResolveBuffers(resolveBuffers);
+    }
+
+    // Update resolve uniforms
+    visBuf->updateResolveUniforms(
+        frameIndex,
+        renderCtx->frame.view,
+        renderCtx->frame.projection,
+        renderCtx->frame.cameraPosition,
+        renderCtx->frame.sunDirection,
+        renderCtx->frame.sunIntensity,
+        systems.hasGPUMaterialBuffer() ? systems.gpuMaterialBuffer()->getMaterialCount() : 0
+    );
+
+    // Dispatch the resolve compute shader
+    VkImageView hdrView = renderCtx->resources.hdrColorView;
+    visBuf->recordResolvePass(cmd, frameIndex, hdrView);
+
+    systems.profiler().endGpuZone(cmd, "VisBufferResolve");
+}
+
+// ============================================================================
+// Pass registration
+// ============================================================================
+
+PassIds addPasses(FrameGraph& graph, RendererSystems& systems) {
+    PassIds ids;
+
+    // Only add if visibility buffer system exists
+    if (!systems.hasVisibilityBuffer()) {
+        return ids;
+    }
+
+    // Cull pass: GPU compute culling to produce indirect draw commands
+    if (systems.hasTwoPassCuller()) {
+        ids.cull = graph.addPass({
+            .name = "VisBufferCull",
+            .execute = [&systems](FrameGraph::RenderContext& ctx) {
+                executeCullPass(ctx, systems);
+            },
+            .canUseSecondary = false,
+            .mainThreadOnly = true,
+            .priority = 32  // Before raster (31)
+        });
+    }
+
+    // Raster pass: draw scene objects into V-buffer
+    ids.raster = graph.addPass({
+        .name = "VisBufferRaster",
+        .execute = [&systems](FrameGraph::RenderContext& ctx) {
+            executeRasterPass(ctx, systems);
+        },
+        .canUseSecondary = false,
+        .mainThreadOnly = true,
+        .priority = 31  // Higher than HDR (30) - runs first at same dependency level
+    });
+
+    // Resolve pass: compute shader material evaluation
+    ids.resolve = graph.addPass({
+        .name = "VisBufferResolve",
+        .execute = [&systems](FrameGraph::RenderContext& ctx) {
+            executeResolvePass(ctx, systems);
+        },
+        .canUseSecondary = false,
+        .mainThreadOnly = true,
+        .priority = 28  // After HDR (30), before post passes
+    });
+
+    return ids;
+}
+
+} // namespace VisBufferPasses

--- a/src/core/passes/VisBufferPasses.cpp
+++ b/src/core/passes/VisBufferPasses.cpp
@@ -500,6 +500,24 @@ static void executeResolvePass(FrameGraph::RenderContext& ctx, RendererSystems& 
 
     // Dispatch the resolve compute shader
     VkImageView hdrView = renderCtx->resources.hdrColorView;
+
+    // One-time diagnostic logging
+    static bool loggedResolveState = false;
+    if (!loggedResolveState) {
+        SDL_Log("VisBufferResolve: pipeline=%p, hdrView=%p, hdrImage=%p, "
+                "globalBufs=%d, texArray=%d, matBuf=%p, instanceBuf=%p",
+                (void*)(uintptr_t)visBuf->getResolvePipeline(),
+                (void*)(uintptr_t)hdrView,
+                (void*)(uintptr_t)renderCtx->resources.hdrColorImage,
+                visBuf->hasGlobalBuffers() ? 1 : 0,
+                visBuf->hasTextureArray() ? 1 : 0,
+                (void*)(uintptr_t)(systems.hasGPUMaterialBuffer()
+                    ? systems.gpuMaterialBuffer()->getBuffer() : VK_NULL_HANDLE),
+                (void*)(uintptr_t)(systems.hasGPUSceneBuffer()
+                    ? systems.gpuSceneBuffer().getInstanceBuffer(frameIndex) : VK_NULL_HANDLE));
+        loggedResolveState = true;
+    }
+
     visBuf->recordResolvePass(cmd, frameIndex, hdrView);
 
     systems.profiler().endGpuZone(cmd, "VisBufferResolve");

--- a/src/core/passes/VisBufferPasses.cpp
+++ b/src/core/passes/VisBufferPasses.cpp
@@ -142,7 +142,8 @@ static bool buildClusterState(RendererSystems& systems) {
             indirectCmd.instanceCount = 1;
             indirectCmd.firstIndex = cluster.firstIndex;
             indirectCmd.vertexOffset = static_cast<int32_t>(cluster.firstVertex);
-            indirectCmd.firstInstance = 0;
+            // firstInstance encodes the draw index for gl_InstanceIndex in raster shader
+            indirectCmd.firstInstance = static_cast<uint32_t>(s_clusterState.fallbackIndirectCmds.size());
             s_clusterState.fallbackIndirectCmds.push_back(indirectCmd);
 
             CPUDrawData dd{};

--- a/src/core/passes/VisBufferPasses.h
+++ b/src/core/passes/VisBufferPasses.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "FrameGraph.h"
+
+class RendererSystems;
+
+/**
+ * VisBufferPasses - Visibility buffer rasterization and material resolve passes
+ *
+ * Two passes:
+ * 1. Raster: Draws scene objects into the V-buffer (R32_UINT with packed instanceId+triangleId)
+ * 2. Resolve: Compute shader evaluates materials per-pixel and writes to HDR target
+ *
+ * Requires:
+ * - VisibilityBuffer (render targets, pipelines)
+ * - GPUSceneBuffer (instance data)
+ * - GPUMaterialBuffer (material properties)
+ * - GlobalBufferManager (UBO for view/proj matrices)
+ * - SceneManager (scene objects to render)
+ * - PostProcessSystem (HDR target to write into)
+ */
+namespace VisBufferPasses {
+
+struct PassIds {
+    FrameGraph::PassId cull = FrameGraph::INVALID_PASS;
+    FrameGraph::PassId raster = FrameGraph::INVALID_PASS;
+    FrameGraph::PassId resolve = FrameGraph::INVALID_PASS;
+};
+
+PassIds addPasses(FrameGraph& graph, RendererSystems& systems);
+
+} // namespace VisBufferPasses

--- a/src/core/pipeline/FrameGraphBuilder.cpp
+++ b/src/core/pipeline/FrameGraphBuilder.cpp
@@ -86,10 +86,12 @@ bool FrameGraphBuilder::build(
         frameGraph.addDependency(computeIds.gpuCull, hdr);
     }
 
-    // V-buffer cull pass depends on Compute (needs UBO/scene data uploaded)
-    // V-buffer raster depends on cull (needs indirect draw commands ready)
-    // HDR depends on V-buffer raster (shared depth buffer — V-buffer writes depth first,
-    // HDR loads it with loadOp=eLoad to preserve V-buffer depth writes)
+    // V-buffer runs alongside (not blocking) the traditional HDR path for now.
+    // Cull depends on Compute (needs UBO/scene data uploaded).
+    // Raster depends on cull (needs indirect draw commands).
+    // Resolve depends on raster + HDR (reads V-buffer, writes to HDR color).
+    // Post passes depend on HDR only — V-buffer is non-interfering until
+    // depth sharing and visBufferActive are enabled.
     if (visBufferIds.cull != FrameGraph::INVALID_PASS) {
         frameGraph.addDependency(computeIds.compute, visBufferIds.cull);
         if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
@@ -100,11 +102,7 @@ bool FrameGraphBuilder::build(
         if (visBufferIds.cull == FrameGraph::INVALID_PASS) {
             frameGraph.addDependency(computeIds.compute, visBufferIds.raster);
         }
-        frameGraph.addDependency(visBufferIds.raster, hdr);
     }
-
-    // V-buffer resolve depends on both raster (needs V-buffer populated)
-    // and HDR (resolve writes resolved materials into HDR color via imageStore)
     if (visBufferIds.resolve != FrameGraph::INVALID_PASS) {
         if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
             frameGraph.addDependency(visBufferIds.raster, visBufferIds.resolve);
@@ -112,14 +110,12 @@ bool FrameGraphBuilder::build(
         frameGraph.addDependency(hdr, visBufferIds.resolve);
     }
 
-    // Post-HDR passes depend on HDR (and VisBuffer resolve if active)
-    FrameGraph::PassId postDep = (visBufferIds.resolve != FrameGraph::INVALID_PASS)
-        ? visBufferIds.resolve : hdr;
-    frameGraph.addDependency(postDep, waterIds.ssr);
-    frameGraph.addDependency(postDep, waterIds.waterTileCull);
-    frameGraph.addDependency(postDep, postIds.hiZ);
-    frameGraph.addDependency(postDep, postIds.bilateralGrid);
-    frameGraph.addDependency(postDep, postIds.godRays);
+    // Post-HDR passes depend on HDR
+    frameGraph.addDependency(hdr, waterIds.ssr);
+    frameGraph.addDependency(hdr, waterIds.waterTileCull);
+    frameGraph.addDependency(hdr, postIds.hiZ);
+    frameGraph.addDependency(hdr, postIds.bilateralGrid);
+    frameGraph.addDependency(hdr, postIds.godRays);
 
     // Bloom depends on HiZ
     frameGraph.addDependency(postIds.hiZ, postIds.bloom);

--- a/src/core/pipeline/FrameGraphBuilder.cpp
+++ b/src/core/pipeline/FrameGraphBuilder.cpp
@@ -6,6 +6,7 @@
 #include "passes/ShadowPasses.h"
 #include "passes/WaterPasses.h"
 #include "passes/HDRPass.h"
+#include "passes/VisBufferPasses.h"
 #include "passes/PostPasses.h"
 
 #include <SDL3/SDL.h>
@@ -47,6 +48,9 @@ bool FrameGraphBuilder::build(
     hdrConfig.recordHDRPassSecondarySlot = callbacks.recordHDRPassSecondarySlot;
     auto hdr = HDRPass::addPass(frameGraph, systems, hdrConfig);
 
+    // Visibility buffer resolve pass (material evaluation)
+    auto visBufferIds = VisBufferPasses::addPasses(frameGraph, systems);
+
     // Post passes (HiZ, bloom, bilateral grid, final composite)
     PostPasses::Config postConfig;
     postConfig.guiRenderCallback = callbacks.guiRenderCallback;
@@ -82,12 +86,40 @@ bool FrameGraphBuilder::build(
         frameGraph.addDependency(computeIds.gpuCull, hdr);
     }
 
-    // Post-HDR passes depend on HDR
-    frameGraph.addDependency(hdr, waterIds.ssr);
-    frameGraph.addDependency(hdr, waterIds.waterTileCull);
-    frameGraph.addDependency(hdr, postIds.hiZ);
-    frameGraph.addDependency(hdr, postIds.bilateralGrid);
-    frameGraph.addDependency(hdr, postIds.godRays);
+    // V-buffer cull pass depends on Compute (needs UBO/scene data uploaded)
+    // V-buffer raster depends on cull (needs indirect draw commands ready)
+    // HDR depends on V-buffer raster (shared depth buffer — V-buffer writes depth first,
+    // HDR loads it with loadOp=eLoad to preserve V-buffer depth writes)
+    if (visBufferIds.cull != FrameGraph::INVALID_PASS) {
+        frameGraph.addDependency(computeIds.compute, visBufferIds.cull);
+        if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
+            frameGraph.addDependency(visBufferIds.cull, visBufferIds.raster);
+        }
+    }
+    if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
+        if (visBufferIds.cull == FrameGraph::INVALID_PASS) {
+            frameGraph.addDependency(computeIds.compute, visBufferIds.raster);
+        }
+        frameGraph.addDependency(visBufferIds.raster, hdr);
+    }
+
+    // V-buffer resolve depends on both raster (needs V-buffer populated)
+    // and HDR (resolve writes resolved materials into HDR color via imageStore)
+    if (visBufferIds.resolve != FrameGraph::INVALID_PASS) {
+        if (visBufferIds.raster != FrameGraph::INVALID_PASS) {
+            frameGraph.addDependency(visBufferIds.raster, visBufferIds.resolve);
+        }
+        frameGraph.addDependency(hdr, visBufferIds.resolve);
+    }
+
+    // Post-HDR passes depend on HDR (and VisBuffer resolve if active)
+    FrameGraph::PassId postDep = (visBufferIds.resolve != FrameGraph::INVALID_PASS)
+        ? visBufferIds.resolve : hdr;
+    frameGraph.addDependency(postDep, waterIds.ssr);
+    frameGraph.addDependency(postDep, waterIds.waterTileCull);
+    frameGraph.addDependency(postDep, postIds.hiZ);
+    frameGraph.addDependency(postDep, postIds.bilateralGrid);
+    frameGraph.addDependency(postDep, postIds.godRays);
 
     // Bloom depends on HiZ
     frameGraph.addDependency(postIds.hiZ, postIds.bloom);

--- a/src/core/vulkan/VulkanContext.h
+++ b/src/core/vulkan/VulkanContext.h
@@ -126,6 +126,12 @@ public:
     // Check if timeline semaphores are supported (always true for Vulkan 1.2+)
     bool hasTimelineSemaphores() const { return hasTimelineSemaphores_; }
 
+    // Check if drawIndirectCount is supported (vkCmdDrawIndexedIndirectCount)
+    bool hasDrawIndirectCount() const { return hasDrawIndirectCount_; }
+
+    // Check if shaderDrawParameters is supported (gl_DrawID)
+    bool hasShaderDrawParameters() const { return hasShaderDrawParameters_; }
+
 private:
     bool createInstance();
     bool createSurface();
@@ -157,6 +163,8 @@ private:
     uint32_t transferQueueFamily_ = 0;
     bool hasDedicatedTransfer_ = false;
     bool hasTimelineSemaphores_ = false;
+    bool hasDrawIndirectCount_ = false;
+    bool hasShaderDrawParameters_ = false;
 
     VmaAllocator allocator = VK_NULL_HANDLE;
 

--- a/src/culling/GPUCullPass.cpp
+++ b/src/culling/GPUCullPass.cpp
@@ -160,7 +160,9 @@ void GPUCullPass::updateUniforms(uint32_t frameIndex,
                                   const glm::mat4& proj,
                                   const glm::vec3& cameraPos,
                                   uint32_t objectCount,
-                                  VkExtent2D screenExtent) {
+                                  VkExtent2D screenExtent,
+                                  float nearPlane,
+                                  float farPlane) {
     GPUCullUniforms uniforms{};
     uniforms.viewMatrix = view;
     uniforms.projMatrix = proj;
@@ -173,8 +175,9 @@ void GPUCullPass::updateUniforms(uint32_t frameIndex,
     } else {
         uniforms.screenParams = glm::vec4(0.0f);
     }
+    uniforms.depthParams = glm::vec4(nearPlane, farPlane, static_cast<float>(hiZMipLevels_), 0.0f);
     uniforms.objectCount = objectCount;
-    uniforms.enableHiZ = hiZEnabled_ ? 1 : 0;
+    uniforms.enableHiZ = (hiZEnabled_ && hiZPyramidView_ != VK_NULL_HANDLE) ? 1 : 0;
     uniforms.maxDrawCommands = MAX_OBJECTS;
     uniforms.padding = 0;
 
@@ -329,9 +332,10 @@ GPUCullPass::CullingStats GPUCullPass::getStats(uint32_t frameIndex) const {
     return stats;
 }
 
-void GPUCullPass::setHiZPyramid(VkImageView pyramidView, VkSampler sampler) {
+void GPUCullPass::setHiZPyramid(VkImageView pyramidView, VkSampler sampler, uint32_t mipLevels) {
     hiZPyramidView_ = pyramidView;
     hiZSampler_ = sampler;
+    hiZMipLevels_ = mipLevels;
 }
 
 void GPUCullPass::setPlaceholderImage(VkImageView view, VkSampler sampler) {

--- a/src/postprocess/PostProcessSystem.h
+++ b/src/postprocess/PostProcessSystem.h
@@ -105,13 +105,20 @@ public:
 
     // Render target accessors (vulkan-hpp)
     vk::ImageView getHDRColorView() const { return vk::ImageView(hdrColorView); }
+    vk::Image getHDRColorImage() const { return vk::Image(hdrColorImage); }
     vk::ImageView getHDRDepthView() const { return vk::ImageView(hdrDepthView); }
+    vk::Image getHDRDepthImage() const { return vk::Image(hdrDepthImage); }
     vk::RenderPass getHDRRenderPass() const { return vk::RenderPass(hdrRenderPass); }
     vk::Framebuffer getHDRFramebuffer() const { return vk::Framebuffer(hdrFramebuffer); }
     vk::Extent2D getRenderExtent() const { return vk::Extent2D{}.setWidth(extent.width).setHeight(extent.height); }
 
     // Legacy raw handle accessors (for existing code)
     VkExtent2D getExtent() const { return extent; }
+
+    // Shared depth: when V-buffer raster writes to the HDR depth before the HDR pass,
+    // the HDR render pass must load depth (not clear) to preserve V-buffer depth writes.
+    void setDepthLoadOnHDRPass(bool load);
+    bool getDepthLoadOnHDRPass() const { return hdrDepthLoadOp_ == VK_ATTACHMENT_LOAD_OP_LOAD; }
 
     // Pre-end callback is called after post-process draw but before ending render pass (for GUI overlay)
     using PreEndCallback = std::function<void(VkCommandBuffer)>;
@@ -287,6 +294,7 @@ private:
     std::optional<vk::raii::RenderPass> hdrRenderPass_;
     VkRenderPass hdrRenderPass = VK_NULL_HANDLE;  // Raw handle for compatibility
     VkFramebuffer hdrFramebuffer = VK_NULL_HANDLE;
+    VkAttachmentLoadOp hdrDepthLoadOp_ = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
     // Final composite pipeline
     VkDescriptorSetLayout compositeDescriptorSetLayout = VK_NULL_HANDLE;

--- a/src/visibility/GPUMaterialBuffer.cpp
+++ b/src/visibility/GPUMaterialBuffer.cpp
@@ -1,0 +1,167 @@
+#include "GPUMaterialBuffer.h"
+#include "MaterialRegistry.h"
+
+#include <SDL3/SDL_log.h>
+#include <cstring>
+#include <algorithm>
+
+std::unique_ptr<GPUMaterialBuffer> GPUMaterialBuffer::create(const InitInfo& info) {
+    auto buffer = std::make_unique<GPUMaterialBuffer>(ConstructToken{});
+    if (!buffer->initInternal(info)) {
+        return nullptr;
+    }
+    return buffer;
+}
+
+bool GPUMaterialBuffer::initInternal(const InitInfo& info) {
+    allocator_ = info.allocator;
+    maxMaterials_ = info.maxMaterials;
+
+    VkDeviceSize bufferSize = maxMaterials_ * sizeof(GPUMaterial);
+
+    if (!VmaBufferFactory::createStorageBufferHostWritable(allocator_, bufferSize, buffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "GPUMaterialBuffer: Failed to create storage buffer (%u materials)",
+                     maxMaterials_);
+        return false;
+    }
+
+    // Map the buffer persistently
+    VmaAllocationInfo allocInfo{};
+    vmaGetAllocationInfo(allocator_, buffer_.get_deleter().allocation, &allocInfo);
+    mappedPtr_ = allocInfo.pMappedData;
+
+    if (!mappedPtr_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "GPUMaterialBuffer: Buffer not mapped");
+        return false;
+    }
+
+    // Zero-initialize
+    memset(mappedPtr_, 0, bufferSize);
+
+    SDL_Log("GPUMaterialBuffer: Created with capacity for %u materials (%zu bytes)",
+            maxMaterials_, static_cast<size_t>(bufferSize));
+    return true;
+}
+
+bool GPUMaterialBuffer::uploadMaterials(const std::vector<GPUMaterial>& materials) {
+    if (!mappedPtr_) return false;
+
+    uint32_t count = static_cast<uint32_t>(
+        std::min(materials.size(), static_cast<size_t>(maxMaterials_)));
+
+    VkDeviceSize bytes = count * sizeof(GPUMaterial);
+    memcpy(mappedPtr_, materials.data(), bytes);
+    vmaFlushAllocation(allocator_, buffer_.get_deleter().allocation, 0, bytes);
+
+    materialCount_ = count;
+    return true;
+}
+
+bool GPUMaterialBuffer::uploadFromRegistry(const MaterialRegistry& registry) {
+    if (!mappedPtr_) return false;
+
+    uint32_t count = static_cast<uint32_t>(
+        std::min(registry.getMaterialCount(), static_cast<size_t>(maxMaterials_)));
+
+    std::vector<GPUMaterial> materials;
+    materials.reserve(count);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        const auto* def = registry.getMaterial(i);
+        GPUMaterial gpuMat{};
+
+        if (def) {
+            // Base color defaults to white (texture will provide actual color)
+            gpuMat.baseColor = glm::vec4(1.0f, 1.0f, 1.0f, 1.0f);
+            gpuMat.roughness = def->roughness;
+            gpuMat.metallic = def->metallic;
+            gpuMat.normalScale = 1.0f;
+            gpuMat.aoStrength = 1.0f;
+
+            // Texture indices default to UINT32_MAX (no texture)
+            // These will be set when a texture array is populated
+            gpuMat.albedoTexIndex = ~0u;
+            gpuMat.normalTexIndex = ~0u;
+            gpuMat.roughnessMetallicTexIndex = ~0u;
+            gpuMat.flags = 0;
+        } else {
+            // Default material (gray, mid-roughness)
+            gpuMat.baseColor = glm::vec4(0.8f, 0.8f, 0.8f, 1.0f);
+            gpuMat.roughness = 0.5f;
+            gpuMat.metallic = 0.0f;
+            gpuMat.normalScale = 1.0f;
+            gpuMat.aoStrength = 1.0f;
+            gpuMat.albedoTexIndex = ~0u;
+            gpuMat.normalTexIndex = ~0u;
+            gpuMat.roughnessMetallicTexIndex = ~0u;
+            gpuMat.flags = 0;
+        }
+
+        materials.push_back(gpuMat);
+    }
+
+    return uploadMaterials(materials);
+}
+
+bool GPUMaterialBuffer::uploadFromRegistry(const MaterialRegistry& registry,
+                                            const VisibilityBuffer& visBuf) {
+    if (!mappedPtr_) return false;
+
+    uint32_t count = static_cast<uint32_t>(
+        std::min(registry.getMaterialCount(), static_cast<size_t>(maxMaterials_)));
+
+    std::vector<GPUMaterial> materials;
+    materials.reserve(count);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        const auto* def = registry.getMaterial(i);
+        GPUMaterial gpuMat{};
+
+        if (def) {
+            gpuMat.baseColor = glm::vec4(1.0f, 1.0f, 1.0f, 1.0f);
+            gpuMat.roughness = def->roughness;
+            gpuMat.metallic = def->metallic;
+            gpuMat.normalScale = 1.0f;
+            gpuMat.aoStrength = 1.0f;
+
+            // Look up texture layers in the unified texture array
+            gpuMat.albedoTexIndex = def->diffuse
+                ? visBuf.getTextureLayerIndex(def->diffuse) : ~0u;
+            gpuMat.normalTexIndex = def->normal
+                ? visBuf.getTextureLayerIndex(def->normal) : ~0u;
+            // Use roughness map as roughness-metallic packed texture
+            // (glTF convention: green=roughness, blue=metallic)
+            gpuMat.roughnessMetallicTexIndex = def->roughnessMap
+                ? visBuf.getTextureLayerIndex(def->roughnessMap) : ~0u;
+            gpuMat.flags = 0;
+        } else {
+            gpuMat.baseColor = glm::vec4(0.8f, 0.8f, 0.8f, 1.0f);
+            gpuMat.roughness = 0.5f;
+            gpuMat.metallic = 0.0f;
+            gpuMat.normalScale = 1.0f;
+            gpuMat.aoStrength = 1.0f;
+            gpuMat.albedoTexIndex = ~0u;
+            gpuMat.normalTexIndex = ~0u;
+            gpuMat.roughnessMetallicTexIndex = ~0u;
+            gpuMat.flags = 0;
+        }
+
+        materials.push_back(gpuMat);
+    }
+
+    return uploadMaterials(materials);
+}
+
+bool GPUMaterialBuffer::setMaterial(uint32_t index, const GPUMaterial& material) {
+    if (!mappedPtr_ || index >= maxMaterials_) return false;
+
+    auto* dst = static_cast<GPUMaterial*>(mappedPtr_) + index;
+    memcpy(dst, &material, sizeof(GPUMaterial));
+    vmaFlushAllocation(allocator_, buffer_.get_deleter().allocation,
+                       index * sizeof(GPUMaterial), sizeof(GPUMaterial));
+
+    materialCount_ = std::max(materialCount_, index + 1);
+    return true;
+}

--- a/src/visibility/GPUMaterialBuffer.h
+++ b/src/visibility/GPUMaterialBuffer.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <vector>
+#include <cstdint>
+#include <memory>
+
+#include "VisibilityBuffer.h"  // for GPUMaterial
+#include "vulkan/VmaBuffer.h"
+#include "vulkan/VmaBufferFactory.h"
+
+class MaterialRegistry;
+
+/**
+ * GPUMaterialBuffer - Manages GPU-side material data for the visibility buffer resolve.
+ *
+ * Uploads GPUMaterial structs to a storage buffer that the resolve compute shader
+ * reads to determine per-pixel material properties (base color, roughness, metallic,
+ * texture indices, etc.).
+ *
+ * Usage:
+ *   1. create() - Initialize with allocator
+ *   2. uploadMaterials() - Upload material data from MaterialRegistry or manual list
+ *   3. getBuffer()/getBufferSize()/getMaterialCount() - Bind to resolve descriptor set
+ */
+class GPUMaterialBuffer {
+public:
+    struct ConstructToken { explicit ConstructToken() = default; };
+    explicit GPUMaterialBuffer(ConstructToken) {}
+
+    struct InitInfo {
+        VmaAllocator allocator = VK_NULL_HANDLE;
+        uint32_t maxMaterials = 256;
+    };
+
+    static std::unique_ptr<GPUMaterialBuffer> create(const InitInfo& info);
+
+    ~GPUMaterialBuffer() = default;
+
+    GPUMaterialBuffer(const GPUMaterialBuffer&) = delete;
+    GPUMaterialBuffer& operator=(const GPUMaterialBuffer&) = delete;
+
+    /**
+     * Upload materials from a vector of GPUMaterial.
+     * Returns true on success.
+     */
+    bool uploadMaterials(const std::vector<GPUMaterial>& materials);
+
+    /**
+     * Upload materials from MaterialRegistry.
+     * Creates GPUMaterial entries from each registered material definition.
+     * Texture indices default to UINT32_MAX (no texture) unless a texture
+     * array is being used and indices are provided.
+     */
+    bool uploadFromRegistry(const MaterialRegistry& registry);
+
+    /**
+     * Upload materials with texture array indices from VisibilityBuffer.
+     * Populates albedoTexIndex from the texture array layer mapping.
+     */
+    bool uploadFromRegistry(const MaterialRegistry& registry,
+                            const VisibilityBuffer& visBuf);
+
+    /**
+     * Set or update a single material at the given index.
+     */
+    bool setMaterial(uint32_t index, const GPUMaterial& material);
+
+    // Buffer accessors
+    VkBuffer getBuffer() const { return buffer_.get(); }
+    VkDeviceSize getBufferSize() const { return maxMaterials_ * sizeof(GPUMaterial); }
+    uint32_t getMaterialCount() const { return materialCount_; }
+    uint32_t getMaxMaterials() const { return maxMaterials_; }
+
+private:
+    bool initInternal(const InitInfo& info);
+
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    uint32_t maxMaterials_ = 0;
+    uint32_t materialCount_ = 0;
+
+    VmaBuffer buffer_;
+    void* mappedPtr_ = nullptr;
+};

--- a/src/visibility/MeshClusterBuilder.cpp
+++ b/src/visibility/MeshClusterBuilder.cpp
@@ -1,0 +1,655 @@
+#include "MeshClusterBuilder.h"
+#include <SDL3/SDL_log.h>
+#include <meshoptimizer.h>
+#include <algorithm>
+#include <cstring>
+#include <numeric>
+#include <unordered_set>
+
+// ============================================================================
+// MeshClusterBuilder
+// ============================================================================
+
+void MeshClusterBuilder::setTargetClusterSize(uint32_t trianglesPerCluster) {
+    targetClusterSize_ = std::clamp(trianglesPerCluster, MIN_CLUSTER_SIZE, MAX_CLUSTER_SIZE);
+}
+
+ClusteredMesh MeshClusterBuilder::build(const std::vector<Vertex>& vertices,
+                                         const std::vector<uint32_t>& indices,
+                                         uint32_t meshId) {
+    ClusteredMesh result;
+    result.vertices = vertices;
+    result.indices = indices;
+
+    uint32_t totalTriangles = static_cast<uint32_t>(indices.size()) / 3;
+    uint32_t trianglesPerCluster = targetClusterSize_;
+
+    // Simple linear partitioning of triangles into clusters
+    // A more sophisticated approach would use spatial partitioning (e.g., k-d tree)
+    // but linear is a good starting point and preserves mesh locality
+    uint32_t numClusters = (totalTriangles + trianglesPerCluster - 1) / trianglesPerCluster;
+
+    result.clusters.reserve(numClusters);
+    result.totalTriangles = totalTriangles;
+    result.totalClusters = numClusters;
+
+    for (uint32_t c = 0; c < numClusters; ++c) {
+        uint32_t firstTriangle = c * trianglesPerCluster;
+        uint32_t clusterTriangles = std::min(trianglesPerCluster, totalTriangles - firstTriangle);
+        uint32_t firstIndex = firstTriangle * 3;
+        uint32_t indexCount = clusterTriangles * 3;
+
+        MeshCluster cluster{};
+        cluster.firstIndex = firstIndex;
+        cluster.indexCount = indexCount;
+        cluster.firstVertex = 0;  // All clusters share the same vertex buffer
+        cluster.meshId = meshId;
+        cluster.lodLevel = 0;
+        cluster.parentError = 0.0f;
+        cluster.error = 0.0f;
+        cluster.parentIndex = UINT32_MAX;
+        cluster.firstChildIndex = 0;
+        cluster.childCount = 0;
+
+        // Compute bounding data
+        cluster.boundingSphere = computeBoundingSphere(vertices, indices, firstIndex, indexCount);
+        computeAABB(vertices, indices, firstIndex, indexCount, cluster.aabbMin, cluster.aabbMax);
+        computeNormalCone(vertices, indices, firstIndex, indexCount, cluster.coneAxis, cluster.coneAngle);
+
+        result.clusters.push_back(cluster);
+    }
+
+    SDL_Log("MeshClusterBuilder: Built %u clusters from %u triangles (target %u tri/cluster)",
+            numClusters, totalTriangles, trianglesPerCluster);
+
+    return result;
+}
+
+glm::vec4 MeshClusterBuilder::computeBoundingSphere(const std::vector<Vertex>& vertices,
+                                                      const std::vector<uint32_t>& indices,
+                                                      uint32_t firstIndex, uint32_t indexCount) {
+    if (indexCount == 0) return glm::vec4(0.0f);
+
+    // Compute center as centroid of all referenced vertices
+    glm::vec3 center(0.0f);
+    for (uint32_t i = firstIndex; i < firstIndex + indexCount; ++i) {
+        center += vertices[indices[i]].position;
+    }
+    center /= static_cast<float>(indexCount);
+
+    // Find maximum distance from center
+    float maxDist2 = 0.0f;
+    for (uint32_t i = firstIndex; i < firstIndex + indexCount; ++i) {
+        float dist2 = glm::dot(vertices[indices[i]].position - center,
+                                vertices[indices[i]].position - center);
+        maxDist2 = std::max(maxDist2, dist2);
+    }
+
+    return glm::vec4(center, std::sqrt(maxDist2));
+}
+
+void MeshClusterBuilder::computeAABB(const std::vector<Vertex>& vertices,
+                                       const std::vector<uint32_t>& indices,
+                                       uint32_t firstIndex, uint32_t indexCount,
+                                       glm::vec3& outMin, glm::vec3& outMax) {
+    outMin = glm::vec3(std::numeric_limits<float>::max());
+    outMax = glm::vec3(std::numeric_limits<float>::lowest());
+
+    for (uint32_t i = firstIndex; i < firstIndex + indexCount; ++i) {
+        const auto& pos = vertices[indices[i]].position;
+        outMin = glm::min(outMin, pos);
+        outMax = glm::max(outMax, pos);
+    }
+}
+
+void MeshClusterBuilder::computeNormalCone(const std::vector<Vertex>& vertices,
+                                             const std::vector<uint32_t>& indices,
+                                             uint32_t firstIndex, uint32_t indexCount,
+                                             glm::vec3& outAxis, float& outAngle) {
+    // Compute average normal direction
+    glm::vec3 avgNormal(0.0f);
+    uint32_t triCount = indexCount / 3;
+    for (uint32_t t = 0; t < triCount; ++t) {
+        uint32_t base = firstIndex + t * 3;
+        const auto& v0 = vertices[indices[base + 0]].position;
+        const auto& v1 = vertices[indices[base + 1]].position;
+        const auto& v2 = vertices[indices[base + 2]].position;
+
+        glm::vec3 edge1 = v1 - v0;
+        glm::vec3 edge2 = v2 - v0;
+        glm::vec3 faceNormal = glm::cross(edge1, edge2);
+        float area = glm::length(faceNormal);
+        if (area > 1e-8f) {
+            avgNormal += faceNormal;  // Area-weighted
+        }
+    }
+
+    float len = glm::length(avgNormal);
+    if (len < 1e-8f) {
+        outAxis = glm::vec3(0.0f, 1.0f, 0.0f);
+        outAngle = -1.0f;  // Degenerate - don't cull
+        return;
+    }
+    outAxis = avgNormal / len;
+
+    // Find max deviation from average normal
+    float minCos = 1.0f;
+    for (uint32_t t = 0; t < triCount; ++t) {
+        uint32_t base = firstIndex + t * 3;
+        const auto& v0 = vertices[indices[base + 0]].position;
+        const auto& v1 = vertices[indices[base + 1]].position;
+        const auto& v2 = vertices[indices[base + 2]].position;
+
+        glm::vec3 edge1 = v1 - v0;
+        glm::vec3 edge2 = v2 - v0;
+        glm::vec3 faceNormal = glm::normalize(glm::cross(edge1, edge2));
+        float cosAngle = glm::dot(faceNormal, outAxis);
+        minCos = std::min(minCos, cosAngle);
+    }
+
+    outAngle = minCos;  // cos(half-angle) - higher = tighter cone
+}
+
+// ============================================================================
+// DAG Builder
+// ============================================================================
+
+ClusteredMesh MeshClusterBuilder::buildWithDAG(const std::vector<Vertex>& vertices,
+                                                const std::vector<uint32_t>& indices,
+                                                uint32_t meshId) {
+    // Step 1: Build leaf clusters (LOD 0)
+    ClusteredMesh result = build(vertices, indices, meshId);
+
+    uint32_t leafCount = result.totalClusters;
+    result.leafClusterCount = leafCount;
+
+    // Need at least 2 clusters to build a hierarchy
+    if (leafCount < 2) {
+        result.dagLevels = 1;
+        result.rootClusterIndex = 0;
+        if (!result.clusters.empty()) {
+            result.clusters[0].parentIndex = UINT32_MAX;
+        }
+        SDL_Log("MeshClusterBuilder: DAG trivial (1 cluster, no hierarchy needed)");
+        return result;
+    }
+
+    // Step 2: Iteratively build DAG levels
+    // currentLevel holds indices into result.clusters for the clusters at this level
+    std::vector<uint32_t> currentLevel(leafCount);
+    std::iota(currentLevel.begin(), currentLevel.end(), 0);
+
+    uint32_t lodLevel = 0;
+    uint32_t targetTrisPerParent = targetClusterSize_;
+
+    while (currentLevel.size() > 1) {
+        lodLevel++;
+
+        // Group spatially adjacent clusters
+        auto groups = groupClustersSpatially(result.clusters, currentLevel);
+
+        std::vector<uint32_t> nextLevel;
+        nextLevel.reserve(groups.size());
+
+        for (const auto& group : groups) {
+            if (group.size() == 1) {
+                // Single cluster can't be grouped further — promote as-is
+                // Mark it as its own "parent" at the next level
+                nextLevel.push_back(group[0]);
+                continue;
+            }
+
+            // Simplify the group into a parent cluster
+            float simplifyError = 0.0f;
+            MeshCluster parent = simplifyClusterGroup(
+                group, result.clusters,
+                result.vertices, result.indices,
+                meshId, lodLevel, targetTrisPerParent,
+                simplifyError);
+
+            uint32_t parentIdx = static_cast<uint32_t>(result.clusters.size());
+            parent.parentIndex = UINT32_MAX;  // Will be set by next level
+            parent.firstChildIndex = group[0]; // Record first child for reference
+            parent.childCount = static_cast<uint32_t>(group.size());
+            parent.error = simplifyError;
+
+            // Wire up parent-child relationships
+            for (uint32_t childIdx : group) {
+                result.clusters[childIdx].parentIndex = parentIdx;
+                result.clusters[childIdx].parentError = simplifyError;
+            }
+
+            result.clusters.push_back(parent);
+            nextLevel.push_back(parentIdx);
+        }
+
+        // If we didn't reduce the count, force-merge remaining into one
+        if (nextLevel.size() >= currentLevel.size()) {
+            SDL_Log("MeshClusterBuilder: DAG stopped at level %u (no further reduction from %zu clusters)",
+                    lodLevel, currentLevel.size());
+            break;
+        }
+
+        currentLevel = std::move(nextLevel);
+    }
+
+    // The last remaining cluster is the root
+    result.rootClusterIndex = currentLevel[0];
+    result.dagLevels = lodLevel + 1;
+    result.totalClusters = static_cast<uint32_t>(result.clusters.size());
+
+    SDL_Log("MeshClusterBuilder: DAG built with %u levels, %u total clusters (%u leaf + %u internal), root=%u",
+            result.dagLevels, result.totalClusters, result.leafClusterCount,
+            result.totalClusters - result.leafClusterCount, result.rootClusterIndex);
+
+    return result;
+}
+
+std::vector<std::vector<uint32_t>> MeshClusterBuilder::groupClustersSpatially(
+    const std::vector<MeshCluster>& clusters,
+    const std::vector<uint32_t>& clusterIndices) {
+
+    std::vector<std::vector<uint32_t>> groups;
+    if (clusterIndices.empty()) return groups;
+
+    // Compute centroids for each cluster
+    struct CentroidEntry {
+        uint32_t clusterIdx;
+        glm::vec3 centroid;
+    };
+    std::vector<CentroidEntry> entries;
+    entries.reserve(clusterIndices.size());
+    for (uint32_t idx : clusterIndices) {
+        entries.push_back({idx, glm::vec3(clusters[idx].boundingSphere)});
+    }
+
+    // Greedy nearest-neighbor grouping: pick an ungrouped cluster,
+    // find its nearest 1-3 ungrouped neighbors, form a group
+    std::vector<bool> used(entries.size(), false);
+    constexpr uint32_t MAX_GROUP_SIZE = 4;
+    constexpr uint32_t TARGET_GROUP_SIZE = 2;
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (used[i]) continue;
+
+        std::vector<uint32_t> group;
+        group.push_back(entries[i].clusterIdx);
+        used[i] = true;
+
+        glm::vec3 groupCenter = entries[i].centroid;
+
+        // Find nearest neighbors
+        for (uint32_t g = 1; g < MAX_GROUP_SIZE; ++g) {
+            float bestDist2 = std::numeric_limits<float>::max();
+            size_t bestJ = SIZE_MAX;
+
+            for (size_t j = 0; j < entries.size(); ++j) {
+                if (used[j]) continue;
+                glm::vec3 diff = entries[j].centroid - groupCenter;
+                float dist2 = glm::dot(diff, diff);
+                if (dist2 < bestDist2) {
+                    bestDist2 = dist2;
+                    bestJ = j;
+                }
+            }
+
+            if (bestJ == SIZE_MAX) break;
+
+            // Only add if reasonably close (within 3x the current group radius)
+            // This prevents merging very distant clusters
+            if (g >= TARGET_GROUP_SIZE) {
+                float groupRadius = clusters[group[0]].boundingSphere.w;
+                for (size_t k = 1; k < group.size(); ++k) {
+                    groupRadius = std::max(groupRadius, clusters[group[k]].boundingSphere.w);
+                }
+                if (bestDist2 > 9.0f * groupRadius * groupRadius && g >= TARGET_GROUP_SIZE) {
+                    break;
+                }
+            }
+
+            group.push_back(entries[bestJ].clusterIdx);
+            used[bestJ] = true;
+
+            // Update group center
+            groupCenter = glm::vec3(0.0f);
+            for (uint32_t idx : group) {
+                groupCenter += glm::vec3(clusters[idx].boundingSphere);
+            }
+            groupCenter /= static_cast<float>(group.size());
+        }
+
+        groups.push_back(std::move(group));
+    }
+
+    return groups;
+}
+
+MeshCluster MeshClusterBuilder::simplifyClusterGroup(
+    const std::vector<uint32_t>& groupIndices,
+    const std::vector<MeshCluster>& clusters,
+    std::vector<Vertex>& vertices,
+    std::vector<uint32_t>& indices,
+    uint32_t meshId,
+    uint32_t lodLevel,
+    uint32_t targetTriangles,
+    float& outError) {
+
+    // Collect all vertices referenced by the group's clusters
+    // We need to remap indices to a local vertex set for meshoptimizer
+    std::unordered_set<uint32_t> usedVertexSet;
+    uint32_t totalGroupIndices = 0;
+    for (uint32_t ci : groupIndices) {
+        const auto& c = clusters[ci];
+        for (uint32_t i = c.firstIndex; i < c.firstIndex + c.indexCount; ++i) {
+            usedVertexSet.insert(indices[i]);
+        }
+        totalGroupIndices += c.indexCount;
+    }
+
+    // Build local vertex buffer and index remapping
+    std::vector<uint32_t> globalToLocal(vertices.size(), UINT32_MAX);
+    std::vector<Vertex> localVertices;
+    localVertices.reserve(usedVertexSet.size());
+
+    for (uint32_t vi : usedVertexSet) {
+        globalToLocal[vi] = static_cast<uint32_t>(localVertices.size());
+        localVertices.push_back(vertices[vi]);
+    }
+
+    // Build local index buffer
+    std::vector<uint32_t> localIndices;
+    localIndices.reserve(totalGroupIndices);
+    for (uint32_t ci : groupIndices) {
+        const auto& c = clusters[ci];
+        for (uint32_t i = c.firstIndex; i < c.firstIndex + c.indexCount; ++i) {
+            localIndices.push_back(globalToLocal[indices[i]]);
+        }
+    }
+
+    // Simplify using meshoptimizer
+    uint32_t targetIndexCount = targetTriangles * 3;
+    // Don't go below 12 indices (4 triangles) - need at least something visible
+    targetIndexCount = std::max(targetIndexCount, 12u);
+    // But also cap at the number of input indices
+    targetIndexCount = std::min(targetIndexCount, static_cast<uint32_t>(localIndices.size()));
+
+    float targetError = 0.05f;  // Allow up to 5% error
+    float resultError = 0.0f;
+
+    std::vector<uint32_t> simplifiedIndices(localIndices.size());
+    size_t simplifiedCount = meshopt_simplify(
+        simplifiedIndices.data(),
+        localIndices.data(),
+        localIndices.size(),
+        &localVertices[0].position.x,
+        localVertices.size(),
+        sizeof(Vertex),
+        targetIndexCount,
+        targetError,
+        0,  // no options
+        &resultError);
+
+    simplifiedIndices.resize(simplifiedCount);
+
+    // If meshopt_simplify didn't reduce enough, try sloppy mode
+    if (simplifiedCount > targetIndexCount * 2) {
+        size_t sloppyCount = meshopt_simplifySloppy(
+            simplifiedIndices.data(),
+            localIndices.data(),
+            localIndices.size(),
+            &localVertices[0].position.x,
+            localVertices.size(),
+            sizeof(Vertex),
+            targetIndexCount,
+            targetError,
+            &resultError);
+        if (sloppyCount > 0 && sloppyCount < simplifiedCount) {
+            simplifiedIndices.resize(sloppyCount);
+            simplifiedCount = sloppyCount;
+        }
+    }
+
+    outError = resultError;
+
+    // Optimize vertex cache for the simplified mesh
+    meshopt_optimizeVertexCache(
+        simplifiedIndices.data(),
+        simplifiedIndices.data(),
+        simplifiedIndices.size(),
+        localVertices.size());
+
+    // Append the simplified geometry to the global buffers
+    uint32_t baseVertex = static_cast<uint32_t>(vertices.size());
+    uint32_t baseIndex = static_cast<uint32_t>(indices.size());
+
+    // We only need to append vertices that are actually used by the simplified mesh
+    std::vector<uint32_t> localToGlobal(localVertices.size(), UINT32_MAX);
+    uint32_t newVertexCount = 0;
+    for (uint32_t si : simplifiedIndices) {
+        if (localToGlobal[si] == UINT32_MAX) {
+            localToGlobal[si] = baseVertex + newVertexCount;
+            vertices.push_back(localVertices[si]);
+            newVertexCount++;
+        }
+    }
+
+    // Remap and append indices
+    for (uint32_t si : simplifiedIndices) {
+        indices.push_back(localToGlobal[si]);
+    }
+
+    // Build the parent cluster
+    uint32_t parentFirstIndex = baseIndex;
+    uint32_t parentIndexCount = static_cast<uint32_t>(simplifiedIndices.size());
+
+    MeshCluster parent{};
+    parent.firstIndex = parentFirstIndex;
+    parent.indexCount = parentIndexCount;
+    parent.firstVertex = 0;  // Global vertex buffer
+    parent.meshId = meshId;
+    parent.lodLevel = lodLevel;
+    parent.error = resultError;
+    parent.parentError = 0.0f;  // Set by next level
+    parent.parentIndex = UINT32_MAX;
+    parent.firstChildIndex = 0;
+    parent.childCount = 0;
+
+    // Compute bounding data from the simplified geometry
+    parent.boundingSphere = computeBoundingSphere(vertices, indices, parentFirstIndex, parentIndexCount);
+    computeAABB(vertices, indices, parentFirstIndex, parentIndexCount, parent.aabbMin, parent.aabbMax);
+    computeNormalCone(vertices, indices, parentFirstIndex, parentIndexCount, parent.coneAxis, parent.coneAngle);
+
+    return parent;
+}
+
+// ============================================================================
+// GPUClusterBuffer
+// ============================================================================
+
+std::unique_ptr<GPUClusterBuffer> GPUClusterBuffer::create(const InitInfo& info) {
+    auto buffer = std::make_unique<GPUClusterBuffer>(ConstructToken{});
+    if (!buffer->initInternal(info)) {
+        return nullptr;
+    }
+    return buffer;
+}
+
+bool GPUClusterBuffer::initInternal(const InitInfo& info) {
+    allocator_ = info.allocator;
+    device_ = info.device;
+    commandPool_ = info.commandPool;
+    queue_ = info.queue;
+    maxClusters_ = info.maxClusters;
+    maxVertices_ = info.maxVertices;
+    maxIndices_ = info.maxIndices;
+
+    // Create device-local buffers sized for max capacity
+    VkBufferCreateInfo bufInfo{};
+    bufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    // Vertex buffer
+    bufInfo.size = maxVertices_ * sizeof(Vertex);
+    bufInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+                    VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    if (!ManagedBuffer::create(allocator_, bufInfo, allocInfo, vertexBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "GPUClusterBuffer: Failed to create vertex buffer");
+        return false;
+    }
+
+    // Index buffer
+    bufInfo.size = maxIndices_ * sizeof(uint32_t);
+    bufInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
+                    VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    if (!ManagedBuffer::create(allocator_, bufInfo, allocInfo, indexBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "GPUClusterBuffer: Failed to create index buffer");
+        return false;
+    }
+
+    // Cluster metadata buffer
+    bufInfo.size = maxClusters_ * sizeof(MeshCluster);
+    bufInfo.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    if (!ManagedBuffer::create(allocator_, bufInfo, allocInfo, clusterBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "GPUClusterBuffer: Failed to create cluster buffer");
+        return false;
+    }
+
+    SDL_Log("GPUClusterBuffer: Created (maxClusters=%u, maxVertices=%u, maxIndices=%u)",
+            maxClusters_, maxVertices_, maxIndices_);
+    return true;
+}
+
+uint32_t GPUClusterBuffer::uploadMesh(const ClusteredMesh& mesh) {
+    if (totalClusters_ + mesh.totalClusters > maxClusters_ ||
+        totalVertices_ + mesh.vertices.size() > maxVertices_ ||
+        totalIndices_ + mesh.indices.size() > maxIndices_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "GPUClusterBuffer: Not enough space (clusters: %u+%u/%u, vertices: %u+%zu/%u, indices: %u+%zu/%u)",
+            totalClusters_, mesh.totalClusters, maxClusters_,
+            totalVertices_, mesh.vertices.size(), maxVertices_,
+            totalIndices_, mesh.indices.size(), maxIndices_);
+        return UINT32_MAX;
+    }
+
+    uint32_t baseCluster = totalClusters_;
+    uint32_t baseVertex = totalVertices_;
+    uint32_t baseIndex = totalIndices_;
+
+    // Create staging buffers and upload
+    VkDeviceSize vertexSize = mesh.vertices.size() * sizeof(Vertex);
+    VkDeviceSize indexSize = mesh.indices.size() * sizeof(uint32_t);
+    VkDeviceSize clusterSize = mesh.clusters.size() * sizeof(MeshCluster);
+
+    // Adjust cluster offsets for global buffer positioning
+    std::vector<MeshCluster> adjustedClusters = mesh.clusters;
+    for (auto& cluster : adjustedClusters) {
+        cluster.firstIndex += baseIndex;
+        cluster.firstVertex += static_cast<int32_t>(baseVertex);
+
+        // Adjust DAG connectivity indices to global cluster buffer positions
+        if (cluster.parentIndex != UINT32_MAX) {
+            cluster.parentIndex += baseCluster;
+        }
+        if (cluster.childCount > 0) {
+            cluster.firstChildIndex += baseCluster;
+        }
+    }
+
+    // Create staging buffer for all three uploads
+    VkDeviceSize totalStagingSize = vertexSize + indexSize + clusterSize;
+
+    VkBufferCreateInfo stagingBufInfo{};
+    stagingBufInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    stagingBufInfo.size = totalStagingSize;
+    stagingBufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+
+    VmaAllocationCreateInfo stagingAllocInfo{};
+    stagingAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    stagingAllocInfo.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                              VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    ManagedBuffer stagingBuffer;
+    if (!ManagedBuffer::create(allocator_, stagingBufInfo, stagingAllocInfo, stagingBuffer)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "GPUClusterBuffer: Failed to create staging buffer");
+        return UINT32_MAX;
+    }
+
+    // Map and copy data
+    void* mapped = stagingBuffer.map();
+    if (!mapped) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "GPUClusterBuffer: Failed to map staging buffer");
+        return UINT32_MAX;
+    }
+
+    auto* ptr = static_cast<uint8_t*>(mapped);
+    memcpy(ptr, mesh.vertices.data(), vertexSize);
+    ptr += vertexSize;
+    memcpy(ptr, mesh.indices.data(), indexSize);
+    ptr += indexSize;
+    memcpy(ptr, adjustedClusters.data(), clusterSize);
+
+    // Record copy commands
+    VkCommandBufferAllocateInfo cmdAllocInfo{};
+    cmdAllocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cmdAllocInfo.commandPool = commandPool_;
+    cmdAllocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmdAllocInfo.commandBufferCount = 1;
+
+    VkCommandBuffer cmd;
+    vkAllocateCommandBuffers(device_, &cmdAllocInfo, &cmd);
+
+    VkCommandBufferBeginInfo beginInfo{};
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &beginInfo);
+
+    VkDeviceSize stagingOffset = 0;
+
+    // Copy vertices
+    VkBufferCopy vertexCopy{};
+    vertexCopy.srcOffset = stagingOffset;
+    vertexCopy.dstOffset = baseVertex * sizeof(Vertex);
+    vertexCopy.size = vertexSize;
+    vkCmdCopyBuffer(cmd, stagingBuffer.get(), vertexBuffer_.get(), 1, &vertexCopy);
+    stagingOffset += vertexSize;
+
+    // Copy indices
+    VkBufferCopy indexCopy{};
+    indexCopy.srcOffset = stagingOffset;
+    indexCopy.dstOffset = baseIndex * sizeof(uint32_t);
+    indexCopy.size = indexSize;
+    vkCmdCopyBuffer(cmd, stagingBuffer.get(), indexBuffer_.get(), 1, &indexCopy);
+    stagingOffset += indexSize;
+
+    // Copy cluster metadata
+    VkBufferCopy clusterCopy{};
+    clusterCopy.srcOffset = stagingOffset;
+    clusterCopy.dstOffset = baseCluster * sizeof(MeshCluster);
+    clusterCopy.size = clusterSize;
+    vkCmdCopyBuffer(cmd, stagingBuffer.get(), clusterBuffer_.get(), 1, &clusterCopy);
+
+    vkEndCommandBuffer(cmd);
+
+    VkSubmitInfo submitInfo{};
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &cmd;
+
+    vkQueueSubmit(queue_, 1, &submitInfo, VK_NULL_HANDLE);
+    vkQueueWaitIdle(queue_);
+
+    vkFreeCommandBuffers(device_, commandPool_, 1, &cmd);
+
+    // Update totals
+    totalClusters_ += mesh.totalClusters;
+    totalVertices_ += static_cast<uint32_t>(mesh.vertices.size());
+    totalIndices_ += static_cast<uint32_t>(mesh.indices.size());
+
+    SDL_Log("GPUClusterBuffer: Uploaded mesh (%u clusters, %zu vertices, %zu indices)",
+            mesh.totalClusters, mesh.vertices.size(), mesh.indices.size());
+
+    return baseCluster;
+}

--- a/src/visibility/MeshClusterBuilder.h
+++ b/src/visibility/MeshClusterBuilder.h
@@ -1,0 +1,227 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <glm/glm.hpp>
+#include <cstdint>
+#include <vector>
+#include <memory>
+#include <functional>
+
+#include "Mesh.h"
+#include "VmaBuffer.h"
+
+/**
+ * MeshCluster - A contiguous group of triangles from a mesh
+ *
+ * Each cluster contains 64-128 triangles with local bounding data
+ * for efficient GPU culling at the cluster granularity.
+ *
+ * The cluster stores indices into the global vertex/index buffers.
+ */
+struct MeshCluster {
+    // Bounding data for culling
+    glm::vec4 boundingSphere;   // xyz = center, w = radius (object space)
+    glm::vec3 aabbMin;          // Object-space AABB min
+    float _pad0;
+    glm::vec3 aabbMax;          // Object-space AABB max
+    float _pad1;
+
+    // Cone data for backface cluster culling (Nanite-style)
+    glm::vec3 coneAxis;         // Averaged normal direction
+    float coneAngle;            // Half-angle of normal cone (cos)
+
+    // Index range in the global index buffer
+    uint32_t firstIndex;        // Offset into global index buffer
+    uint32_t indexCount;         // Number of indices (triangles * 3)
+    uint32_t firstVertex;       // Base vertex offset
+    uint32_t meshId;            // Which mesh this cluster belongs to
+
+    // LOD information
+    float parentError;          // Object-space error of parent cluster
+    float error;                // Object-space error of this cluster
+    uint32_t lodLevel;          // LOD level (0 = highest detail)
+    uint32_t parentIndex;       // Index of parent in cluster array (UINT32_MAX for root)
+
+    // DAG connectivity
+    uint32_t firstChildIndex;   // Index of first child in cluster array
+    uint32_t childCount;        // Number of children (0 = leaf)
+    uint32_t _pad2;
+    uint32_t _pad3;
+};
+
+/**
+ * ClusteredMesh - Result of clustering a single mesh
+ *
+ * Contains the clusters and their associated vertex/index data
+ * ready for upload to the GPU.
+ */
+struct ClusteredMesh {
+    std::vector<MeshCluster> clusters;
+
+    // Vertex and index data (may be reordered for cluster locality)
+    std::vector<Vertex> vertices;
+    std::vector<uint32_t> indices;
+
+    // Per-cluster groups for LOD hierarchy
+    uint32_t totalTriangles = 0;
+    uint32_t totalClusters = 0;
+
+    // DAG metadata
+    uint32_t leafClusterCount = 0;  // Number of LOD 0 clusters
+    uint32_t dagLevels = 0;         // Total hierarchy depth
+    uint32_t rootClusterIndex = 0;  // Index of the root cluster (coarsest LOD)
+};
+
+/**
+ * MeshClusterBuilder - Splits meshes into GPU-friendly clusters
+ *
+ * Takes an arbitrary triangle mesh and produces:
+ * - 64-128 triangle clusters with bounding data
+ * - Spatially coherent triangle ordering within clusters
+ * - Normal cones for backface cluster culling
+ *
+ * This is a CPU preprocessing step done once per mesh.
+ *
+ * Usage:
+ *   MeshClusterBuilder builder;
+ *   builder.setTargetClusterSize(64);
+ *   auto result = builder.build(mesh.getVertices(), mesh.getIndices());
+ */
+class MeshClusterBuilder {
+public:
+    static constexpr uint32_t DEFAULT_CLUSTER_SIZE = 64;  // triangles per cluster
+    static constexpr uint32_t MIN_CLUSTER_SIZE = 32;
+    static constexpr uint32_t MAX_CLUSTER_SIZE = 128;
+
+    void setTargetClusterSize(uint32_t trianglesPerCluster);
+
+    /**
+     * Build clusters from mesh vertex/index data.
+     * @param vertices Mesh vertices
+     * @param indices  Mesh indices (triangle list)
+     * @param meshId   ID to tag clusters with
+     * @return ClusteredMesh with cluster data
+     */
+    ClusteredMesh build(const std::vector<Vertex>& vertices,
+                        const std::vector<uint32_t>& indices,
+                        uint32_t meshId = 0);
+
+    /**
+     * Build clusters AND a DAG hierarchy for LOD selection.
+     * First builds leaf clusters, then iteratively groups and simplifies
+     * them into coarser parent clusters using meshoptimizer.
+     *
+     * @param vertices Mesh vertices
+     * @param indices  Mesh indices (triangle list)
+     * @param meshId   ID to tag clusters with
+     * @return ClusteredMesh with full DAG hierarchy
+     */
+    ClusteredMesh buildWithDAG(const std::vector<Vertex>& vertices,
+                               const std::vector<uint32_t>& indices,
+                               uint32_t meshId = 0);
+
+private:
+    // Compute bounding sphere from a set of points
+    static glm::vec4 computeBoundingSphere(const std::vector<Vertex>& vertices,
+                                            const std::vector<uint32_t>& indices,
+                                            uint32_t firstIndex, uint32_t indexCount);
+
+    // Compute AABB from a set of triangles
+    static void computeAABB(const std::vector<Vertex>& vertices,
+                             const std::vector<uint32_t>& indices,
+                             uint32_t firstIndex, uint32_t indexCount,
+                             glm::vec3& outMin, glm::vec3& outMax);
+
+    // Compute normal cone for backface cluster culling
+    static void computeNormalCone(const std::vector<Vertex>& vertices,
+                                   const std::vector<uint32_t>& indices,
+                                   uint32_t firstIndex, uint32_t indexCount,
+                                   glm::vec3& outAxis, float& outAngle);
+
+    // Group clusters spatially for DAG level building.
+    // Returns groups of cluster indices (2-4 per group).
+    static std::vector<std::vector<uint32_t>> groupClustersSpatially(
+        const std::vector<MeshCluster>& clusters,
+        const std::vector<uint32_t>& clusterIndices);
+
+    // Merge a group of clusters' geometry and simplify into a single parent cluster.
+    // Appends new vertices/indices to the mesh and returns the parent cluster.
+    static MeshCluster simplifyClusterGroup(
+        const std::vector<uint32_t>& groupIndices,
+        const std::vector<MeshCluster>& clusters,
+        std::vector<Vertex>& vertices,
+        std::vector<uint32_t>& indices,
+        uint32_t meshId,
+        uint32_t lodLevel,
+        uint32_t targetTriangles,
+        float& outError);
+
+    uint32_t targetClusterSize_ = DEFAULT_CLUSTER_SIZE;
+};
+
+/**
+ * GPUClusterBuffer - Manages GPU-side cluster data
+ *
+ * Holds the global vertex buffer, index buffer, and cluster metadata buffer
+ * for all clustered meshes in the scene.
+ */
+class GPUClusterBuffer {
+public:
+    struct ConstructToken { explicit ConstructToken() = default; };
+    explicit GPUClusterBuffer(ConstructToken) {}
+
+    struct InitInfo {
+        VmaAllocator allocator;
+        VkDevice device;
+        VkCommandPool commandPool;
+        VkQueue queue;
+        uint32_t maxClusters;       // Max total clusters across all meshes
+        uint32_t maxVertices;       // Max total vertices
+        uint32_t maxIndices;        // Max total indices
+    };
+
+    static std::unique_ptr<GPUClusterBuffer> create(const InitInfo& info);
+
+    ~GPUClusterBuffer() = default;
+
+    // Non-copyable, non-movable
+    GPUClusterBuffer(const GPUClusterBuffer&) = delete;
+    GPUClusterBuffer& operator=(const GPUClusterBuffer&) = delete;
+
+    /**
+     * Upload a clustered mesh to the GPU buffers.
+     * Returns the base cluster index for this mesh.
+     * Returns UINT32_MAX on failure.
+     */
+    uint32_t uploadMesh(const ClusteredMesh& mesh);
+
+    // Buffer accessors for binding
+    VkBuffer getVertexBuffer() const { return vertexBuffer_.get(); }
+    VkBuffer getIndexBuffer() const { return indexBuffer_.get(); }
+    VkBuffer getClusterBuffer() const { return clusterBuffer_.get(); }
+
+    uint32_t getTotalClusters() const { return totalClusters_; }
+    uint32_t getTotalVertices() const { return totalVertices_; }
+    uint32_t getTotalIndices() const { return totalIndices_; }
+
+private:
+    bool initInternal(const InitInfo& info);
+
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    VkDevice device_ = VK_NULL_HANDLE;
+    VkCommandPool commandPool_ = VK_NULL_HANDLE;
+    VkQueue queue_ = VK_NULL_HANDLE;
+
+    // Global buffers
+    ManagedBuffer vertexBuffer_;    // All vertices from all clustered meshes
+    ManagedBuffer indexBuffer_;     // All indices
+    ManagedBuffer clusterBuffer_;   // MeshCluster array (SSBO)
+
+    uint32_t maxClusters_ = 0;
+    uint32_t maxVertices_ = 0;
+    uint32_t maxIndices_ = 0;
+    uint32_t totalClusters_ = 0;
+    uint32_t totalVertices_ = 0;
+    uint32_t totalIndices_ = 0;
+};

--- a/src/visibility/TwoPassCuller.cpp
+++ b/src/visibility/TwoPassCuller.cpp
@@ -1,0 +1,905 @@
+#include "TwoPassCuller.h"
+#include "ShaderLoader.h"
+#include "ImageBuilder.h"
+#include "shaders/bindings.h"
+
+#include <SDL3/SDL_log.h>
+#include <cstring>
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+std::unique_ptr<TwoPassCuller> TwoPassCuller::create(const InitInfo& info) {
+    auto culler = std::make_unique<TwoPassCuller>(ConstructToken{});
+    if (!culler->initInternal(info)) {
+        return nullptr;
+    }
+    return culler;
+}
+
+std::unique_ptr<TwoPassCuller> TwoPassCuller::create(const InitContext& ctx,
+                                                       uint32_t maxClusters,
+                                                       uint32_t maxDrawCommands) {
+    InitInfo info{};
+    info.device = ctx.device;
+    info.allocator = ctx.allocator;
+    info.descriptorPool = ctx.descriptorPool;
+    info.shaderPath = ctx.shaderPath;
+    info.framesInFlight = ctx.framesInFlight;
+    info.maxClusters = maxClusters;
+    info.maxDrawCommands = maxDrawCommands;
+    info.raiiDevice = ctx.raiiDevice;
+    return create(info);
+}
+
+TwoPassCuller::~TwoPassCuller() {
+    cleanup();
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+bool TwoPassCuller::initInternal(const InitInfo& info) {
+    device_ = info.device;
+    allocator_ = info.allocator;
+    descriptorPool_ = info.descriptorPool;
+    shaderPath_ = info.shaderPath;
+    framesInFlight_ = info.framesInFlight;
+    maxClusters_ = info.maxClusters;
+    maxDrawCommands_ = info.maxDrawCommands;
+    maxDAGLevels_ = info.maxDAGLevels;
+    hasDrawIndirectCount_ = info.hasDrawIndirectCount;
+    raiiDevice_ = info.raiiDevice;
+
+    if (!createBuffers()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create buffers");
+        return false;
+    }
+
+    if (!createPipeline()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create pipeline");
+        return false;
+    }
+
+    if (!createLODSelectPipeline()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create LOD selection pipeline");
+        return false;
+    }
+
+    SDL_Log("TwoPassCuller: Initialized (maxClusters=%u, maxDrawCommands=%u, maxDAGLevels=%u)",
+            maxClusters_, maxDrawCommands_, maxDAGLevels_);
+    return true;
+}
+
+void TwoPassCuller::cleanup() {
+    if (device_ == VK_NULL_HANDLE) return;
+    vkDeviceWaitIdle(device_);
+    destroyDescriptorSets();
+    destroyLODSelectPipeline();
+    destroyPipeline();
+    destroyBuffers();
+}
+
+// ============================================================================
+// Buffers
+// ============================================================================
+
+bool TwoPassCuller::createBuffers() {
+    VkDeviceSize indirectSize = maxDrawCommands_ * sizeof(VkDrawIndexedIndirectCommand);
+    VkDeviceSize countSize = sizeof(uint32_t);
+    VkDeviceSize visibleSize = maxClusters_ * sizeof(uint32_t);
+    VkDeviceSize uniformSize = sizeof(ClusterCullUniforms);
+
+    auto builder = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator_)
+        .setFrameCount(framesInFlight_);
+
+    // Indirect command buffers (GPU-written, GPU-read for vkCmdDrawIndexedIndirectCount)
+    bool ok = builder
+        .setSize(indirectSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
+        .setAllocationFlags(0)
+        .setMemoryUsage(VMA_MEMORY_USAGE_GPU_ONLY)
+        .build(pass1IndirectBuffers_);
+    if (!ok) return false;
+
+    ok = builder.build(pass2IndirectBuffers_);
+    if (!ok) return false;
+
+    // Per-draw data buffers (parallel to indirect commands, read by raster shader via gl_DrawID)
+    // Each entry: { uint instanceId, uint triangleOffset } = 8 bytes
+    VkDeviceSize drawDataSize = maxDrawCommands_ * 2 * sizeof(uint32_t);
+    ok = builder
+        .setSize(drawDataSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
+        .build(pass1DrawDataBuffers_);
+    if (!ok) return false;
+
+    ok = builder.build(pass2DrawDataBuffers_);
+    if (!ok) return false;
+
+    // Draw count buffers (atomic counter, GPU-written)
+    ok = builder
+        .setSize(countSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
+                  VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .build(pass1DrawCountBuffers_);
+    if (!ok) return false;
+
+    ok = builder.build(pass2DrawCountBuffers_);
+    if (!ok) return false;
+
+    // Visible cluster ID buffers
+    ok = builder
+        .setSize(visibleSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
+        .build(visibleClusterBuffers_);
+    if (!ok) return false;
+
+    ok = builder.build(prevVisibleClusterBuffers_);
+    if (!ok) return false;
+
+    // Visible count buffers
+    ok = builder
+        .setSize(countSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .build(visibleCountBuffers_);
+    if (!ok) return false;
+
+    ok = builder.build(prevVisibleCountBuffers_);
+    if (!ok) return false;
+
+    // Uniform buffers (CPU-written each frame)
+    ok = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator_)
+        .setFrameCount(framesInFlight_)
+        .setSize(uniformSize)
+        .setUsage(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+        .setAllocationFlags(VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                           VMA_ALLOCATION_CREATE_MAPPED_BIT)
+        .build(uniformBuffers_);
+    if (!ok) return false;
+
+    // LOD selection buffers
+    ok = builder
+        .setSize(visibleSize)  // same capacity as visible cluster buffers
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
+        .setAllocationFlags(0)
+        .setMemoryUsage(VMA_MEMORY_USAGE_GPU_ONLY)
+        .build(selectedClusterBuffers_);
+    if (!ok) return false;
+
+    ok = builder
+        .setSize(countSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .build(selectedCountBuffers_);
+    if (!ok) return false;
+
+    VkDeviceSize lodSelectUniformSize = sizeof(ClusterSelectUniforms);
+    ok = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator_)
+        .setFrameCount(framesInFlight_)
+        .setSize(lodSelectUniformSize)
+        .setUsage(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+        .setAllocationFlags(VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                           VMA_ALLOCATION_CREATE_MAPPED_BIT)
+        .build(lodSelectUniformBuffers_);
+    if (!ok) return false;
+
+    // Top-down DAG traversal: ping-pong node buffers
+    // Each buffer holds cluster indices for one level of the DAG
+    ok = builder
+        .setSize(visibleSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .setAllocationFlags(0)
+        .setMemoryUsage(VMA_MEMORY_USAGE_GPU_ONLY)
+        .build(nodeBufferA_);
+    if (!ok) return false;
+
+    ok = builder.build(nodeBufferB_);
+    if (!ok) return false;
+
+    // Node count buffers (atomic counters for each ping-pong side)
+    ok = builder
+        .setSize(countSize)
+        .setUsage(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT)
+        .build(nodeCountA_);
+    if (!ok) return false;
+
+    ok = builder.build(nodeCountB_);
+    if (!ok) return false;
+
+    return true;
+}
+
+void TwoPassCuller::destroyBuffers() {
+    BufferUtils::destroyBuffers(allocator_, pass1IndirectBuffers_);
+    BufferUtils::destroyBuffers(allocator_, pass1DrawCountBuffers_);
+    BufferUtils::destroyBuffers(allocator_, pass1DrawDataBuffers_);
+    BufferUtils::destroyBuffers(allocator_, pass2IndirectBuffers_);
+    BufferUtils::destroyBuffers(allocator_, pass2DrawCountBuffers_);
+    BufferUtils::destroyBuffers(allocator_, pass2DrawDataBuffers_);
+    BufferUtils::destroyBuffers(allocator_, visibleClusterBuffers_);
+    BufferUtils::destroyBuffers(allocator_, visibleCountBuffers_);
+    BufferUtils::destroyBuffers(allocator_, prevVisibleClusterBuffers_);
+    BufferUtils::destroyBuffers(allocator_, prevVisibleCountBuffers_);
+    BufferUtils::destroyBuffers(allocator_, uniformBuffers_);
+    BufferUtils::destroyBuffers(allocator_, selectedClusterBuffers_);
+    BufferUtils::destroyBuffers(allocator_, selectedCountBuffers_);
+    BufferUtils::destroyBuffers(allocator_, lodSelectUniformBuffers_);
+    BufferUtils::destroyBuffers(allocator_, nodeBufferA_);
+    BufferUtils::destroyBuffers(allocator_, nodeBufferB_);
+    BufferUtils::destroyBuffers(allocator_, nodeCountA_);
+    BufferUtils::destroyBuffers(allocator_, nodeCountB_);
+}
+
+// ============================================================================
+// Pipeline
+// ============================================================================
+
+bool TwoPassCuller::createPipeline() {
+    if (!raiiDevice_) return false;
+
+    // Descriptor set layout matching cluster_cull.comp bindings (0-10)
+    std::array<vk::DescriptorSetLayoutBinding, 11> bindings;
+    bindings[0] = vk::DescriptorSetLayoutBinding{}.setBinding(0)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // clusters
+    bindings[1] = vk::DescriptorSetLayoutBinding{}.setBinding(1)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // instances
+    bindings[2] = vk::DescriptorSetLayoutBinding{}.setBinding(2)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // indirect commands
+    bindings[3] = vk::DescriptorSetLayoutBinding{}.setBinding(3)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // draw count
+    bindings[4] = vk::DescriptorSetLayoutBinding{}.setBinding(4)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // visible clusters
+    bindings[5] = vk::DescriptorSetLayoutBinding{}.setBinding(5)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // visible count
+    bindings[6] = vk::DescriptorSetLayoutBinding{}.setBinding(6)
+        .setDescriptorType(vk::DescriptorType::eUniformBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // cull uniforms
+    bindings[7] = vk::DescriptorSetLayoutBinding{}.setBinding(7)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // Hi-Z pyramid
+    bindings[8] = vk::DescriptorSetLayoutBinding{}.setBinding(8)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // prev visible clusters
+    bindings[9] = vk::DescriptorSetLayoutBinding{}.setBinding(9)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // prev visible count
+    bindings[10] = vk::DescriptorSetLayoutBinding{}.setBinding(BINDING_CLUSTER_CULL_DRAW_DATA)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // per-draw data output
+
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(bindings);
+
+    try {
+        descSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create desc set layout: %s", e.what());
+        return false;
+    }
+
+    vk::DescriptorSetLayout vkDescLayout(**descSetLayout_);
+
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}.setSetLayouts(vkDescLayout);
+
+    vk::Device vkDevice(device_);
+    pipelineLayout_ = static_cast<VkPipelineLayout>(vkDevice.createPipelineLayout(pipelineLayoutInfo));
+
+    // Load compute shader
+    auto compModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/cluster_cull.comp.spv");
+    if (!compModule) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to load cluster_cull.comp shader");
+        return false;
+    }
+
+    auto stageInfo = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eCompute)
+        .setModule(*compModule)
+        .setPName("main");
+
+    auto computeInfo = vk::ComputePipelineCreateInfo{}
+        .setStage(stageInfo)
+        .setLayout(pipelineLayout_);
+
+    auto result = vkDevice.createComputePipeline(nullptr, computeInfo);
+    if (result.result != vk::Result::eSuccess) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create compute pipeline");
+        vkDevice.destroyShaderModule(*compModule);
+        return false;
+    }
+    pipeline_ = static_cast<VkPipeline>(result.value);
+
+    vkDevice.destroyShaderModule(*compModule);
+
+    SDL_Log("TwoPassCuller: Compute pipeline created");
+    return true;
+}
+
+void TwoPassCuller::destroyPipeline() {
+    if (pipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, pipeline_, nullptr);
+        pipeline_ = VK_NULL_HANDLE;
+    }
+    if (pipelineLayout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device_, pipelineLayout_, nullptr);
+        pipelineLayout_ = VK_NULL_HANDLE;
+    }
+    descSetLayout_.reset();
+}
+
+bool TwoPassCuller::createLODSelectPipeline() {
+    if (!raiiDevice_) return false;
+
+    // Descriptor set layout matching cluster_select.comp bindings (0-8)
+    std::array<vk::DescriptorSetLayoutBinding, 9> bindings;
+    bindings[0] = vk::DescriptorSetLayoutBinding{}.setBinding(0)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // clusters
+    bindings[1] = vk::DescriptorSetLayoutBinding{}.setBinding(1)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // instances
+    bindings[2] = vk::DescriptorSetLayoutBinding{}.setBinding(2)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // selected clusters output
+    bindings[3] = vk::DescriptorSetLayoutBinding{}.setBinding(3)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // selected count
+    bindings[4] = vk::DescriptorSetLayoutBinding{}.setBinding(4)
+        .setDescriptorType(vk::DescriptorType::eUniformBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // select uniforms
+    bindings[5] = vk::DescriptorSetLayoutBinding{}.setBinding(5)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // input nodes
+    bindings[6] = vk::DescriptorSetLayoutBinding{}.setBinding(6)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // input node count
+    bindings[7] = vk::DescriptorSetLayoutBinding{}.setBinding(7)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // output nodes
+    bindings[8] = vk::DescriptorSetLayoutBinding{}.setBinding(8)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer).setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);  // output node count
+
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(bindings);
+
+    try {
+        lodSelectDescSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create LOD select desc set layout: %s", e.what());
+        return false;
+    }
+
+    vk::DescriptorSetLayout vkDescLayout(**lodSelectDescSetLayout_);
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}.setSetLayouts(vkDescLayout);
+
+    vk::Device vkDevice(device_);
+    lodSelectPipelineLayout_ = static_cast<VkPipelineLayout>(vkDevice.createPipelineLayout(pipelineLayoutInfo));
+
+    // Load compute shader
+    auto compModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/cluster_select.comp.spv");
+    if (!compModule) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to load cluster_select.comp shader");
+        return false;
+    }
+
+    auto stageInfo = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eCompute)
+        .setModule(*compModule)
+        .setPName("main");
+
+    auto computeInfo = vk::ComputePipelineCreateInfo{}
+        .setStage(stageInfo)
+        .setLayout(lodSelectPipelineLayout_);
+
+    auto result = vkDevice.createComputePipeline(nullptr, computeInfo);
+    if (result.result != vk::Result::eSuccess) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create LOD select compute pipeline");
+        vkDevice.destroyShaderModule(*compModule);
+        return false;
+    }
+    lodSelectPipeline_ = static_cast<VkPipeline>(result.value);
+
+    vkDevice.destroyShaderModule(*compModule);
+
+    SDL_Log("TwoPassCuller: LOD selection compute pipeline created");
+    return true;
+}
+
+void TwoPassCuller::destroyLODSelectPipeline() {
+    if (lodSelectPipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, lodSelectPipeline_, nullptr);
+        lodSelectPipeline_ = VK_NULL_HANDLE;
+    }
+    if (lodSelectPipelineLayout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device_, lodSelectPipelineLayout_, nullptr);
+        lodSelectPipelineLayout_ = VK_NULL_HANDLE;
+    }
+    lodSelectDescSetLayout_.reset();
+}
+
+void TwoPassCuller::setRootClusters(const std::vector<uint32_t>& rootIndices) {
+    rootClusterIndices_ = rootIndices;
+    SDL_Log("TwoPassCuller: Set %zu root clusters for DAG traversal",
+            rootClusterIndices_.size());
+}
+
+void TwoPassCuller::recordLODSelection(VkCommandBuffer cmd, uint32_t frameIndex,
+                                         uint32_t totalDAGClusters, uint32_t instanceCount) {
+    // Update LOD selection uniforms
+    ClusterSelectUniforms selectUniforms{};
+
+    // Reuse the viewProjMatrix from the cull uniforms (already written this frame)
+    void* cullMapped = uniformBuffers_.mappedPointers[frameIndex];
+    if (cullMapped) {
+        auto* cullUbo = static_cast<const ClusterCullUniforms*>(cullMapped);
+        selectUniforms.viewProjMatrix = cullUbo->viewProjMatrix;
+        selectUniforms.screenParams = cullUbo->screenParams;
+    }
+
+    selectUniforms.totalClusterCount = totalDAGClusters;
+    selectUniforms.instanceCount = instanceCount;
+    selectUniforms.errorThreshold = errorThreshold_;
+    selectUniforms.maxSelectedClusters = maxClusters_;
+
+    void* mapped = lodSelectUniformBuffers_.mappedPointers[frameIndex];
+    if (mapped) {
+        memcpy(mapped, &selectUniforms, sizeof(selectUniforms));
+        vmaFlushAllocation(allocator_, lodSelectUniformBuffers_.allocations[frameIndex],
+                           0, sizeof(selectUniforms));
+    }
+
+    // Clear selected count to 0 (accumulated across all passes)
+    vkCmdFillBuffer(cmd, selectedCountBuffers_.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+
+    // Seed input buffer A with root cluster indices
+    if (!rootClusterIndices_.empty()) {
+        VkDeviceSize seedSize = rootClusterIndices_.size() * sizeof(uint32_t);
+        vkCmdUpdateBuffer(cmd, nodeBufferA_.buffers[frameIndex], 0,
+                          seedSize, rootClusterIndices_.data());
+
+        // Write root count to nodeCountA
+        uint32_t rootCount = static_cast<uint32_t>(rootClusterIndices_.size());
+        vkCmdUpdateBuffer(cmd, nodeCountA_.buffers[frameIndex], 0,
+                          sizeof(uint32_t), &rootCount);
+    } else {
+        // No roots — write 0 count
+        vkCmdFillBuffer(cmd, nodeCountA_.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+    }
+
+    // Barrier: transfer writes -> compute reads
+    VkMemoryBarrier memBarrier{};
+    memBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    memBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+    // Bind LOD selection pipeline
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, lodSelectPipeline_);
+
+    // Multi-pass top-down traversal: one dispatch per DAG level
+    // Each pass reads from the input buffer and writes children to the output buffer.
+    // Selected clusters are accumulated into selectedClusterBuffers_ across all passes.
+    //
+    // We dispatch ceil(maxClusters/64) workgroups each pass. Threads beyond
+    // the actual node count early-exit via the inputNodeCount SSBO check.
+    uint32_t workGroupSize = 64;
+    uint32_t maxDispatch = (maxClusters_ + workGroupSize - 1) / workGroupSize;
+
+    // Ping-pong: even levels read A/write B, odd levels read B/write A
+    auto* inputBuffers = &nodeBufferA_;
+    auto* inputCountBuffers = &nodeCountA_;
+    auto* outputBuffers = &nodeBufferB_;
+    auto* outputCountBuffers = &nodeCountB_;
+
+    for (uint32_t level = 0; level < maxDAGLevels_; ++level) {
+        // Clear output node count for this pass
+        vkCmdFillBuffer(cmd, outputCountBuffers->buffers[frameIndex], 0, sizeof(uint32_t), 0);
+
+        // Barrier: clear -> compute
+        memBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+        // Descriptor sets would be bound here for (input, output) pair
+        // Bindings 5-8 change each pass for the ping-pong:
+        //   5 = inputBuffers, 6 = inputCountBuffers,
+        //   7 = outputBuffers, 8 = outputCountBuffers
+
+        // Dispatch
+        vkCmdDispatch(cmd, maxDispatch, 1, 1);
+
+        // Barrier: compute writes -> next pass compute reads + transfer (for clear)
+        memBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+            0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+        // Swap ping-pong: output becomes input for next level
+        std::swap(inputBuffers, outputBuffers);
+        std::swap(inputCountBuffers, outputCountBuffers);
+    }
+
+    // Final barrier: compute write -> compute read (selected clusters -> cull pass)
+    memBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+}
+
+VkBuffer TwoPassCuller::getSelectedClusterBuffer(uint32_t frameIndex) const {
+    return selectedClusterBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getSelectedCountBuffer(uint32_t frameIndex) const {
+    return selectedCountBuffers_.buffers[frameIndex];
+}
+
+void TwoPassCuller::setExternalBuffers(VkBuffer clusterBuffer, VkDeviceSize clusterSize,
+                                        const std::vector<VkBuffer>& instanceBuffers,
+                                        VkDeviceSize instanceSize) {
+    externalClusterBuffer_ = clusterBuffer;
+    externalClusterSize_ = clusterSize;
+    externalInstanceBuffers_ = instanceBuffers;
+    externalInstanceSize_ = instanceSize;
+
+    // (Re)create descriptor sets now that we have all buffers
+    destroyDescriptorSets();
+    createDescriptorSets();
+}
+
+bool TwoPassCuller::createDescriptorSets() {
+    if (!descSetLayout_ || externalClusterBuffer_ == VK_NULL_HANDLE ||
+        externalInstanceBuffers_.empty()) {
+        return true;  // Not ready yet — will be called from setExternalBuffers
+    }
+
+    VkDescriptorSetLayout rawLayout = **descSetLayout_;
+    VkDeviceSize drawDataSize = maxDrawCommands_ * 2 * sizeof(uint32_t);
+
+    // Allocate pass 1 and pass 2 descriptor sets (one per frame)
+    pass1DescSets_ = descriptorPool_->allocate(rawLayout, framesInFlight_);
+    pass2DescSets_ = descriptorPool_->allocate(rawLayout, framesInFlight_);
+
+    if (pass1DescSets_.size() != framesInFlight_ || pass2DescSets_.size() != framesInFlight_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to allocate cull descriptor sets");
+        return false;
+    }
+
+    // Create Hi-Z sampler (nearest, clamp) for pass 2
+    if (!hiZSampler_) {
+        auto samplerInfo = vk::SamplerCreateInfo{}
+            .setMagFilter(vk::Filter::eNearest)
+            .setMinFilter(vk::Filter::eNearest)
+            .setMipmapMode(vk::SamplerMipmapMode::eNearest)
+            .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+            .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+            .setMaxLod(16.0f);
+        hiZSampler_.emplace(*raiiDevice_, samplerInfo);
+    }
+
+    // Create 1x1 placeholder for Hi-Z in pass 1 (not used but must be valid)
+    if (placeholderHiZView_ == VK_NULL_HANDLE) {
+        bool built = ImageBuilder(allocator_)
+            .setExtent(1, 1)
+            .setFormat(VK_FORMAT_R32_SFLOAT)
+            .setUsage(VK_IMAGE_USAGE_SAMPLED_BIT)
+            .setGpuOnly()
+            .build(device_, placeholderHiZImage_, placeholderHiZView_, VK_IMAGE_ASPECT_COLOR_BIT);
+        if (!built) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "TwoPassCuller: Failed to create placeholder Hi-Z image");
+        }
+    }
+
+    VkSampler rawHiZSampler = hiZSampler_ ? static_cast<VkSampler>(**hiZSampler_) : VK_NULL_HANDLE;
+
+    for (uint32_t i = 0; i < framesInFlight_; ++i) {
+        // Common buffer infos shared between pass 1 and pass 2
+        VkDescriptorBufferInfo clusterInfo{externalClusterBuffer_, 0, externalClusterSize_};
+        VkDescriptorBufferInfo instanceInfo{
+            (i < externalInstanceBuffers_.size()) ? externalInstanceBuffers_[i] : externalInstanceBuffers_[0],
+            0, externalInstanceSize_};
+        VkDescriptorBufferInfo uniformInfo{uniformBuffers_.buffers[i], 0, sizeof(ClusterCullUniforms)};
+        VkDescriptorBufferInfo prevVisClusterInfo{prevVisibleClusterBuffers_.buffers[i], 0, maxClusters_ * sizeof(uint32_t)};
+        VkDescriptorBufferInfo prevVisCountInfo{prevVisibleCountBuffers_.buffers[i], 0, sizeof(uint32_t)};
+
+        // Placeholder Hi-Z image for pass 1 (not used, enableHiZ=0)
+        VkDescriptorImageInfo hiZInfo{rawHiZSampler, placeholderHiZView_, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+
+        // Pass 1 descriptor set
+        {
+            VkDescriptorBufferInfo indirectInfo{pass1IndirectBuffers_.buffers[i], 0, maxDrawCommands_ * sizeof(VkDrawIndexedIndirectCommand)};
+            VkDescriptorBufferInfo drawCountInfo{pass1DrawCountBuffers_.buffers[i], 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo visClusterInfo{visibleClusterBuffers_.buffers[i], 0, maxClusters_ * sizeof(uint32_t)};
+            VkDescriptorBufferInfo visCountInfo{visibleCountBuffers_.buffers[i], 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo drawDataInfo{pass1DrawDataBuffers_.buffers[i], 0, drawDataSize};
+
+            std::array<VkWriteDescriptorSet, 11> writes{};
+            for (auto& w : writes) w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+
+            writes[0].dstSet = pass1DescSets_[i]; writes[0].dstBinding = 0;
+            writes[0].descriptorCount = 1; writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[0].pBufferInfo = &clusterInfo;
+
+            writes[1].dstSet = pass1DescSets_[i]; writes[1].dstBinding = 1;
+            writes[1].descriptorCount = 1; writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[1].pBufferInfo = &instanceInfo;
+
+            writes[2].dstSet = pass1DescSets_[i]; writes[2].dstBinding = 2;
+            writes[2].descriptorCount = 1; writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[2].pBufferInfo = &indirectInfo;
+
+            writes[3].dstSet = pass1DescSets_[i]; writes[3].dstBinding = 3;
+            writes[3].descriptorCount = 1; writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[3].pBufferInfo = &drawCountInfo;
+
+            writes[4].dstSet = pass1DescSets_[i]; writes[4].dstBinding = 4;
+            writes[4].descriptorCount = 1; writes[4].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[4].pBufferInfo = &visClusterInfo;
+
+            writes[5].dstSet = pass1DescSets_[i]; writes[5].dstBinding = 5;
+            writes[5].descriptorCount = 1; writes[5].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[5].pBufferInfo = &visCountInfo;
+
+            writes[6].dstSet = pass1DescSets_[i]; writes[6].dstBinding = 6;
+            writes[6].descriptorCount = 1; writes[6].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            writes[6].pBufferInfo = &uniformInfo;
+
+            writes[7].dstSet = pass1DescSets_[i]; writes[7].dstBinding = 7;
+            writes[7].descriptorCount = 1; writes[7].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[7].pImageInfo = &hiZInfo;
+
+            writes[8].dstSet = pass1DescSets_[i]; writes[8].dstBinding = 8;
+            writes[8].descriptorCount = 1; writes[8].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[8].pBufferInfo = &prevVisClusterInfo;
+
+            writes[9].dstSet = pass1DescSets_[i]; writes[9].dstBinding = 9;
+            writes[9].descriptorCount = 1; writes[9].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[9].pBufferInfo = &prevVisCountInfo;
+
+            writes[10].dstSet = pass1DescSets_[i]; writes[10].dstBinding = BINDING_CLUSTER_CULL_DRAW_DATA;
+            writes[10].descriptorCount = 1; writes[10].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[10].pBufferInfo = &drawDataInfo;
+
+            vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+        }
+
+        // Pass 2 descriptor set (same layout, different output buffers, Hi-Z enabled)
+        {
+            VkDescriptorBufferInfo indirectInfo{pass2IndirectBuffers_.buffers[i], 0, maxDrawCommands_ * sizeof(VkDrawIndexedIndirectCommand)};
+            VkDescriptorBufferInfo drawCountInfo{pass2DrawCountBuffers_.buffers[i], 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo visClusterInfo{visibleClusterBuffers_.buffers[i], 0, maxClusters_ * sizeof(uint32_t)};
+            VkDescriptorBufferInfo visCountInfo{visibleCountBuffers_.buffers[i], 0, sizeof(uint32_t)};
+            VkDescriptorBufferInfo drawDataInfo{pass2DrawDataBuffers_.buffers[i], 0, drawDataSize};
+
+            std::array<VkWriteDescriptorSet, 11> writes{};
+            for (auto& w : writes) w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+
+            writes[0].dstSet = pass2DescSets_[i]; writes[0].dstBinding = 0;
+            writes[0].descriptorCount = 1; writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[0].pBufferInfo = &clusterInfo;
+
+            writes[1].dstSet = pass2DescSets_[i]; writes[1].dstBinding = 1;
+            writes[1].descriptorCount = 1; writes[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[1].pBufferInfo = &instanceInfo;
+
+            writes[2].dstSet = pass2DescSets_[i]; writes[2].dstBinding = 2;
+            writes[2].descriptorCount = 1; writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[2].pBufferInfo = &indirectInfo;
+
+            writes[3].dstSet = pass2DescSets_[i]; writes[3].dstBinding = 3;
+            writes[3].descriptorCount = 1; writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[3].pBufferInfo = &drawCountInfo;
+
+            writes[4].dstSet = pass2DescSets_[i]; writes[4].dstBinding = 4;
+            writes[4].descriptorCount = 1; writes[4].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[4].pBufferInfo = &visClusterInfo;
+
+            writes[5].dstSet = pass2DescSets_[i]; writes[5].dstBinding = 5;
+            writes[5].descriptorCount = 1; writes[5].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[5].pBufferInfo = &visCountInfo;
+
+            writes[6].dstSet = pass2DescSets_[i]; writes[6].dstBinding = 6;
+            writes[6].descriptorCount = 1; writes[6].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            writes[6].pBufferInfo = &uniformInfo;
+
+            writes[7].dstSet = pass2DescSets_[i]; writes[7].dstBinding = 7;
+            writes[7].descriptorCount = 1; writes[7].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            writes[7].pImageInfo = &hiZInfo;  // Will be updated per-frame with real Hi-Z
+
+            writes[8].dstSet = pass2DescSets_[i]; writes[8].dstBinding = 8;
+            writes[8].descriptorCount = 1; writes[8].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[8].pBufferInfo = &prevVisClusterInfo;
+
+            writes[9].dstSet = pass2DescSets_[i]; writes[9].dstBinding = 9;
+            writes[9].descriptorCount = 1; writes[9].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[9].pBufferInfo = &prevVisCountInfo;
+
+            writes[10].dstSet = pass2DescSets_[i]; writes[10].dstBinding = BINDING_CLUSTER_CULL_DRAW_DATA;
+            writes[10].descriptorCount = 1; writes[10].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            writes[10].pBufferInfo = &drawDataInfo;
+
+            vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+        }
+    }
+
+    SDL_Log("TwoPassCuller: Descriptor sets created (%u frames)", framesInFlight_);
+    return true;
+}
+
+void TwoPassCuller::destroyDescriptorSets() {
+    pass1DescSets_.clear();
+    pass2DescSets_.clear();
+    lodSelectDescSetsAB_.clear();
+    lodSelectDescSetsBA_.clear();
+    if (placeholderHiZView_ != VK_NULL_HANDLE) {
+        vkDestroyImageView(device_, placeholderHiZView_, nullptr);
+        placeholderHiZView_ = VK_NULL_HANDLE;
+    }
+    placeholderHiZImage_.reset();
+    hiZSampler_.reset();
+}
+
+// ============================================================================
+// Per-frame operations
+// ============================================================================
+
+void TwoPassCuller::updateUniforms(uint32_t frameIndex,
+                                     const glm::mat4& view, const glm::mat4& proj,
+                                     const glm::vec3& cameraPos,
+                                     const glm::vec4 frustumPlanes[6],
+                                     uint32_t clusterCount, uint32_t instanceCount,
+                                     float nearPlane, float farPlane, uint32_t hiZMipLevels) {
+    ClusterCullUniforms uniforms{};
+    uniforms.viewMatrix = view;
+    uniforms.projMatrix = proj;
+    uniforms.viewProjMatrix = proj * view;
+    for (int i = 0; i < 6; ++i) {
+        uniforms.frustumPlanes[i] = frustumPlanes[i];
+    }
+    uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
+    uniforms.screenParams = glm::vec4(0.0f);  // Set by caller based on render target size
+    uniforms.depthParams = glm::vec4(nearPlane, farPlane, static_cast<float>(hiZMipLevels), 0.0f);
+    uniforms.clusterCount = clusterCount;
+    uniforms.instanceCount = instanceCount;
+    uniforms.enableHiZ = 0;  // Pass 1 doesn't use Hi-Z
+    uniforms.maxDrawCommands = maxDrawCommands_;
+
+    void* mapped = uniformBuffers_.mappedPointers[frameIndex];
+    if (mapped) {
+        memcpy(mapped, &uniforms, sizeof(uniforms));
+        vmaFlushAllocation(allocator_, uniformBuffers_.allocations[frameIndex],
+                           0, sizeof(uniforms));
+    }
+}
+
+void TwoPassCuller::recordPass1(VkCommandBuffer cmd, uint32_t frameIndex) {
+    // Clear draw count to 0 and indirect command buffer (unused slots have indexCount=0)
+    vkCmdFillBuffer(cmd, pass1DrawCountBuffers_.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+    vkCmdFillBuffer(cmd, visibleCountBuffers_.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+    VkDeviceSize indirectSize = maxDrawCommands_ * sizeof(VkDrawIndexedIndirectCommand);
+    vkCmdFillBuffer(cmd, pass1IndirectBuffers_.buffers[frameIndex], 0, indirectSize, 0);
+
+    // Barrier: transfer -> compute
+    VkMemoryBarrier memBarrier{};
+    memBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    memBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+    // Bind pipeline and descriptor sets
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_);
+
+    if (frameIndex < pass1DescSets_.size()) {
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+            pipelineLayout_, 0, 1, &pass1DescSets_[frameIndex], 0, nullptr);
+    }
+
+    uint32_t workGroupSize = 64;
+    uint32_t dispatchCount = (maxClusters_ + workGroupSize - 1) / workGroupSize;
+    vkCmdDispatch(cmd, dispatchCount, 1, 1);
+
+    // Barrier: compute write -> indirect read + vertex shader read
+    memBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+}
+
+void TwoPassCuller::recordPass2(VkCommandBuffer cmd, uint32_t frameIndex, VkImageView hiZView) {
+    (void)hiZView;  // TODO: update pass2 descriptor set binding 7 with real Hi-Z view
+
+    // Clear pass 2 draw count
+    vkCmdFillBuffer(cmd, pass2DrawCountBuffers_.buffers[frameIndex], 0, sizeof(uint32_t), 0);
+
+    VkMemoryBarrier memBarrier{};
+    memBarrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    memBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_);
+
+    if (frameIndex < pass2DescSets_.size()) {
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+            pipelineLayout_, 0, 1, &pass2DescSets_[frameIndex], 0, nullptr);
+    }
+
+    uint32_t workGroupSize = 64;
+    uint32_t dispatchCount = (maxClusters_ + workGroupSize - 1) / workGroupSize;
+    vkCmdDispatch(cmd, dispatchCount, 1, 1);
+
+    // Barrier: compute -> indirect draw + vertex shader read
+    memBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    memBarrier.dstAccessMask = VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+        0, 1, &memBarrier, 0, nullptr, 0, nullptr);
+}
+
+void TwoPassCuller::swapBuffers() {
+    currentBufferIndex_ = 1 - currentBufferIndex_;
+}
+
+VkBuffer TwoPassCuller::getPass1IndirectBuffer(uint32_t frameIndex) const {
+    return pass1IndirectBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getPass1DrawCountBuffer(uint32_t frameIndex) const {
+    return pass1DrawCountBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getPass2IndirectBuffer(uint32_t frameIndex) const {
+    return pass2IndirectBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getPass2DrawCountBuffer(uint32_t frameIndex) const {
+    return pass2DrawCountBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getPass1DrawDataBuffer(uint32_t frameIndex) const {
+    return pass1DrawDataBuffers_.buffers[frameIndex];
+}
+
+VkBuffer TwoPassCuller::getPass2DrawDataBuffer(uint32_t frameIndex) const {
+    return pass2DrawDataBuffers_.buffers[frameIndex];
+}
+
+VkDeviceSize TwoPassCuller::getDrawDataBufferSize() const {
+    return maxDrawCommands_ * 2 * sizeof(uint32_t);
+}

--- a/src/visibility/TwoPassCuller.h
+++ b/src/visibility/TwoPassCuller.h
@@ -1,0 +1,304 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
+#include <vk_mem_alloc.h>
+#include <glm/glm.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "InitContext.h"
+#include "DescriptorManager.h"
+#include "VmaBuffer.h"
+#include "VmaImage.h"
+#include "PerFrameBuffer.h"
+
+class GPUClusterBuffer;
+class HiZSystem;
+
+// Uniform data for the cluster culling compute shader
+struct alignas(16) ClusterCullUniforms {
+    glm::mat4 viewMatrix;
+    glm::mat4 projMatrix;
+    glm::mat4 viewProjMatrix;
+    glm::vec4 frustumPlanes[6];
+    glm::vec4 cameraPosition;
+    glm::vec4 screenParams;    // width, height, 1/width, 1/height
+    glm::vec4 depthParams;     // near, far, numMipLevels, unused
+    uint32_t clusterCount;
+    uint32_t instanceCount;
+    uint32_t enableHiZ;
+    uint32_t maxDrawCommands;
+    uint32_t passIndex;        // 0 = pass 1 (prev visible), 1 = pass 2 (remaining)
+    uint32_t _pad0, _pad1, _pad2;
+};
+
+// Uniform data for the cluster LOD selection compute shader
+struct alignas(16) ClusterSelectUniforms {
+    glm::mat4 viewProjMatrix;
+    glm::vec4 screenParams;     // width, height, 1/width, 1/height
+    uint32_t totalClusterCount; // total clusters in the DAG
+    uint32_t instanceCount;
+    float errorThreshold;       // max acceptable screen-space error in pixels
+    uint32_t maxSelectedClusters;
+};
+
+/**
+ * TwoPassCuller - Two-phase GPU occlusion culling for mesh clusters
+ *
+ * Implements the nanite-style two-pass approach:
+ *
+ * Pass 1 (early):
+ *   - Test clusters visible in the previous frame (high hit rate)
+ *   - Render these to produce an initial depth buffer
+ *   - Build Hi-Z pyramid from this depth
+ *
+ * Pass 2 (late):
+ *   - Test remaining clusters against the Hi-Z from pass 1
+ *   - Catches newly visible clusters (disocclusion)
+ *   - Results merged with pass 1 for final rendering
+ *
+ * The key insight: most clusters visible last frame are still visible,
+ * so pass 1 produces a good depth buffer for pass 2's occlusion tests.
+ *
+ * LOD Selection uses top-down DAG traversal:
+ *   - CPU seeds root cluster indices into the input buffer
+ *   - Multiple dispatches process one level per pass, ping-ponging
+ *     between input/output node buffers
+ *   - Only clusters whose parents exceed the error threshold are visited
+ *   - Selected clusters are accumulated across all passes
+ *
+ * Usage:
+ *   1. create()
+ *   2. setRootClusters() - set root cluster indices for DAG traversal
+ *   3. updateUniforms() - set camera, frustum
+ *   4. recordLODSelection() - top-down DAG traversal
+ *   5. recordPass1() - cull previous frame's visible clusters
+ *   6. [render pass 1 visible clusters]
+ *   7. [build Hi-Z from pass 1 depth]
+ *   8. recordPass2() - cull remaining clusters against Hi-Z
+ *   9. [render pass 2 visible clusters]
+ *   10. swapBuffers() - swap visible lists for next frame
+ */
+class TwoPassCuller {
+public:
+    struct ConstructToken { explicit ConstructToken() = default; };
+    explicit TwoPassCuller(ConstructToken) {}
+
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        DescriptorManager::Pool* descriptorPool;
+        std::string shaderPath;
+        uint32_t framesInFlight;
+        uint32_t maxClusters;      // Max clusters to cull per frame
+        uint32_t maxDrawCommands;   // Max indirect draw commands
+        uint32_t maxDAGLevels = 8;  // Max depth of DAG hierarchy
+        const vk::raii::Device* raiiDevice = nullptr;
+        bool hasDrawIndirectCount = false;  // vkCmdDrawIndexedIndirectCount support
+    };
+
+    static std::unique_ptr<TwoPassCuller> create(const InitInfo& info);
+    static std::unique_ptr<TwoPassCuller> create(const InitContext& ctx,
+                                                   uint32_t maxClusters,
+                                                   uint32_t maxDrawCommands);
+
+    ~TwoPassCuller();
+
+    // Non-copyable, non-movable
+    TwoPassCuller(const TwoPassCuller&) = delete;
+    TwoPassCuller& operator=(const TwoPassCuller&) = delete;
+
+    /**
+     * Set root cluster indices for DAG traversal.
+     * Call after uploading meshes. Each root is the coarsest LOD of a mesh.
+     * These seed the first pass of the top-down LOD selection.
+     */
+    void setRootClusters(const std::vector<uint32_t>& rootIndices);
+
+    /**
+     * Update culling uniforms for the current frame.
+     */
+    void updateUniforms(uint32_t frameIndex,
+                         const glm::mat4& view, const glm::mat4& proj,
+                         const glm::vec3& cameraPos,
+                         const glm::vec4 frustumPlanes[6],
+                         uint32_t clusterCount, uint32_t instanceCount,
+                         float nearPlane, float farPlane, uint32_t hiZMipLevels);
+
+    /**
+     * Set the LOD error threshold in pixels (default 1.0).
+     * Lower = more detail, higher = more aggressive LOD.
+     */
+    void setErrorThreshold(float pixelError) { errorThreshold_ = pixelError; }
+    float getErrorThreshold() const { return errorThreshold_; }
+
+    /**
+     * Record LOD selection via top-down DAG traversal.
+     *
+     * Dispatches cluster_select.comp once per DAG level, ping-ponging between
+     * node buffers. Only evaluates clusters whose parents exceeded the error
+     * threshold, avoiding wasted work on unreachable clusters.
+     *
+     * Must be called BEFORE recordPass1().
+     */
+    void recordLODSelection(VkCommandBuffer cmd, uint32_t frameIndex,
+                             uint32_t totalDAGClusters, uint32_t instanceCount);
+
+    /**
+     * Get the buffer of selected cluster indices (output of LOD selection).
+     * This is the input to the culling passes.
+     */
+    VkBuffer getSelectedClusterBuffer(uint32_t frameIndex) const;
+    VkBuffer getSelectedCountBuffer(uint32_t frameIndex) const;
+
+    /**
+     * Record pass 1: cull previous frame's visible clusters.
+     * After this, render the visible clusters and build Hi-Z.
+     */
+    void recordPass1(VkCommandBuffer cmd, uint32_t frameIndex);
+
+    /**
+     * Record pass 2: cull remaining clusters against Hi-Z.
+     * hiZView must be the Hi-Z pyramid built from pass 1.
+     */
+    void recordPass2(VkCommandBuffer cmd, uint32_t frameIndex, VkImageView hiZView);
+
+    /**
+     * Swap the visible cluster buffers (call at end of frame).
+     * Current frame's visible list becomes next frame's "previous" list.
+     */
+    void swapBuffers();
+
+    // Access indirect draw commands and counts
+    VkBuffer getPass1IndirectBuffer(uint32_t frameIndex) const;
+    VkBuffer getPass1DrawCountBuffer(uint32_t frameIndex) const;
+    VkBuffer getPass2IndirectBuffer(uint32_t frameIndex) const;
+    VkBuffer getPass2DrawCountBuffer(uint32_t frameIndex) const;
+
+    // Access per-draw data buffers (parallel to indirect commands, indexed by gl_DrawID)
+    VkBuffer getPass1DrawDataBuffer(uint32_t frameIndex) const;
+    VkBuffer getPass2DrawDataBuffer(uint32_t frameIndex) const;
+    VkDeviceSize getDrawDataBufferSize() const;
+
+    uint32_t getMaxDrawCommands() const { return maxDrawCommands_; }
+    bool supportsDrawIndirectCount() const { return hasDrawIndirectCount_; }
+
+    /**
+     * Set external buffer references needed by culling descriptor sets.
+     * Must be called before the first frame that uses the culler.
+     * clusterBuffer: GPUClusterBuffer::getClusterBuffer()
+     * instanceBuffers: per-frame instance buffers from GPUSceneBuffer
+     */
+    void setExternalBuffers(VkBuffer clusterBuffer, VkDeviceSize clusterSize,
+                            const std::vector<VkBuffer>& instanceBuffers,
+                            VkDeviceSize instanceSize);
+    bool hasDescriptorSets() const { return !pass1DescSets_.empty(); }
+
+    // Statistics
+    struct Stats {
+        uint32_t pass1Visible;
+        uint32_t pass2Visible;
+        uint32_t totalCulled;
+    };
+
+private:
+    bool initInternal(const InitInfo& info);
+    void cleanup();
+
+    bool createBuffers();
+    void destroyBuffers();
+
+    bool createPipeline();
+    void destroyPipeline();
+
+    bool createLODSelectPipeline();
+    void destroyLODSelectPipeline();
+
+    bool createDescriptorSets();
+    void destroyDescriptorSets();
+
+    VkDevice device_ = VK_NULL_HANDLE;
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool_ = nullptr;
+    std::string shaderPath_;
+    uint32_t framesInFlight_ = 0;
+    uint32_t maxClusters_ = 0;
+    uint32_t maxDrawCommands_ = 0;
+    uint32_t maxDAGLevels_ = 8;
+    bool hasDrawIndirectCount_ = false;
+    const vk::raii::Device* raiiDevice_ = nullptr;
+
+    // Compute pipeline (cluster_cull.comp)
+    std::optional<vk::raii::DescriptorSetLayout> descSetLayout_;
+    VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+    VkPipeline pipeline_ = VK_NULL_HANDLE;
+
+    // Per-frame buffers (double-buffered for pass 1 / pass 2)
+    // Indirect draw command buffers
+    BufferUtils::PerFrameBufferSet pass1IndirectBuffers_;
+    BufferUtils::PerFrameBufferSet pass1DrawCountBuffers_;
+    BufferUtils::PerFrameBufferSet pass2IndirectBuffers_;
+    BufferUtils::PerFrameBufferSet pass2DrawCountBuffers_;
+
+    // Per-draw data buffers (parallel to indirect commands, indexed by gl_DrawID in raster shader)
+    BufferUtils::PerFrameBufferSet pass1DrawDataBuffers_;
+    BufferUtils::PerFrameBufferSet pass2DrawDataBuffers_;
+
+    // Visible cluster tracking (double-buffered)
+    BufferUtils::PerFrameBufferSet visibleClusterBuffers_;     // Current frame output
+    BufferUtils::PerFrameBufferSet visibleCountBuffers_;       // Current frame count
+    BufferUtils::PerFrameBufferSet prevVisibleClusterBuffers_; // Previous frame (pass 1 input)
+    BufferUtils::PerFrameBufferSet prevVisibleCountBuffers_;   // Previous frame count
+
+    // Uniform buffers
+    BufferUtils::PerFrameBufferSet uniformBuffers_;
+
+    // Descriptor sets per frame
+    std::vector<VkDescriptorSet> pass1DescSets_;
+    std::vector<VkDescriptorSet> pass2DescSets_;
+
+    // LOD selection pipeline (cluster_select.comp)
+    std::optional<vk::raii::DescriptorSetLayout> lodSelectDescSetLayout_;
+    VkPipelineLayout lodSelectPipelineLayout_ = VK_NULL_HANDLE;
+    VkPipeline lodSelectPipeline_ = VK_NULL_HANDLE;
+
+    // LOD selection buffers
+    BufferUtils::PerFrameBufferSet selectedClusterBuffers_;   // Output: selected cluster indices
+    BufferUtils::PerFrameBufferSet selectedCountBuffers_;     // Output: selected cluster count
+    BufferUtils::PerFrameBufferSet lodSelectUniformBuffers_;  // Uniforms
+
+    // Top-down DAG traversal: ping-pong node buffers
+    // Buffer A and B alternate as input/output each level
+    BufferUtils::PerFrameBufferSet nodeBufferA_;     // Node indices (ping)
+    BufferUtils::PerFrameBufferSet nodeBufferB_;     // Node indices (pong)
+    BufferUtils::PerFrameBufferSet nodeCountA_;      // Node count (ping)
+    BufferUtils::PerFrameBufferSet nodeCountB_;      // Node count (pong)
+
+    // Root cluster indices (CPU-seeded, copied to node buffer at start of traversal)
+    std::vector<uint32_t> rootClusterIndices_;
+
+    // LOD selection descriptor sets per frame (2 per frame for ping-pong)
+    std::vector<VkDescriptorSet> lodSelectDescSetsAB_;  // input=A, output=B
+    std::vector<VkDescriptorSet> lodSelectDescSetsBA_;  // input=B, output=A
+
+    float errorThreshold_ = 1.0f;  // Default: 1 pixel error threshold
+
+    // Ping-pong index for visible buffer swapping
+    uint32_t currentBufferIndex_ = 0;
+
+    // External buffer references for descriptor sets
+    VkBuffer externalClusterBuffer_ = VK_NULL_HANDLE;
+    VkDeviceSize externalClusterSize_ = 0;
+    std::vector<VkBuffer> externalInstanceBuffers_;
+    VkDeviceSize externalInstanceSize_ = 0;
+
+    // Hi-Z sampler for pass 2 occlusion testing
+    std::optional<vk::raii::Sampler> hiZSampler_;
+
+    // Placeholder image for unbound Hi-Z descriptor in pass 1
+    ManagedImage placeholderHiZImage_;
+    VkImageView placeholderHiZView_ = VK_NULL_HANDLE;
+};

--- a/src/visibility/VisibilityBuffer.cpp
+++ b/src/visibility/VisibilityBuffer.cpp
@@ -1,0 +1,1771 @@
+#include "VisibilityBuffer.h"
+#include "ShaderLoader.h"
+#include "Mesh.h"
+#include "MeshClusterBuilder.h"
+#include "Texture.h"
+#include "MaterialRegistry.h"
+#include "vulkan/CommandBufferUtils.h"
+#include "shaders/bindings.h"
+#include "vulkan/VmaBufferFactory.h"
+
+#include <SDL3/SDL_log.h>
+#include <array>
+#include <cstring>
+
+// ============================================================================
+// Factory methods
+// ============================================================================
+
+std::unique_ptr<VisibilityBuffer> VisibilityBuffer::create(const InitInfo& info) {
+    auto system = std::make_unique<VisibilityBuffer>(ConstructToken{});
+    if (!system->initInternal(info)) {
+        return nullptr;
+    }
+    return system;
+}
+
+std::unique_ptr<VisibilityBuffer> VisibilityBuffer::create(const InitContext& ctx, VkFormat depthFormat) {
+    InitInfo info{};
+    info.device = ctx.device;
+    info.allocator = ctx.allocator;
+    info.descriptorPool = ctx.descriptorPool;
+    info.extent = ctx.extent;
+    info.shaderPath = ctx.shaderPath;
+    info.framesInFlight = ctx.framesInFlight;
+    info.depthFormat = depthFormat;
+    info.raiiDevice = ctx.raiiDevice;
+    info.graphicsQueue = ctx.graphicsQueue;
+    info.commandPool = ctx.commandPool;
+    return create(info);
+}
+
+VisibilityBuffer::~VisibilityBuffer() {
+    cleanup();
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+bool VisibilityBuffer::initInternal(const InitInfo& info) {
+    device_ = info.device;
+    allocator_ = info.allocator;
+    descriptorPool_ = info.descriptorPool;
+    extent_ = info.extent;
+    shaderPath_ = info.shaderPath;
+    framesInFlight_ = info.framesInFlight;
+    depthFormat_ = info.depthFormat;
+    raiiDevice_ = info.raiiDevice;
+    graphicsQueue_ = info.graphicsQueue;
+    commandPool_ = info.commandPool;
+
+    // Use shared depth from HDR pass if provided
+    if (info.sharedDepthImage != VK_NULL_HANDLE && info.sharedDepthView != VK_NULL_HANDLE) {
+        sharedDepth_ = true;
+        depthView_ = info.sharedDepthView;
+    }
+
+    if (!createRenderTargets()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create render targets");
+        return false;
+    }
+
+    if (!createRenderPass()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create render pass");
+        return false;
+    }
+
+    if (!createFramebuffer()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create framebuffer");
+        return false;
+    }
+
+    // Raster pipeline requires shaderDrawParameters (gl_DrawID) for GPU-driven draws
+    if (info.hasShaderDrawParameters) {
+        if (!createRasterPipeline()) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create raster pipeline");
+            return false;
+        }
+    } else {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+            "VisibilityBuffer: Raster pipeline skipped (shaderDrawParameters not available)");
+    }
+
+    if (!createDebugPipeline()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create debug pipeline");
+        return false;
+    }
+
+    if (!createResolveBuffers()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create resolve buffers");
+        return false;
+    }
+
+    if (!createResolvePipeline()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create resolve pipeline");
+        return false;
+    }
+
+    SDL_Log("VisibilityBuffer: Initialized (%ux%u, %u frames)",
+            extent_.width, extent_.height, framesInFlight_);
+    return true;
+}
+
+void VisibilityBuffer::cleanup() {
+    if (device_ == VK_NULL_HANDLE) return;
+
+    vkDeviceWaitIdle(device_);
+
+    destroyResolveBuffers();
+    destroyResolvePipeline();
+    destroyDebugPipeline();
+    destroyRasterPipeline();
+    destroyFramebuffer();
+    destroyRenderPass();
+    destroyRenderTargets();
+    destroyDescriptorSets();
+}
+
+// ============================================================================
+// Render targets
+// ============================================================================
+
+bool VisibilityBuffer::createRenderTargets() {
+    // V-buffer: R32G32_UINT — R=instanceId, G=triangleId (64-bit, no packing)
+    bool ok = ImageBuilder(allocator_)
+        .setExtent(extent_)
+        .setFormat(VISBUF_FORMAT)
+        .setUsage(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                  VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+        .build(device_, visibilityImage_, visibilityView_);
+
+    if (!ok) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create visibility image");
+        return false;
+    }
+
+    // Depth buffer — only create if not using shared depth from HDR pass
+    if (!sharedDepth_) {
+        ok = ImageBuilder(allocator_)
+            .setExtent(extent_)
+            .setFormat(depthFormat_)
+            .setUsage(VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT)
+            .build(device_, depthImage_, depthView_, VK_IMAGE_ASPECT_DEPTH_BIT);
+
+        if (!ok) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create depth image");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void VisibilityBuffer::destroyRenderTargets() {
+    // Only destroy depth if we own it (not shared from HDR pass)
+    if (!sharedDepth_) {
+        if (depthView_ != VK_NULL_HANDLE) {
+            vkDestroyImageView(device_, depthView_, nullptr);
+            depthView_ = VK_NULL_HANDLE;
+        }
+        depthImage_.reset();
+    }
+
+    if (visibilityView_ != VK_NULL_HANDLE) {
+        vkDestroyImageView(device_, visibilityView_, nullptr);
+        visibilityView_ = VK_NULL_HANDLE;
+    }
+    visibilityImage_.reset();
+}
+
+// ============================================================================
+// Render pass
+// ============================================================================
+
+bool VisibilityBuffer::createRenderPass() {
+    // Attachment 0: Visibility buffer (R32_UINT)
+    VkAttachmentDescription visAttachment{};
+    visAttachment.format = VISBUF_FORMAT;
+    visAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    visAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    visAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    visAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    visAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    visAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    visAttachment.finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    // Attachment 1: Depth
+    // When shared with HDR pass, finalLayout = ATTACHMENT so HDR can continue writing.
+    // When owned, finalLayout = READ_ONLY for sampling.
+    VkAttachmentDescription depthAttachment{};
+    depthAttachment.format = depthFormat_;
+    depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    depthAttachment.finalLayout = sharedDepth_
+        ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+
+    VkAttachmentReference colorRef{};
+    colorRef.attachment = 0;
+    colorRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference depthRef{};
+    depthRef.attachment = 1;
+    depthRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &colorRef;
+    subpass.pDepthStencilAttachment = &depthRef;
+
+    // Dependencies for proper synchronization
+    std::array<VkSubpassDependency, 2> dependencies{};
+
+    // External -> Subpass 0
+    dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependencies[0].dstSubpass = 0;
+    dependencies[0].srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                   VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    dependencies[0].srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+    // Subpass 0 -> External
+    dependencies[1].srcSubpass = 0;
+    dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+    dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    dependencies[1].dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                   VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+
+    std::array<VkAttachmentDescription, 2> attachments = {visAttachment, depthAttachment};
+
+    VkRenderPassCreateInfo renderPassInfo{};
+    renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+    renderPassInfo.pAttachments = attachments.data();
+    renderPassInfo.subpassCount = 1;
+    renderPassInfo.pSubpasses = &subpass;
+    renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
+    renderPassInfo.pDependencies = dependencies.data();
+
+    if (vkCreateRenderPass(device_, &renderPassInfo, nullptr, &renderPass_) != VK_SUCCESS) {
+        return false;
+    }
+
+    return true;
+}
+
+void VisibilityBuffer::destroyRenderPass() {
+    if (renderPass_ != VK_NULL_HANDLE) {
+        vkDestroyRenderPass(device_, renderPass_, nullptr);
+        renderPass_ = VK_NULL_HANDLE;
+    }
+}
+
+// ============================================================================
+// Framebuffer
+// ============================================================================
+
+bool VisibilityBuffer::createFramebuffer() {
+    std::array<VkImageView, 2> attachments = {visibilityView_, depthView_};
+
+    VkFramebufferCreateInfo fbInfo{};
+    fbInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    fbInfo.renderPass = renderPass_;
+    fbInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
+    fbInfo.pAttachments = attachments.data();
+    fbInfo.width = extent_.width;
+    fbInfo.height = extent_.height;
+    fbInfo.layers = 1;
+
+    if (vkCreateFramebuffer(device_, &fbInfo, nullptr, &framebuffer_) != VK_SUCCESS) {
+        return false;
+    }
+
+    return true;
+}
+
+void VisibilityBuffer::destroyFramebuffer() {
+    if (framebuffer_ != VK_NULL_HANDLE) {
+        vkDestroyFramebuffer(device_, framebuffer_, nullptr);
+        framebuffer_ = VK_NULL_HANDLE;
+    }
+}
+
+// ============================================================================
+// Raster pipeline (V-buffer write)
+// ============================================================================
+
+bool VisibilityBuffer::createRasterPipeline() {
+    // Create descriptor set layout for raster pass (GPU-driven indirect draws)
+    // Binding 0: Main UBO (camera matrices)
+    // Binding 1: Diffuse texture (for alpha testing, placeholder for now)
+    // Binding 2: DrawData SSBO (per-draw instanceId + triangleOffset from TwoPassCuller)
+    // Binding 3: Instance SSBO (transforms from GPUSceneBuffer)
+    std::array<vk::DescriptorSetLayoutBinding, 4> layoutBindings;
+    layoutBindings[0] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_UBO)
+        .setDescriptorType(vk::DescriptorType::eUniformBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eVertex);
+
+    layoutBindings[1] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_DIFFUSE_TEX)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eFragment);
+
+    layoutBindings[2] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_RASTER_DRAW_DATA)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eVertex);
+
+    layoutBindings[3] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_RASTER_INSTANCES)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eVertex);
+
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}
+        .setBindings(layoutBindings);
+
+    try {
+        rasterDescSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create raster desc set layout: %s", e.what());
+        return false;
+    }
+
+    // No push constants — all per-draw data comes via DrawData SSBO
+    vk::DescriptorSetLayout vkRasterLayout(**rasterDescSetLayout_);
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}
+        .setSetLayouts(vkRasterLayout);
+
+    vk::Device vkDevice(device_);
+    rasterPipelineLayout_ = static_cast<VkPipelineLayout>(vkDevice.createPipelineLayout(pipelineLayoutInfo));
+
+    // Load shaders
+    auto vertModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/visbuf.vert.spv");
+    auto fragModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/visbuf.frag.spv");
+
+    if (!vertModule || !fragModule) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to load raster shaders");
+        return false;
+    }
+
+    std::array<vk::PipelineShaderStageCreateInfo, 2> shaderStages;
+    shaderStages[0] = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eVertex)
+        .setModule(*vertModule)
+        .setPName("main");
+    shaderStages[1] = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eFragment)
+        .setModule(*fragModule)
+        .setPName("main");
+
+    // Vertex input - same as standard Vertex
+    auto bindingDesc = Vertex::getBindingDescription();
+    auto attrDescs = Vertex::getAttributeDescriptions();
+
+    auto vertexInputInfo = vk::PipelineVertexInputStateCreateInfo{}
+        .setVertexBindingDescriptionCount(1)
+        .setPVertexBindingDescriptions(reinterpret_cast<const vk::VertexInputBindingDescription*>(&bindingDesc))
+        .setVertexAttributeDescriptionCount(static_cast<uint32_t>(attrDescs.size()))
+        .setPVertexAttributeDescriptions(reinterpret_cast<const vk::VertexInputAttributeDescription*>(attrDescs.data()));
+
+    auto inputAssembly = vk::PipelineInputAssemblyStateCreateInfo{}
+        .setTopology(vk::PrimitiveTopology::eTriangleList);
+
+    // Dynamic viewport/scissor
+    auto viewport = vk::Viewport{0.0f, 0.0f, static_cast<float>(extent_.width), static_cast<float>(extent_.height), 0.0f, 1.0f};
+    auto scissor = vk::Rect2D{{0, 0}, {extent_.width, extent_.height}};
+
+    auto viewportState = vk::PipelineViewportStateCreateInfo{}
+        .setViewportCount(1)
+        .setPViewports(&viewport)
+        .setScissorCount(1)
+        .setPScissors(&scissor);
+
+    auto rasterizer = vk::PipelineRasterizationStateCreateInfo{}
+        .setPolygonMode(vk::PolygonMode::eFill)
+        .setCullMode(vk::CullModeFlagBits::eBack)
+        .setFrontFace(vk::FrontFace::eCounterClockwise)
+        .setLineWidth(1.0f);
+
+    auto multisampling = vk::PipelineMultisampleStateCreateInfo{}
+        .setRasterizationSamples(vk::SampleCountFlagBits::e1);
+
+    auto depthStencil = vk::PipelineDepthStencilStateCreateInfo{}
+        .setDepthTestEnable(VK_TRUE)
+        .setDepthWriteEnable(VK_TRUE)
+        .setDepthCompareOp(vk::CompareOp::eLess);
+
+    // No blending for R32G32_UINT (integer format) — write R and G channels
+    auto colorBlendAttachment = vk::PipelineColorBlendAttachmentState{}
+        .setColorWriteMask(vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG);
+
+    auto colorBlending = vk::PipelineColorBlendStateCreateInfo{}
+        .setAttachmentCount(1)
+        .setPAttachments(&colorBlendAttachment);
+
+    // Dynamic state for viewport/scissor
+    std::array<vk::DynamicState, 2> dynamicStates = {
+        vk::DynamicState::eViewport,
+        vk::DynamicState::eScissor
+    };
+    auto dynamicState = vk::PipelineDynamicStateCreateInfo{}
+        .setDynamicStates(dynamicStates);
+
+    auto pipelineInfo = vk::GraphicsPipelineCreateInfo{}
+        .setStageCount(static_cast<uint32_t>(shaderStages.size()))
+        .setPStages(shaderStages.data())
+        .setPVertexInputState(&vertexInputInfo)
+        .setPInputAssemblyState(&inputAssembly)
+        .setPViewportState(&viewportState)
+        .setPRasterizationState(&rasterizer)
+        .setPMultisampleState(&multisampling)
+        .setPDepthStencilState(&depthStencil)
+        .setPColorBlendState(&colorBlending)
+        .setPDynamicState(&dynamicState)
+        .setLayout(rasterPipelineLayout_)
+        .setRenderPass(renderPass_)
+        .setSubpass(0);
+
+    auto result = vkDevice.createGraphicsPipeline(nullptr, pipelineInfo);
+    if (result.result != vk::Result::eSuccess) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create raster pipeline");
+        vkDevice.destroyShaderModule(*vertModule);
+        vkDevice.destroyShaderModule(*fragModule);
+        return false;
+    }
+    rasterPipeline_ = static_cast<VkPipeline>(result.value);
+
+    vkDevice.destroyShaderModule(*vertModule);
+    vkDevice.destroyShaderModule(*fragModule);
+
+    SDL_Log("VisibilityBuffer: Raster pipeline created");
+    return true;
+}
+
+void VisibilityBuffer::destroyRasterPipeline() {
+    if (rasterPipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, rasterPipeline_, nullptr);
+        rasterPipeline_ = VK_NULL_HANDLE;
+    }
+    if (rasterPipelineLayout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device_, rasterPipelineLayout_, nullptr);
+        rasterPipelineLayout_ = VK_NULL_HANDLE;
+    }
+    rasterDescSetLayout_.reset();
+}
+
+// ============================================================================
+// Debug visualization pipeline
+// ============================================================================
+
+bool VisibilityBuffer::createDebugPipeline() {
+    if (!raiiDevice_) return false;
+
+    // Create nearest sampler for integer texture sampling
+    auto samplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eNearest)
+        .setMinFilter(vk::Filter::eNearest)
+        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge);
+
+    try {
+        nearestSampler_.emplace(*raiiDevice_, samplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create sampler: %s", e.what());
+        return false;
+    }
+
+    // Descriptor set layout: visibility buffer + depth buffer
+    std::array<vk::DescriptorSetLayoutBinding, 2> bindings;
+    bindings[0] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_DEBUG_INPUT)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eFragment);
+
+    bindings[1] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_DEBUG_DEPTH_INPUT)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eFragment);
+
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(bindings);
+
+    try {
+        debugDescSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create debug desc set layout: %s", e.what());
+        return false;
+    }
+
+    // Allocate debug descriptor set
+    VkDescriptorSetLayout rawDebugLayout = **debugDescSetLayout_;
+    auto debugSets = descriptorPool_->allocate(rawDebugLayout, 1);
+    if (debugSets.empty()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to allocate debug descriptor set");
+        return false;
+    }
+    debugDescSet_ = debugSets[0];
+
+    // Update debug descriptor set with V-buffer and depth views
+    VkSampler rawSampler = **nearestSampler_;
+
+    VkDescriptorImageInfo visInfo{};
+    visInfo.sampler = rawSampler;
+    visInfo.imageView = visibilityView_;
+    visInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkDescriptorImageInfo depthInfo{};
+    depthInfo.sampler = rawSampler;
+    depthInfo.imageView = depthView_;
+    depthInfo.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+
+    std::array<VkWriteDescriptorSet, 2> writes{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[0].dstSet = debugDescSet_;
+    writes[0].dstBinding = BINDING_VISBUF_DEBUG_INPUT;
+    writes[0].descriptorCount = 1;
+    writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    writes[0].pImageInfo = &visInfo;
+
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[1].dstSet = debugDescSet_;
+    writes[1].dstBinding = BINDING_VISBUF_DEBUG_DEPTH_INPUT;
+    writes[1].descriptorCount = 1;
+    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    writes[1].pImageInfo = &depthInfo;
+
+    vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+
+    // Push constants
+    vk::PushConstantRange pushRange{};
+    pushRange.stageFlags = vk::ShaderStageFlagBits::eFragment;
+    pushRange.offset = 0;
+    pushRange.size = sizeof(VisBufDebugPushConstants);
+
+    vk::DescriptorSetLayout vkDebugLayout(**debugDescSetLayout_);
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}
+        .setSetLayouts(vkDebugLayout)
+        .setPushConstantRanges(pushRange);
+
+    vk::Device vkDevice(device_);
+    debugPipelineLayout_ = static_cast<VkPipelineLayout>(vkDevice.createPipelineLayout(pipelineLayoutInfo));
+
+    // Load debug shaders
+    auto vertModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/visbuf_debug.vert.spv");
+    auto fragModule = ShaderLoader::loadShaderModule(vkDevice, shaderPath_ + "/visbuf_debug.frag.spv");
+
+    if (!vertModule || !fragModule) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to load debug shaders");
+        return false;
+    }
+
+    std::array<vk::PipelineShaderStageCreateInfo, 2> shaderStages;
+    shaderStages[0] = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eVertex)
+        .setModule(*vertModule)
+        .setPName("main");
+    shaderStages[1] = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eFragment)
+        .setModule(*fragModule)
+        .setPName("main");
+
+    // No vertex input (fullscreen triangle)
+    auto vertexInputInfo = vk::PipelineVertexInputStateCreateInfo{};
+    auto inputAssembly = vk::PipelineInputAssemblyStateCreateInfo{}
+        .setTopology(vk::PrimitiveTopology::eTriangleList);
+
+    auto viewport = vk::Viewport{0.0f, 0.0f, static_cast<float>(extent_.width), static_cast<float>(extent_.height), 0.0f, 1.0f};
+    auto scissor = vk::Rect2D{{0, 0}, {extent_.width, extent_.height}};
+
+    auto viewportState = vk::PipelineViewportStateCreateInfo{}
+        .setViewportCount(1)
+        .setPViewports(&viewport)
+        .setScissorCount(1)
+        .setPScissors(&scissor);
+
+    auto rasterizer = vk::PipelineRasterizationStateCreateInfo{}
+        .setPolygonMode(vk::PolygonMode::eFill)
+        .setCullMode(vk::CullModeFlagBits::eNone)
+        .setLineWidth(1.0f);
+
+    auto multisampling = vk::PipelineMultisampleStateCreateInfo{}
+        .setRasterizationSamples(vk::SampleCountFlagBits::e1);
+
+    auto depthStencil = vk::PipelineDepthStencilStateCreateInfo{}
+        .setDepthTestEnable(VK_FALSE)
+        .setDepthWriteEnable(VK_FALSE);
+
+    auto colorBlendAttachment = vk::PipelineColorBlendAttachmentState{}
+        .setColorWriteMask(vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG |
+                           vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA);
+
+    auto colorBlending = vk::PipelineColorBlendStateCreateInfo{}
+        .setAttachmentCount(1)
+        .setPAttachments(&colorBlendAttachment);
+
+    std::array<vk::DynamicState, 2> dynamicStates = {
+        vk::DynamicState::eViewport,
+        vk::DynamicState::eScissor
+    };
+    auto dynamicState = vk::PipelineDynamicStateCreateInfo{}
+        .setDynamicStates(dynamicStates);
+
+    // Debug pipeline renders to the swapchain render pass, not the V-buffer render pass.
+    // We'll need the swapchain render pass to be passed in. For now, skip the
+    // graphics pipeline creation and create it lazily when the render pass is known.
+    // Store the shader modules for later creation.
+
+    // Actually, the debug visualization will be rendered in the post-process pass's
+    // output render pass. We don't have that here, so we'll create the pipeline lazily.
+    // For now, just clean up.
+    vkDevice.destroyShaderModule(*vertModule);
+    vkDevice.destroyShaderModule(*fragModule);
+
+    SDL_Log("VisibilityBuffer: Debug descriptor set created (pipeline deferred)");
+    return true;
+}
+
+void VisibilityBuffer::destroyDebugPipeline() {
+    nearestSampler_.reset();
+    if (debugPipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, debugPipeline_, nullptr);
+        debugPipeline_ = VK_NULL_HANDLE;
+    }
+    if (debugPipelineLayout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device_, debugPipelineLayout_, nullptr);
+        debugPipelineLayout_ = VK_NULL_HANDLE;
+    }
+    debugDescSetLayout_.reset();
+}
+
+// ============================================================================
+// Resolve pipeline (compute)
+// ============================================================================
+
+bool VisibilityBuffer::createResolvePipeline() {
+    if (!raiiDevice_) return false;
+
+    // Create depth sampler for the resolve pass
+    auto depthSamplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eNearest)
+        .setMinFilter(vk::Filter::eNearest)
+        .setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge);
+
+    try {
+        depthSampler_.emplace(*raiiDevice_, depthSamplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create depth sampler: %s", e.what());
+        return false;
+    }
+
+    // Create texture sampler for material textures
+    auto texSamplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eLinear)
+        .setMinFilter(vk::Filter::eLinear)
+        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
+        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeW(vk::SamplerAddressMode::eRepeat)
+        .setMaxAnisotropy(1.0f)
+        .setMaxLod(VK_LOD_CLAMP_NONE);
+
+    try {
+        textureSampler_.emplace(*raiiDevice_, texSamplerInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create texture sampler: %s", e.what());
+        return false;
+    }
+
+    // Descriptor set layout: 10 bindings matching visbuf_resolve.comp
+    // (binding 9 / HDR depth removed — shared depth buffer handles visibility)
+    std::array<vk::DescriptorSetLayoutBinding, 10> bindings;
+
+    // Binding 0: Visibility buffer (uimage2D, storage image)
+    bindings[0] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_VISIBILITY)
+        .setDescriptorType(vk::DescriptorType::eStorageImage)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 1: Depth buffer (sampler2D) — shared depth for position reconstruction
+    bindings[1] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_DEPTH)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 2: HDR output (image2D, storage image)
+    bindings[2] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_HDR_OUTPUT)
+        .setDescriptorType(vk::DescriptorType::eStorageImage)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 3: Vertex buffer (SSBO)
+    bindings[3] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_VERTEX_BUFFER)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 4: Index buffer (SSBO)
+    bindings[4] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_INDEX_BUFFER)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 5: Instance buffer (SSBO)
+    bindings[5] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_INSTANCE_BUFFER)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 6: Material buffer (SSBO)
+    bindings[6] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_MATERIAL_BUFFER)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 7: Resolve uniforms (UBO)
+    bindings[7] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_UNIFORMS)
+        .setDescriptorType(vk::DescriptorType::eUniformBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 8: Material texture array (sampler2DArray)
+    bindings[8] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_TEXTURE_ARRAY)
+        .setDescriptorType(vk::DescriptorType::eCombinedImageSampler)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    // Binding 10: Dynamic light buffer (SSBO) — for multi-light resolve
+    bindings[9] = vk::DescriptorSetLayoutBinding{}
+        .setBinding(BINDING_VISBUF_LIGHT_BUFFER)
+        .setDescriptorType(vk::DescriptorType::eStorageBuffer)
+        .setDescriptorCount(1)
+        .setStageFlags(vk::ShaderStageFlagBits::eCompute);
+
+    auto layoutInfo = vk::DescriptorSetLayoutCreateInfo{}.setBindings(bindings);
+
+    try {
+        resolveDescSetLayout_.emplace(*raiiDevice_, layoutInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create resolve desc set layout: %s", e.what());
+        return false;
+    }
+
+    // Pipeline layout (no push constants needed)
+    vk::DescriptorSetLayout vkResolveLayout(**resolveDescSetLayout_);
+    auto pipelineLayoutInfo = vk::PipelineLayoutCreateInfo{}
+        .setSetLayouts(vkResolveLayout);
+
+    vk::Device vkDevice(device_);
+    resolvePipelineLayout_ = static_cast<VkPipelineLayout>(
+        vkDevice.createPipelineLayout(pipelineLayoutInfo));
+
+    // Load compute shader
+    auto compModule = ShaderLoader::loadShaderModule(
+        vkDevice, shaderPath_ + "/visbuf_resolve.comp.spv");
+
+    if (!compModule) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to load resolve compute shader");
+        return false;
+    }
+
+    auto stageInfo = vk::PipelineShaderStageCreateInfo{}
+        .setStage(vk::ShaderStageFlagBits::eCompute)
+        .setModule(*compModule)
+        .setPName("main");
+
+    auto pipelineInfo = vk::ComputePipelineCreateInfo{}
+        .setStage(stageInfo)
+        .setLayout(resolvePipelineLayout_);
+
+    auto result = vkDevice.createComputePipeline(nullptr, pipelineInfo);
+    if (result.result != vk::Result::eSuccess) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create resolve compute pipeline");
+        vkDevice.destroyShaderModule(*compModule);
+        return false;
+    }
+    resolvePipeline_ = static_cast<VkPipeline>(result.value);
+
+    vkDevice.destroyShaderModule(*compModule);
+
+    // Allocate descriptor sets (one per frame in flight)
+    VkDescriptorSetLayout rawResolveLayout = **resolveDescSetLayout_;
+    resolveDescSets_ = descriptorPool_->allocate(rawResolveLayout, framesInFlight_);
+    if (resolveDescSets_.size() != framesInFlight_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to allocate resolve descriptor sets");
+        return false;
+    }
+
+    SDL_Log("VisibilityBuffer: Resolve pipeline created (10 bindings)");
+    return true;
+}
+
+void VisibilityBuffer::destroyResolvePipeline() {
+    depthSampler_.reset();
+    textureSampler_.reset();
+    if (resolvePipeline_ != VK_NULL_HANDLE) {
+        vkDestroyPipeline(device_, resolvePipeline_, nullptr);
+        resolvePipeline_ = VK_NULL_HANDLE;
+    }
+    if (resolvePipelineLayout_ != VK_NULL_HANDLE) {
+        vkDestroyPipelineLayout(device_, resolvePipelineLayout_, nullptr);
+        resolvePipelineLayout_ = VK_NULL_HANDLE;
+    }
+    resolveDescSetLayout_.reset();
+    resolveDescSets_.clear();
+}
+
+VkPipeline VisibilityBuffer::getResolvePipeline() const {
+    return resolvePipeline_;
+}
+
+VkPipelineLayout VisibilityBuffer::getResolvePipelineLayout() const {
+    return resolvePipelineLayout_;
+}
+
+// ============================================================================
+// Descriptor sets
+// ============================================================================
+
+bool VisibilityBuffer::createDescriptorSets() {
+    return true;
+}
+
+void VisibilityBuffer::destroyDescriptorSets() {
+    resolveDescSets_.clear();
+}
+
+// ============================================================================
+// Resolve buffers
+// ============================================================================
+
+bool VisibilityBuffer::createResolveBuffers() {
+    VkDeviceSize uniformSize = sizeof(VisBufResolveUniforms);
+    bool ok = BufferUtils::PerFrameBufferBuilder()
+        .setAllocator(allocator_)
+        .setFrameCount(framesInFlight_)
+        .setSize(uniformSize)
+        .setUsage(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
+        .setAllocationFlags(VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                           VMA_ALLOCATION_CREATE_MAPPED_BIT)
+        .build(resolveUniformBuffers_);
+
+    if (!ok) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create resolve uniform buffers");
+        return false;
+    }
+
+    // Create placeholder SSBO for unbound vertex/index/material descriptors.
+    // The resolve shader early-returns on background pixels (packed == 0),
+    // so these are never actually read, but Vulkan requires valid descriptors.
+    if (!VmaBufferFactory::createStorageBufferHostWritable(allocator_, PLACEHOLDER_BUFFER_SIZE, placeholderBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create placeholder buffer");
+        return false;
+    }
+    // Zero-fill placeholder
+    VmaAllocationInfo placeholderAllocInfo{};
+    vmaGetAllocationInfo(allocator_, placeholderBuffer_.get_deleter().allocation, &placeholderAllocInfo);
+    if (placeholderAllocInfo.pMappedData) {
+        memset(placeholderAllocInfo.pMappedData, 0, PLACEHOLDER_BUFFER_SIZE);
+    }
+
+    // Create a 1x1 placeholder texture for the unbound texture array descriptor
+    ok = ImageBuilder(allocator_)
+        .setExtent(VkExtent2D{1, 1})
+        .setFormat(VK_FORMAT_R8G8B8A8_UNORM)
+        .setUsage(VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+        .build(device_, placeholderTexImage_, placeholderTexView_);
+
+    if (!ok) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create placeholder texture");
+        return false;
+    }
+
+    return true;
+}
+
+void VisibilityBuffer::destroyResolveBuffers() {
+    if (placeholderTexView_ != VK_NULL_HANDLE) {
+        vkDestroyImageView(device_, placeholderTexView_, nullptr);
+        placeholderTexView_ = VK_NULL_HANDLE;
+    }
+    placeholderTexImage_.reset();
+    placeholderBuffer_.reset();
+    BufferUtils::destroyBuffers(allocator_, resolveUniformBuffers_);
+}
+
+// ============================================================================
+// Global vertex/index buffers (for resolve pass)
+// ============================================================================
+
+bool VisibilityBuffer::buildGlobalBuffersFromClusters(
+        const std::vector<std::pair<const Mesh*, const ClusteredMesh*>>& meshClusters) {
+    if (meshClusters.empty()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VisibilityBuffer: No clustered meshes to build global buffers");
+        return false;
+    }
+
+    // Count total vertices and indices across all clustered meshes
+    uint32_t totalVertices = 0;
+    uint32_t totalIndices = 0;
+    for (const auto& [mesh, clustered] : meshClusters) {
+        if (!clustered) continue;
+        totalVertices += static_cast<uint32_t>(clustered->vertices.size());
+        totalIndices += static_cast<uint32_t>(clustered->indices.size());
+    }
+
+    if (totalVertices == 0 || totalIndices == 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VisibilityBuffer: Empty clustered mesh data");
+        return false;
+    }
+
+    // Build CPU-side packed vertex and offset-adjusted index arrays
+    std::vector<VisBufPackedVertex> packedVertices;
+    packedVertices.reserve(totalVertices);
+    std::vector<uint32_t> globalIndices;
+    globalIndices.reserve(totalIndices);
+    meshInfoMap_.clear();
+
+    uint32_t currentVertexOffset = 0;
+    uint32_t currentIndexOffset = 0;
+
+    for (const auto& [mesh, clustered] : meshClusters) {
+        if (!clustered || !mesh) continue;
+
+        // Track mesh info (same structure as buildGlobalBuffers)
+        VisBufMeshInfo info{};
+        info.globalVertexOffset = currentVertexOffset;
+        info.globalIndexOffset = currentIndexOffset;
+        info.triangleOffset = currentIndexOffset / 3;
+        meshInfoMap_[mesh] = info;
+
+        // Repack cluster vertices into PackedVertex format
+        for (const auto& v : clustered->vertices) {
+            VisBufPackedVertex pv{};
+            pv.positionAndU = glm::vec4(v.position, v.texCoord.x);
+            pv.normalAndV = glm::vec4(v.normal, v.texCoord.y);
+            pv.tangent = v.tangent;
+            pv.color = v.color;
+            packedVertices.push_back(pv);
+        }
+
+        // Copy cluster indices, offset to global vertex space
+        for (uint32_t idx : clustered->indices) {
+            globalIndices.push_back(idx + currentVertexOffset);
+        }
+
+        currentVertexOffset += static_cast<uint32_t>(clustered->vertices.size());
+        currentIndexOffset += static_cast<uint32_t>(clustered->indices.size());
+    }
+
+    // Upload to GPU storage buffers
+    globalVertexBufferSize_ = packedVertices.size() * sizeof(VisBufPackedVertex);
+    globalIndexBufferSize_ = globalIndices.size() * sizeof(uint32_t);
+
+    if (!VmaBufferFactory::createStorageBufferHostWritable(
+            allocator_, globalVertexBufferSize_, globalVertexBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create cluster global vertex buffer");
+        return false;
+    }
+
+    VmaAllocationInfo vertAllocInfo{};
+    vmaGetAllocationInfo(allocator_, globalVertexBuffer_.get_deleter().allocation, &vertAllocInfo);
+    if (vertAllocInfo.pMappedData) {
+        memcpy(vertAllocInfo.pMappedData, packedVertices.data(), globalVertexBufferSize_);
+        vmaFlushAllocation(allocator_, globalVertexBuffer_.get_deleter().allocation,
+                           0, globalVertexBufferSize_);
+    }
+
+    if (!VmaBufferFactory::createStorageBufferHostWritable(
+            allocator_, globalIndexBufferSize_, globalIndexBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create cluster global index buffer");
+        return false;
+    }
+
+    VmaAllocationInfo idxAllocInfo{};
+    vmaGetAllocationInfo(allocator_, globalIndexBuffer_.get_deleter().allocation, &idxAllocInfo);
+    if (idxAllocInfo.pMappedData) {
+        memcpy(idxAllocInfo.pMappedData, globalIndices.data(), globalIndexBufferSize_);
+        vmaFlushAllocation(allocator_, globalIndexBuffer_.get_deleter().allocation,
+                           0, globalIndexBufferSize_);
+    }
+
+    globalBuffersBuilt_ = true;
+    SDL_Log("VisibilityBuffer: Cluster global buffers built (%u vertices, %u indices, %zu meshes)",
+            totalVertices, totalIndices, meshClusters.size());
+    return true;
+}
+
+const VisBufMeshInfo* VisibilityBuffer::getMeshInfo(const Mesh* mesh) const {
+    auto it = meshInfoMap_.find(mesh);
+    if (it != meshInfoMap_.end()) {
+        return &it->second;
+    }
+    return nullptr;
+}
+
+// ============================================================================
+// Material texture array
+// ============================================================================
+
+bool VisibilityBuffer::buildMaterialTextureArray(const MaterialRegistry& registry) {
+    if (graphicsQueue_ == VK_NULL_HANDLE || commandPool_ == VK_NULL_HANDLE) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Cannot build texture array - no queue/command pool");
+        return false;
+    }
+
+    // Collect unique textures from all materials (diffuse, normal, roughness/metallic)
+    std::vector<const Texture*> textures;
+    textureLayerMap_.clear();
+
+    auto addTexture = [&](const Texture* tex) {
+        if (!tex) return;
+        if (textureLayerMap_.find(tex) != textureLayerMap_.end()) return;
+        textureLayerMap_[tex] = static_cast<uint32_t>(textures.size());
+        textures.push_back(tex);
+    };
+
+    size_t matCount = registry.getMaterialCount();
+    for (uint32_t i = 0; i < matCount; ++i) {
+        const auto* def = registry.getMaterial(i);
+        if (!def) continue;
+        addTexture(def->diffuse);
+        addTexture(def->normal);
+        addTexture(def->roughnessMap);
+        addTexture(def->metallicMap);
+    }
+
+    if (textures.empty()) {
+        SDL_Log("VisibilityBuffer: No material textures to build array from");
+        return false;
+    }
+
+    // Determine array resolution from the first texture (blit handles resizing)
+    uint32_t arrayW = static_cast<uint32_t>(textures[0]->getWidth());
+    uint32_t arrayH = static_cast<uint32_t>(textures[0]->getHeight());
+    uint32_t layerCount = static_cast<uint32_t>(textures.size());
+
+    SDL_Log("VisibilityBuffer: Building texture array %ux%u with %u layers",
+            arrayW, arrayH, layerCount);
+
+    // Create the 2D array image (UNORM - sRGB conversion done in shader for albedo)
+    auto imageInfo = vk::ImageCreateInfo{}
+        .setImageType(vk::ImageType::e2D)
+        .setFormat(vk::Format::eR8G8B8A8Unorm)
+        .setExtent({arrayW, arrayH, 1})
+        .setMipLevels(1)
+        .setArrayLayers(layerCount)
+        .setSamples(vk::SampleCountFlagBits::e1)
+        .setTiling(vk::ImageTiling::eOptimal)
+        .setUsage(vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eSampled)
+        .setSharingMode(vk::SharingMode::eExclusive)
+        .setInitialLayout(vk::ImageLayout::eUndefined);
+
+    VmaAllocationCreateInfo allocInfo{};
+    allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+    allocInfo.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+
+    VkImage rawImage;
+    VmaAllocation rawAlloc;
+    if (vmaCreateImage(allocator_,
+                       reinterpret_cast<const VkImageCreateInfo*>(&imageInfo),
+                       &allocInfo, &rawImage, &rawAlloc, nullptr) != VK_SUCCESS) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to create texture array image");
+        return false;
+    }
+    textureArrayImage_ = ManagedImage(rawImage, {allocator_, rawAlloc});
+
+    // One-shot command buffer for blitting
+    CommandScope cmd(device_, commandPool_, graphicsQueue_);
+    if (!cmd.begin()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to begin texture array command buffer");
+        return false;
+    }
+
+    vk::CommandBuffer vkCmd = cmd.get();
+
+    // Transition the entire array to TRANSFER_DST
+    {
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setSrcAccessMask(vk::AccessFlagBits::eNone)
+            .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
+            .setOldLayout(vk::ImageLayout::eUndefined)
+            .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setImage(textureArrayImage_.get())
+            .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, layerCount});
+
+        vkCmd.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTopOfPipe,
+            vk::PipelineStageFlagBits::eTransfer,
+            {}, {}, {}, barrier);
+    }
+
+    // Blit each texture into its layer
+    for (uint32_t layer = 0; layer < layerCount; ++layer) {
+        const Texture* tex = textures[layer];
+        VkImage srcImage = tex->getImage();
+        int srcW = tex->getWidth();
+        int srcH = tex->getHeight();
+
+        // Transition source to TRANSFER_SRC
+        {
+            auto barrier = vk::ImageMemoryBarrier{}
+                .setSrcAccessMask(vk::AccessFlagBits::eShaderRead)
+                .setDstAccessMask(vk::AccessFlagBits::eTransferRead)
+                .setOldLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+                .setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
+                .setImage(srcImage)
+                .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+
+            vkCmd.pipelineBarrier(
+                vk::PipelineStageFlagBits::eFragmentShader,
+                vk::PipelineStageFlagBits::eTransfer,
+                {}, {}, {}, barrier);
+        }
+
+        // Blit (handles format conversion and resizing)
+        vk::ImageBlit region;
+        region.srcSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1};
+        region.srcOffsets[0] = vk::Offset3D{0, 0, 0};
+        region.srcOffsets[1] = vk::Offset3D{srcW, srcH, 1};
+        region.dstSubresource = {vk::ImageAspectFlagBits::eColor, 0, layer, 1};
+        region.dstOffsets[0] = vk::Offset3D{0, 0, 0};
+        region.dstOffsets[1] = vk::Offset3D{
+            static_cast<int32_t>(arrayW),
+            static_cast<int32_t>(arrayH), 1};
+
+        vkCmd.blitImage(
+            srcImage, vk::ImageLayout::eTransferSrcOptimal,
+            textureArrayImage_.get(), vk::ImageLayout::eTransferDstOptimal,
+            region, vk::Filter::eLinear);
+
+        // Transition source back to SHADER_READ_ONLY
+        {
+            auto barrier = vk::ImageMemoryBarrier{}
+                .setSrcAccessMask(vk::AccessFlagBits::eTransferRead)
+                .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+                .setOldLayout(vk::ImageLayout::eTransferSrcOptimal)
+                .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+                .setImage(srcImage)
+                .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1});
+
+            vkCmd.pipelineBarrier(
+                vk::PipelineStageFlagBits::eTransfer,
+                vk::PipelineStageFlagBits::eFragmentShader,
+                {}, {}, {}, barrier);
+        }
+    }
+
+    // Transition array to SHADER_READ_ONLY
+    {
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+            .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+            .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+            .setImage(textureArrayImage_.get())
+            .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, layerCount});
+
+        vkCmd.pipelineBarrier(
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eComputeShader,
+            {}, {}, {}, barrier);
+    }
+
+    if (!cmd.end()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to submit texture array commands");
+        return false;
+    }
+
+    // Create 2D array image view
+    auto viewInfo = vk::ImageViewCreateInfo{}
+        .setImage(textureArrayImage_.get())
+        .setViewType(vk::ImageViewType::e2DArray)
+        .setFormat(vk::Format::eR8G8B8A8Unorm)
+        .setSubresourceRange({vk::ImageAspectFlagBits::eColor, 0, 1, 0, layerCount});
+
+    vk::Device vkDevice(device_);
+    textureArrayView_ = static_cast<VkImageView>(vkDevice.createImageView(viewInfo));
+
+    // Create sampler
+    auto samplerInfo = vk::SamplerCreateInfo{}
+        .setMagFilter(vk::Filter::eLinear)
+        .setMinFilter(vk::Filter::eLinear)
+        .setMipmapMode(vk::SamplerMipmapMode::eLinear)
+        .setAddressModeU(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeV(vk::SamplerAddressMode::eRepeat)
+        .setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
+        .setMaxAnisotropy(1.0f)
+        .setMaxLod(VK_LOD_CLAMP_NONE);
+
+    textureArraySampler_.emplace(*raiiDevice_, samplerInfo);
+
+    textureArrayBuilt_ = true;
+    SDL_Log("VisibilityBuffer: Texture array built (%u layers, %ux%u)",
+            layerCount, arrayW, arrayH);
+    return true;
+}
+
+VkSampler VisibilityBuffer::getTextureArraySampler() const {
+    return textureArraySampler_ ? static_cast<VkSampler>(**textureArraySampler_) : VK_NULL_HANDLE;
+}
+
+uint32_t VisibilityBuffer::getTextureLayerIndex(const Texture* tex) const {
+    auto it = textureLayerMap_.find(tex);
+    return (it != textureLayerMap_.end()) ? it->second : ~0u;
+}
+
+// ============================================================================
+// Raster pass descriptor sets
+// ============================================================================
+
+bool VisibilityBuffer::createRasterDescriptorSets(
+    const std::vector<VkBuffer>& uboBuffers,
+    VkDeviceSize uboSize,
+    const std::vector<VkBuffer>& drawDataBuffers,
+    VkDeviceSize drawDataSize,
+    const std::vector<VkBuffer>& instanceBuffers,
+    VkDeviceSize instanceSize) {
+
+    if (!rasterDescSetLayout_ || uboBuffers.empty()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Cannot create raster desc sets - layout or UBO not ready");
+        return false;
+    }
+
+    VkDescriptorSetLayout rawLayout = **rasterDescSetLayout_;
+    rasterDescSets_ = descriptorPool_->allocate(rawLayout, static_cast<uint32_t>(uboBuffers.size()));
+    if (rasterDescSets_.size() != uboBuffers.size()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "VisibilityBuffer: Failed to allocate raster descriptor sets");
+        return false;
+    }
+
+    // Update each frame's descriptor set
+    for (size_t i = 0; i < rasterDescSets_.size(); ++i) {
+        VkDescriptorSet descSet = rasterDescSets_[i];
+
+        // Binding 0: UBO
+        VkDescriptorBufferInfo uboInfo{};
+        uboInfo.buffer = uboBuffers[i];
+        uboInfo.offset = 0;
+        uboInfo.range = uboSize;
+
+        // Binding 1: Placeholder diffuse texture
+        VkDescriptorImageInfo texInfo{};
+        texInfo.sampler = nearestSampler_ ? static_cast<VkSampler>(**nearestSampler_) : VK_NULL_HANDLE;
+        texInfo.imageView = placeholderTexView_;
+        texInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        // Binding 2: DrawData SSBO (per-draw data from TwoPassCuller)
+        VkDescriptorBufferInfo drawDataInfo{};
+        drawDataInfo.buffer = (i < drawDataBuffers.size()) ? drawDataBuffers[i] : placeholderBuffer_.get();
+        drawDataInfo.offset = 0;
+        drawDataInfo.range = (i < drawDataBuffers.size() && drawDataSize > 0) ? drawDataSize : PLACEHOLDER_BUFFER_SIZE;
+
+        // Binding 3: Instance SSBO (transforms from GPUSceneBuffer)
+        VkDescriptorBufferInfo instanceInfo{};
+        instanceInfo.buffer = (i < instanceBuffers.size()) ? instanceBuffers[i] : placeholderBuffer_.get();
+        instanceInfo.offset = 0;
+        instanceInfo.range = (i < instanceBuffers.size() && instanceSize > 0) ? instanceSize : PLACEHOLDER_BUFFER_SIZE;
+
+        std::array<VkWriteDescriptorSet, 4> writes{};
+
+        writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[0].dstSet = descSet;
+        writes[0].dstBinding = BINDING_UBO;
+        writes[0].descriptorCount = 1;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].pBufferInfo = &uboInfo;
+
+        writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1].dstSet = descSet;
+        writes[1].dstBinding = BINDING_DIFFUSE_TEX;
+        writes[1].descriptorCount = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[1].pImageInfo = &texInfo;
+
+        writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[2].dstSet = descSet;
+        writes[2].dstBinding = BINDING_VISBUF_RASTER_DRAW_DATA;
+        writes[2].descriptorCount = 1;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[2].pBufferInfo = &drawDataInfo;
+
+        writes[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[3].dstSet = descSet;
+        writes[3].dstBinding = BINDING_VISBUF_RASTER_INSTANCES;
+        writes[3].descriptorCount = 1;
+        writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[3].pBufferInfo = &instanceInfo;
+
+        vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()),
+                               writes.data(), 0, nullptr);
+    }
+
+    SDL_Log("VisibilityBuffer: Raster descriptor sets created (%zu frames)",
+            rasterDescSets_.size());
+    return true;
+}
+
+VkDescriptorSet VisibilityBuffer::getRasterDescriptorSet(uint32_t frameIndex) const {
+    if (frameIndex < rasterDescSets_.size()) {
+        return rasterDescSets_[frameIndex];
+    }
+    return VK_NULL_HANDLE;
+}
+
+// ============================================================================
+// Resize
+// ============================================================================
+
+void VisibilityBuffer::updateSharedDepth(VkImageView newDepthView) {
+    if (!sharedDepth_) return;
+    depthView_ = newDepthView;
+}
+
+void VisibilityBuffer::resize(VkExtent2D newExtent) {
+    if (newExtent.width == extent_.width && newExtent.height == extent_.height) {
+        return;
+    }
+
+    vkDeviceWaitIdle(device_);
+
+    extent_ = newExtent;
+
+    // Recreate size-dependent resources
+    destroyFramebuffer();
+    destroyRenderTargets();
+
+    createRenderTargets();
+    createFramebuffer();
+
+    // Update debug descriptor set with new image views
+    if (debugDescSet_ != VK_NULL_HANDLE && nearestSampler_) {
+        VkSampler rawSampler = **nearestSampler_;
+
+        VkDescriptorImageInfo visInfo{};
+        visInfo.sampler = rawSampler;
+        visInfo.imageView = visibilityView_;
+        visInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        VkDescriptorImageInfo depthInfo{};
+        depthInfo.sampler = rawSampler;
+        depthInfo.imageView = depthView_;
+        depthInfo.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+
+        std::array<VkWriteDescriptorSet, 2> writes{};
+        writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[0].dstSet = debugDescSet_;
+        writes[0].dstBinding = BINDING_VISBUF_DEBUG_INPUT;
+        writes[0].descriptorCount = 1;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[0].pImageInfo = &visInfo;
+
+        writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        writes[1].dstSet = debugDescSet_;
+        writes[1].dstBinding = BINDING_VISBUF_DEBUG_DEPTH_INPUT;
+        writes[1].descriptorCount = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[1].pImageInfo = &depthInfo;
+
+        vkUpdateDescriptorSets(device_, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+    }
+
+    SDL_Log("VisibilityBuffer: Resized to %ux%u", extent_.width, extent_.height);
+}
+
+// ============================================================================
+// Command recording helpers
+// ============================================================================
+
+void VisibilityBuffer::transitionToShaderRead(VkCommandBuffer cmd) {
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.image = visibilityImage_.get();
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.layerCount = 1;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+void VisibilityBuffer::transitionToColorAttachment(VkCommandBuffer cmd) {
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    barrier.image = visibilityImage_.get();
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.layerCount = 1;
+
+    vkCmdPipelineBarrier(cmd,
+        VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+void VisibilityBuffer::recordClear(VkCommandBuffer cmd) {
+    // V-buffer clear happens in the render pass (loadOp = CLEAR)
+    // This method is for explicit clears if needed outside the render pass
+    VkClearColorValue clearColor{};
+    clearColor.uint32[0] = 0;  // 0 = no geometry
+
+    VkImageSubresourceRange range{};
+    range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    range.levelCount = 1;
+    range.layerCount = 1;
+
+    vkCmdClearColorImage(cmd, visibilityImage_.get(),
+                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                          &clearColor, 1, &range);
+}
+
+void VisibilityBuffer::setResolveBuffers(const ResolveBuffers& buffers) {
+    resolveBuffers_ = buffers;
+    resolveDescSetsDirty_ = true;
+}
+
+void VisibilityBuffer::updateResolveUniforms(uint32_t frameIndex,
+                                              const glm::mat4& view, const glm::mat4& proj,
+                                              const glm::vec3& cameraPos,
+                                              const glm::vec3& sunDir, float sunIntensity,
+                                              uint32_t materialCount) {
+    VisBufResolveUniforms uniforms{};
+    uniforms.viewMatrix = view;
+    uniforms.projMatrix = proj;
+    uniforms.invViewProj = glm::inverse(proj * view);
+    uniforms.cameraPosition = glm::vec4(cameraPos, 1.0f);
+    uniforms.screenParams = glm::vec4(
+        static_cast<float>(extent_.width),
+        static_cast<float>(extent_.height),
+        1.0f / static_cast<float>(extent_.width),
+        1.0f / static_cast<float>(extent_.height)
+    );
+    uniforms.lightDirection = glm::vec4(sunDir, sunIntensity);
+    uniforms.materialCount = materialCount > 0 ? materialCount : resolveBuffers_.materialCount;
+
+    void* mapped = resolveUniformBuffers_.mappedPointers[frameIndex];
+    if (mapped) {
+        memcpy(mapped, &uniforms, sizeof(uniforms));
+        vmaFlushAllocation(allocator_, resolveUniformBuffers_.allocations[frameIndex],
+                           0, sizeof(uniforms));
+    }
+}
+
+void VisibilityBuffer::recordResolvePass(VkCommandBuffer cmd, uint32_t frameIndex,
+                                          VkImageView hdrOutputView) {
+    if (resolvePipeline_ == VK_NULL_HANDLE) {
+        return; // Pipeline not yet created
+    }
+
+    if (resolveDescSets_.empty() || frameIndex >= resolveDescSets_.size()) {
+        return;
+    }
+
+    // Update descriptor set if buffers changed or HDR output changed
+    if (resolveDescSetsDirty_ || hdrOutputView != VK_NULL_HANDLE) {
+        VkDescriptorSet descSet = resolveDescSets_[frameIndex];
+        VkBuffer placeholder = placeholderBuffer_.get();
+
+        // Always bind all 10 descriptors. Use placeholder buffer/texture for
+        // unbound slots so Vulkan validation is satisfied. The resolve shader
+        // early-returns on background pixels (packed == 0) so placeholders
+        // are never actually read when the V-buffer is empty.
+
+        std::array<VkWriteDescriptorSet, 10> writes{};
+        for (auto& w : writes) w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+
+        // Binding 0: Visibility buffer (storage image)
+        VkDescriptorImageInfo visImageInfo{};
+        visImageInfo.imageView = visibilityView_;
+        visImageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+        writes[0].dstSet = descSet;
+        writes[0].dstBinding = BINDING_VISBUF_VISIBILITY;
+        writes[0].descriptorCount = 1;
+        writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[0].pImageInfo = &visImageInfo;
+
+        // Binding 1: Depth buffer (combined image sampler)
+        VkDescriptorImageInfo depthImageInfo{};
+        depthImageInfo.sampler = depthSampler_ ? static_cast<VkSampler>(**depthSampler_) : VK_NULL_HANDLE;
+        depthImageInfo.imageView = depthView_;
+        depthImageInfo.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+
+        writes[1].dstSet = descSet;
+        writes[1].dstBinding = BINDING_VISBUF_DEPTH;
+        writes[1].descriptorCount = 1;
+        writes[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[1].pImageInfo = &depthImageInfo;
+
+        // Binding 2: HDR output (storage image)
+        VkDescriptorImageInfo hdrImageInfo{};
+        hdrImageInfo.imageView = hdrOutputView;
+        hdrImageInfo.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+        writes[2].dstSet = descSet;
+        writes[2].dstBinding = BINDING_VISBUF_HDR_OUTPUT;
+        writes[2].descriptorCount = 1;
+        writes[2].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[2].pImageInfo = &hdrImageInfo;
+
+        // Binding 3: Vertex buffer (SSBO) - use placeholder if not wired
+        VkDescriptorBufferInfo vertexBufInfo{};
+        vertexBufInfo.buffer = resolveBuffers_.vertexBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.vertexBuffer : placeholder;
+        vertexBufInfo.offset = 0;
+        vertexBufInfo.range = resolveBuffers_.vertexBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.vertexBufferSize : PLACEHOLDER_BUFFER_SIZE;
+
+        writes[3].dstSet = descSet;
+        writes[3].dstBinding = BINDING_VISBUF_VERTEX_BUFFER;
+        writes[3].descriptorCount = 1;
+        writes[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[3].pBufferInfo = &vertexBufInfo;
+
+        // Binding 4: Index buffer (SSBO) - use placeholder if not wired
+        VkDescriptorBufferInfo indexBufInfo{};
+        indexBufInfo.buffer = resolveBuffers_.indexBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.indexBuffer : placeholder;
+        indexBufInfo.offset = 0;
+        indexBufInfo.range = resolveBuffers_.indexBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.indexBufferSize : PLACEHOLDER_BUFFER_SIZE;
+
+        writes[4].dstSet = descSet;
+        writes[4].dstBinding = BINDING_VISBUF_INDEX_BUFFER;
+        writes[4].descriptorCount = 1;
+        writes[4].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[4].pBufferInfo = &indexBufInfo;
+
+        // Binding 5: Instance buffer (SSBO) - use placeholder if not wired
+        VkDescriptorBufferInfo instanceBufInfo{};
+        instanceBufInfo.buffer = resolveBuffers_.instanceBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.instanceBuffer : placeholder;
+        instanceBufInfo.offset = 0;
+        instanceBufInfo.range = resolveBuffers_.instanceBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.instanceBufferSize : PLACEHOLDER_BUFFER_SIZE;
+
+        writes[5].dstSet = descSet;
+        writes[5].dstBinding = BINDING_VISBUF_INSTANCE_BUFFER;
+        writes[5].descriptorCount = 1;
+        writes[5].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[5].pBufferInfo = &instanceBufInfo;
+
+        // Binding 6: Material buffer (SSBO) - use placeholder if not wired
+        VkDescriptorBufferInfo materialBufInfo{};
+        materialBufInfo.buffer = resolveBuffers_.materialBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.materialBuffer : placeholder;
+        materialBufInfo.offset = 0;
+        materialBufInfo.range = resolveBuffers_.materialBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.materialBufferSize : PLACEHOLDER_BUFFER_SIZE;
+
+        writes[6].dstSet = descSet;
+        writes[6].dstBinding = BINDING_VISBUF_MATERIAL_BUFFER;
+        writes[6].descriptorCount = 1;
+        writes[6].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[6].pBufferInfo = &materialBufInfo;
+
+        // Binding 7: Resolve uniforms (UBO)
+        VkDescriptorBufferInfo uniformBufInfo{};
+        uniformBufInfo.buffer = resolveUniformBuffers_.buffers[frameIndex];
+        uniformBufInfo.offset = 0;
+        uniformBufInfo.range = sizeof(VisBufResolveUniforms);
+
+        writes[7].dstSet = descSet;
+        writes[7].dstBinding = BINDING_VISBUF_UNIFORMS;
+        writes[7].descriptorCount = 1;
+        writes[7].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[7].pBufferInfo = &uniformBufInfo;
+
+        // Binding 8: Material texture array (combined image sampler)
+        // Use placeholder texture if no texture array is wired
+        VkDescriptorImageInfo texArrayInfo{};
+        if (resolveBuffers_.textureArraySampler != VK_NULL_HANDLE) {
+            texArrayInfo.sampler = resolveBuffers_.textureArraySampler;
+        } else if (textureSampler_) {
+            texArrayInfo.sampler = static_cast<VkSampler>(**textureSampler_);
+        }
+        texArrayInfo.imageView = resolveBuffers_.textureArrayView != VK_NULL_HANDLE
+            ? resolveBuffers_.textureArrayView : placeholderTexView_;
+        texArrayInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        writes[8].dstSet = descSet;
+        writes[8].dstBinding = BINDING_VISBUF_TEXTURE_ARRAY;
+        writes[8].descriptorCount = 1;
+        writes[8].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        writes[8].pImageInfo = &texArrayInfo;
+
+        // Binding 10: Dynamic light buffer (SSBO)
+        VkDescriptorBufferInfo lightBufInfo{};
+        lightBufInfo.buffer = resolveBuffers_.lightBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.lightBuffer : placeholder;
+        lightBufInfo.offset = 0;
+        lightBufInfo.range = resolveBuffers_.lightBuffer != VK_NULL_HANDLE
+            ? resolveBuffers_.lightBufferSize : PLACEHOLDER_BUFFER_SIZE;
+
+        writes[9].dstSet = descSet;
+        writes[9].dstBinding = BINDING_VISBUF_LIGHT_BUFFER;
+        writes[9].descriptorCount = 1;
+        writes[9].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        writes[9].pBufferInfo = &lightBufInfo;
+
+        vkUpdateDescriptorSets(device_,
+                               static_cast<uint32_t>(writes.size()),
+                               writes.data(), 0, nullptr);
+
+        resolveDescSetsDirty_ = false;
+    }
+
+    // Transition images for compute shader access
+    // V-buffer raster and HDR pass have both completed (frame graph dependencies).
+    // V-buffer: SHADER_READ_ONLY → GENERAL (for storage image read)
+    // HDR color: SHADER_READ_ONLY → GENERAL (for imageStore)
+    // Shared depth: already in READ_ONLY from HDR render pass finalLayout — no transition needed
+    {
+        std::array<VkImageMemoryBarrier, 2> barriers{};
+        uint32_t barrierCount = 0;
+
+        // V-buffer: SHADER_READ_ONLY → GENERAL
+        barriers[barrierCount].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barriers[barrierCount].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        barriers[barrierCount].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barriers[barrierCount].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        barriers[barrierCount].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        barriers[barrierCount].image = visibilityImage_.get();
+        barriers[barrierCount].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        barriers[barrierCount].subresourceRange.levelCount = 1;
+        barriers[barrierCount].subresourceRange.layerCount = 1;
+        barrierCount++;
+
+        // HDR color: SHADER_READ_ONLY → GENERAL
+        if (resolveBuffers_.hdrColorImage != VK_NULL_HANDLE) {
+            barriers[barrierCount].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            barriers[barrierCount].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            barriers[barrierCount].dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
+            barriers[barrierCount].oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            barriers[barrierCount].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+            barriers[barrierCount].image = resolveBuffers_.hdrColorImage;
+            barriers[barrierCount].subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            barriers[barrierCount].subresourceRange.levelCount = 1;
+            barriers[barrierCount].subresourceRange.layerCount = 1;
+            barrierCount++;
+        }
+
+        vkCmdPipelineBarrier(cmd,
+            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+            VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 0, nullptr, 0, nullptr, barrierCount, barriers.data());
+    }
+
+    // Bind pipeline and descriptor set
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, resolvePipeline_);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                             resolvePipelineLayout_, 0, 1,
+                             &resolveDescSets_[frameIndex], 0, nullptr);
+
+    // Dispatch: 8x8 workgroup size
+    uint32_t groupsX = (extent_.width + 7) / 8;
+    uint32_t groupsY = (extent_.height + 7) / 8;
+    vkCmdDispatch(cmd, groupsX, groupsY, 1);
+
+    // Barrier: resolve writes -> subsequent reads
+    // Transition HDR color back to SHADER_READ_ONLY for post-processing sampling
+    // HDR depth stays in DEPTH_STENCIL_READ_ONLY (post-processing expects that layout)
+    {
+        VkImageMemoryBarrier postBarrier{};
+        postBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        postBarrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        postBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        postBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        postBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        postBarrier.image = resolveBuffers_.hdrColorImage;
+        postBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        postBarrier.subresourceRange.levelCount = 1;
+        postBarrier.subresourceRange.layerCount = 1;
+
+        if (resolveBuffers_.hdrColorImage != VK_NULL_HANDLE) {
+            vkCmdPipelineBarrier(cmd,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &postBarrier);
+        }
+    }
+}
+
+void VisibilityBuffer::recordDebugVisualization(VkCommandBuffer cmd, uint32_t debugMode) {
+    if (debugDescSet_ == VK_NULL_HANDLE || debugPipelineLayout_ == VK_NULL_HANDLE) {
+        return;
+    }
+
+    vk::CommandBuffer vkCmd(cmd);
+
+    // Bind debug descriptor set
+    vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eGraphics,
+                              vk::PipelineLayout(debugPipelineLayout_),
+                              0, vk::DescriptorSet(debugDescSet_), {});
+
+    // Push debug mode
+    VisBufDebugPushConstants push{};
+    push.mode = debugMode;
+    vkCmd.pushConstants<VisBufDebugPushConstants>(
+        vk::PipelineLayout(debugPipelineLayout_),
+        vk::ShaderStageFlagBits::eFragment,
+        0, push);
+
+    // Draw fullscreen triangle (3 vertices, no vertex buffer needed)
+    vkCmd.draw(3, 1, 0, 0);
+}

--- a/src/visibility/VisibilityBuffer.cpp
+++ b/src/visibility/VisibilityBuffer.cpp
@@ -80,15 +80,11 @@ bool VisibilityBuffer::initInternal(const InitInfo& info) {
         return false;
     }
 
-    // Raster pipeline requires shaderDrawParameters (gl_DrawID) for GPU-driven draws
-    if (info.hasShaderDrawParameters) {
-        if (!createRasterPipeline()) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create raster pipeline");
-            return false;
-        }
-    } else {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-            "VisibilityBuffer: Raster pipeline skipped (shaderDrawParameters not available)");
+    // Raster pipeline uses gl_InstanceIndex (via firstInstance) instead of gl_DrawID,
+    // so shaderDrawParameters is NOT required — works on all Vulkan implementations.
+    if (!createRasterPipeline()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "VisibilityBuffer: Failed to create raster pipeline");
+        return false;
     }
 
     if (!createDebugPipeline()) {

--- a/src/visibility/VisibilityBuffer.h
+++ b/src/visibility/VisibilityBuffer.h
@@ -1,0 +1,383 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
+#include <vk_mem_alloc.h>
+#include <glm/glm.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "InitContext.h"
+#include "DescriptorManager.h"
+#include "ImageBuilder.h"
+#include "VmaImage.h"
+#include "VmaBuffer.h"
+#include "PerFrameBuffer.h"
+
+class Mesh;
+class Texture;
+class MaterialRegistry;
+struct Renderable;
+struct ClusteredMesh;
+
+// Packed vertex format for SSBO (matches PackedVertex in visbuf_resolve.comp)
+struct VisBufPackedVertex {
+    glm::vec4 positionAndU;  // xyz = position, w = texCoord.x
+    glm::vec4 normalAndV;    // xyz = normal,   w = texCoord.y
+    glm::vec4 tangent;       // xyzw = tangent (w = handedness)
+    glm::vec4 color;         // vertex color
+};
+
+// Per-mesh tracking info for V-buffer global buffers
+struct VisBufMeshInfo {
+    uint32_t globalVertexOffset;
+    uint32_t globalIndexOffset;
+    uint32_t triangleOffset;  // = globalIndexOffset / 3
+};
+
+// GPU material data for the resolve shader (matches GPUMaterial in visbuf_resolve.comp)
+struct GPUMaterial {
+    glm::vec4 baseColor;            // RGB + alpha
+    float roughness;
+    float metallic;
+    float normalScale;
+    float aoStrength;
+    uint32_t albedoTexIndex;        // UINT32_MAX = no texture
+    uint32_t normalTexIndex;        // UINT32_MAX = no texture
+    uint32_t roughnessMetallicTexIndex; // UINT32_MAX = no texture
+    uint32_t flags;                 // reserved
+};
+
+// Resolve uniforms for the compute material resolve pass
+struct alignas(16) VisBufResolveUniforms {
+    glm::mat4 invViewProj;
+    glm::mat4 viewMatrix;
+    glm::mat4 projMatrix;
+    glm::vec4 cameraPosition;
+    glm::vec4 screenParams;    // width, height, 1/width, 1/height
+    glm::vec4 lightDirection;  // xyz = sun dir, w = intensity
+    uint32_t instanceCount;
+    uint32_t materialCount;
+    uint32_t _pad1, _pad2;
+};
+
+// Push constants for the V-buffer rasterization pass
+struct VisBufPushConstants {
+    glm::mat4 model;
+    uint32_t instanceId;
+    uint32_t triangleOffset;
+    float alphaTestThreshold;
+    float _pad;
+};
+
+// Push constants for debug visualization
+struct VisBufDebugPushConstants {
+    uint32_t mode;  // 0=instance, 1=triangle, 2=mixed, 3=cluster, 4=cluster+instance, 5=depth
+    float _pad0, _pad1, _pad2;
+};
+
+/**
+ * VisibilityBuffer - GPU-driven visibility buffer rendering system
+ *
+ * Implements a two-phase rendering approach:
+ * Phase 1 (rasterize): Render scene objects writing (instanceID, triangleID) to a uint target
+ * Phase 2 (resolve):   Compute shader reads V-buffer, reconstructs attributes, evaluates materials
+ *
+ * The V-buffer target is a R32G32_UINT image (64-bit): R = instanceId, G = triangleId.
+ * Full 32-bit range for both IDs — no bit-packing limits.
+ *
+ * Usage:
+ *   1. create() - Initialize once at startup
+ *   2. resize() - Handle window resize
+ *   3. beginFrame() - Clear V-buffer
+ *   4. recordRasterPass() - Record draw commands writing to V-buffer
+ *   5. recordResolvePass() - Compute shader material evaluation
+ *   6. getDebugPipeline() - Optional debug visualization
+ */
+class VisibilityBuffer {
+public:
+    struct ConstructToken { explicit ConstructToken() = default; };
+    explicit VisibilityBuffer(ConstructToken) {}
+
+    struct InitInfo {
+        VkDevice device;
+        VmaAllocator allocator;
+        DescriptorManager::Pool* descriptorPool;
+        VkExtent2D extent;
+        std::string shaderPath;
+        uint32_t framesInFlight;
+        VkFormat depthFormat;
+        const vk::raii::Device* raiiDevice = nullptr;
+        VkQueue graphicsQueue = VK_NULL_HANDLE;
+        VkCommandPool commandPool = VK_NULL_HANDLE;
+        // Shared depth buffer from HDR pass (if null, creates own)
+        VkImage sharedDepthImage = VK_NULL_HANDLE;
+        VkImageView sharedDepthView = VK_NULL_HANDLE;
+        // Skip raster pipeline when shaderDrawParameters (gl_DrawID) unavailable
+        bool hasShaderDrawParameters = true;
+    };
+
+    static std::unique_ptr<VisibilityBuffer> create(const InitInfo& info);
+    static std::unique_ptr<VisibilityBuffer> create(const InitContext& ctx, VkFormat depthFormat);
+
+    ~VisibilityBuffer();
+
+    // Non-copyable, non-movable
+    VisibilityBuffer(const VisibilityBuffer&) = delete;
+    VisibilityBuffer& operator=(const VisibilityBuffer&) = delete;
+    VisibilityBuffer(VisibilityBuffer&&) = delete;
+    VisibilityBuffer& operator=(VisibilityBuffer&&) = delete;
+
+    void resize(VkExtent2D newExtent);
+
+    // Update shared depth view (call before resize when PostProcessSystem recreates depth)
+    void updateSharedDepth(VkImageView newDepthView);
+
+    // Get the V-buffer render pass (color=R32G32_UINT + depth)
+    VkRenderPass getRenderPass() const { return renderPass_; }
+    VkFramebuffer getFramebuffer() const { return framebuffer_; }
+    VkExtent2D getExtent() const { return extent_; }
+
+    // Get the V-buffer image view for reading (debug vis, resolve)
+    VkImageView getVisibilityView() const { return visibilityView_; }
+    VkImage getVisibilityImage() const { return visibilityImage_.get(); }
+
+    // Rasterization pipeline for writing to V-buffer
+    VkPipeline getRasterPipeline() const { return rasterPipeline_; }
+    VkPipelineLayout getRasterPipelineLayout() const { return rasterPipelineLayout_; }
+
+    // Debug visualization
+    VkPipeline getDebugPipeline() const { return debugPipeline_; }
+    VkPipelineLayout getDebugPipelineLayout() const { return debugPipelineLayout_; }
+
+    // Resolve compute pipeline
+    VkPipeline getResolvePipeline() const;
+    VkPipelineLayout getResolvePipelineLayout() const;
+
+    // Record transition of V-buffer to shader read after rasterization
+    void transitionToShaderRead(VkCommandBuffer cmd);
+
+    // Record transition of V-buffer to color attachment for rasterization
+    void transitionToColorAttachment(VkCommandBuffer cmd);
+
+    // Record clear of the V-buffer (writes 0 to indicate no geometry)
+    void recordClear(VkCommandBuffer cmd);
+
+    // External buffer references for resolve pass
+    struct ResolveBuffers {
+        VkBuffer vertexBuffer = VK_NULL_HANDLE;
+        VkBuffer indexBuffer = VK_NULL_HANDLE;
+        VkBuffer instanceBuffer = VK_NULL_HANDLE;
+        VkBuffer materialBuffer = VK_NULL_HANDLE;
+        VkDeviceSize vertexBufferSize = 0;
+        VkDeviceSize indexBufferSize = 0;
+        VkDeviceSize instanceBufferSize = 0;
+        VkDeviceSize materialBufferSize = 0;
+        uint32_t materialCount = 0;
+        VkImageView textureArrayView = VK_NULL_HANDLE; // sampler2DArray
+        VkSampler textureArraySampler = VK_NULL_HANDLE;
+        VkImage hdrColorImage = VK_NULL_HANDLE;       // HDR color image (for layout barriers)
+        VkBuffer lightBuffer = VK_NULL_HANDLE;        // Dynamic light SSBO
+        VkDeviceSize lightBufferSize = 0;
+    };
+
+    /**
+     * Set external buffer references for the resolve pass.
+     * Must be called before recordResolvePass(). Re-creates resolve
+     * descriptor sets whenever buffers change.
+     */
+    void setResolveBuffers(const ResolveBuffers& buffers);
+
+    // Update resolve uniforms
+    void updateResolveUniforms(uint32_t frameIndex,
+                                const glm::mat4& view, const glm::mat4& proj,
+                                const glm::vec3& cameraPos,
+                                const glm::vec3& sunDir, float sunIntensity,
+                                uint32_t materialCount = 0);
+
+    // Record the compute resolve pass (dispatches visbuf_resolve.comp)
+    void recordResolvePass(VkCommandBuffer cmd, uint32_t frameIndex,
+                           VkImageView hdrOutputView);
+
+    // Bind the debug visualization descriptor set and record fullscreen draw
+    void recordDebugVisualization(VkCommandBuffer cmd, uint32_t debugMode);
+
+    // ====================================================================
+    // Global vertex/index buffer management (for resolve pass)
+    // ====================================================================
+
+    /**
+     * Build global vertex/index buffers from clustered mesh data.
+     * Uses cluster vertex/index ordering so resolve triangleIds match cluster raster output.
+     * meshId maps each ClusteredMesh back to its source Mesh pointer.
+     */
+    bool buildGlobalBuffersFromClusters(
+        const std::vector<std::pair<const Mesh*, const ClusteredMesh*>>& meshClusters);
+
+    /** Get mesh info (offsets) for a given mesh pointer. Returns nullptr if not found. */
+    const VisBufMeshInfo* getMeshInfo(const Mesh* mesh) const;
+
+    bool hasGlobalBuffers() const { return globalBuffersBuilt_; }
+    VkBuffer getGlobalVertexBuffer() const { return globalVertexBuffer_.get(); }
+    VkBuffer getGlobalIndexBuffer() const { return globalIndexBuffer_.get(); }
+    VkDeviceSize getGlobalVertexBufferSize() const { return globalVertexBufferSize_; }
+    VkDeviceSize getGlobalIndexBufferSize() const { return globalIndexBufferSize_; }
+
+    // ====================================================================
+    // Raster pass descriptor set management
+    // ====================================================================
+
+    /**
+     * Create per-frame descriptor sets for the raster pass (GPU-driven indirect draws).
+     * Binds UBO, placeholder texture, DrawData SSBO, and Instance SSBO.
+     * Call once after TwoPassCuller and GPUSceneBuffer are initialized.
+     */
+    bool createRasterDescriptorSets(const std::vector<VkBuffer>& uboBuffers,
+                                     VkDeviceSize uboSize,
+                                     const std::vector<VkBuffer>& drawDataBuffers = {},
+                                     VkDeviceSize drawDataSize = 0,
+                                     const std::vector<VkBuffer>& instanceBuffers = {},
+                                     VkDeviceSize instanceSize = 0);
+
+    VkDescriptorSet getRasterDescriptorSet(uint32_t frameIndex) const;
+    bool hasRasterDescriptorSets() const { return !rasterDescSets_.empty(); }
+
+    // ====================================================================
+    // Material texture array (albedo textures packed into sampler2DArray)
+    // ====================================================================
+
+    /**
+     * Build a 2D array texture from all material albedo textures.
+     * Uses one-shot command buffer with blit for resizing.
+     * Returns the texture-to-layer mapping for populating GPUMaterial indices.
+     */
+    bool buildMaterialTextureArray(const MaterialRegistry& registry);
+    bool hasTextureArray() const { return textureArrayBuilt_; }
+    VkImageView getTextureArrayView() const { return textureArrayView_; }
+    VkSampler getTextureArraySampler() const;
+    uint32_t getTextureLayerIndex(const Texture* tex) const;
+
+    // Get the depth image/view (shared with main HDR pass when V-buffer is active)
+    VkImageView getDepthView() const { return depthView_; }
+    VkImage getDepthImage() const { return depthImage_.get(); }
+
+    // Statistics
+    struct Stats {
+        uint32_t rasterizedObjects;
+        uint32_t resolvedPixels;
+    };
+    Stats getStats() const { return stats_; }
+
+private:
+    bool initInternal(const InitInfo& info);
+    void cleanup();
+
+    bool createRenderTargets();
+    void destroyRenderTargets();
+
+    bool createRenderPass();
+    void destroyRenderPass();
+
+    bool createFramebuffer();
+    void destroyFramebuffer();
+
+    bool createRasterPipeline();
+    void destroyRasterPipeline();
+
+    bool createDebugPipeline();
+    void destroyDebugPipeline();
+
+    bool createResolvePipeline();
+    void destroyResolvePipeline();
+
+    bool createDescriptorSets();
+    void destroyDescriptorSets();
+
+    bool createResolveBuffers();
+    void destroyResolveBuffers();
+
+    VkDevice device_ = VK_NULL_HANDLE;
+    VmaAllocator allocator_ = VK_NULL_HANDLE;
+    DescriptorManager::Pool* descriptorPool_ = nullptr;
+    VkExtent2D extent_ = {0, 0};
+    std::string shaderPath_;
+    uint32_t framesInFlight_ = 0;
+    VkFormat depthFormat_ = VK_FORMAT_D32_SFLOAT;
+    const vk::raii::Device* raiiDevice_ = nullptr;
+
+    // V-buffer render target (R32G32_UINT — 64-bit: R=instanceId, G=triangleId)
+    static constexpr VkFormat VISBUF_FORMAT = VK_FORMAT_R32G32_UINT;
+    ManagedImage visibilityImage_;
+    VkImageView visibilityView_ = VK_NULL_HANDLE;
+
+    // Depth target (shared from HDR pass, or owned)
+    bool sharedDepth_ = false;        // true = depth image owned by PostProcessSystem
+    ManagedImage depthImage_;          // only used when !sharedDepth_
+    VkImageView depthView_ = VK_NULL_HANDLE;
+
+    // Render pass + framebuffer
+    VkRenderPass renderPass_ = VK_NULL_HANDLE;
+    VkFramebuffer framebuffer_ = VK_NULL_HANDLE;
+
+    // Rasterization pipeline (writes instance+triangle IDs)
+    std::optional<vk::raii::DescriptorSetLayout> rasterDescSetLayout_;
+    VkPipelineLayout rasterPipelineLayout_ = VK_NULL_HANDLE;
+    VkPipeline rasterPipeline_ = VK_NULL_HANDLE;
+
+    // Debug visualization pipeline (fullscreen quad)
+    std::optional<vk::raii::DescriptorSetLayout> debugDescSetLayout_;
+    VkPipelineLayout debugPipelineLayout_ = VK_NULL_HANDLE;
+    VkPipeline debugPipeline_ = VK_NULL_HANDLE;
+    VkDescriptorSet debugDescSet_ = VK_NULL_HANDLE;
+    std::optional<vk::raii::Sampler> nearestSampler_;
+
+    // Resolve compute pipeline
+    std::optional<vk::raii::DescriptorSetLayout> resolveDescSetLayout_;
+    VkPipelineLayout resolvePipelineLayout_ = VK_NULL_HANDLE;
+    VkPipeline resolvePipeline_ = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSet> resolveDescSets_;
+
+    // Resolve uniform buffers (per frame)
+    BufferUtils::PerFrameBufferSet resolveUniformBuffers_;
+
+    // External buffer references for resolve
+    ResolveBuffers resolveBuffers_;
+    std::optional<vk::raii::Sampler> depthSampler_;
+    std::optional<vk::raii::Sampler> textureSampler_;
+    bool resolveDescSetsDirty_ = true;
+
+    // Placeholder buffer for unbound SSBO descriptors (vertex/index/material when not yet wired)
+    VmaBuffer placeholderBuffer_;
+    static constexpr VkDeviceSize PLACEHOLDER_BUFFER_SIZE = 256;
+
+    // Placeholder 1x1 image for unbound texture array descriptor
+    ManagedImage placeholderTexImage_;
+    VkImageView placeholderTexView_ = VK_NULL_HANDLE;
+
+    // Global vertex/index buffers for resolve pass
+    VmaBuffer globalVertexBuffer_;
+    VmaBuffer globalIndexBuffer_;
+    VkDeviceSize globalVertexBufferSize_ = 0;
+    VkDeviceSize globalIndexBufferSize_ = 0;
+    std::unordered_map<const Mesh*, VisBufMeshInfo> meshInfoMap_;
+    bool globalBuffersBuilt_ = false;
+
+    // Raster pass descriptor sets (per-frame: UBO + placeholder texture)
+    std::vector<VkDescriptorSet> rasterDescSets_;
+
+    // Material texture array (albedo textures as sampler2DArray)
+    ManagedImage textureArrayImage_;
+    VkImageView textureArrayView_ = VK_NULL_HANDLE;
+    std::optional<vk::raii::Sampler> textureArraySampler_;
+    bool textureArrayBuilt_ = false;
+    std::unordered_map<const Texture*, uint32_t> textureLayerMap_;
+
+    // Queue/command pool for one-shot operations (texture array building)
+    VkQueue graphicsQueue_ = VK_NULL_HANDLE;
+    VkCommandPool commandPool_ = VK_NULL_HANDLE;
+
+    Stats stats_ = {};
+};


### PR DESCRIPTION
## Summary

This PR implements a complete Nanite-inspired visibility buffer rendering system for non-terrain geometry. The system replaces traditional forward/deferred rendering with GPU-driven cluster selection, two-pass occlusion culling, and deferred material resolve via a visibility buffer.

## Key Changes

### Core Visibility Buffer System
- **VisibilityBuffer** (`src/visibility/VisibilityBuffer.h/.cpp`): Main system managing V-buffer render targets (R32G32_UINT format storing instanceId + triangleId), render pass, framebuffer, and raster/resolve pipelines
- **Mesh Clustering** (`src/visibility/MeshClusterBuilder.h/.cpp`): Converts arbitrary meshes into 64-128 triangle clusters organized in a DAG hierarchy using meshoptimizer for simplification and error metrics
- **GPU Material Buffer** (`src/visibility/GPUMaterialBuffer.h/.cpp`): Manages GPU-side material data (PBR parameters, texture indices) for the resolve shader

### GPU-Driven Culling & LOD Selection
- **TwoPassCuller** (`src/visibility/TwoPassCuller.h/.cpp`): Implements two-phase occlusion culling:
  - Pass 1: Tests clusters visible in previous frame (high hit rate)
  - Pass 2: Tests remaining clusters against newly built Hi-Z pyramid
  - Generates indirect draw commands and per-draw data buffers
- **Cluster LOD Selection** (`shaders/cluster_select.comp`): Top-down DAG traversal selecting appropriate LOD clusters based on screen-space error threshold
- **Cluster Culling** (`shaders/cluster_cull.comp`): Frustum + Hi-Z occlusion culling with normal cone backface rejection

### Rendering & Material Resolve
- **V-buffer Raster** (`shaders/visbuf.vert/.frag`): GPU-driven indirect draws writing cluster/triangle IDs to visibility buffer
- **Material Resolve** (`shaders/visbuf_resolve.comp`): Fullscreen compute shader reconstructing world position via barycentrics, fetching vertex attributes, evaluating PBR materials, and writing to HDR output
- **Debug Visualization** (`shaders/visbuf_debug.vert/.frag`): Displays V-buffer contents colored by instance/triangle ID for verification

### Integration & Infrastructure
- **VisBufferPasses** (`src/core/passes/VisBufferPasses.h/.cpp`): Frame graph passes for cluster building, LOD selection, culling, rasterization, and material resolve
- **Shared Hi-Z Culling** (`shaders/hiz_occlusion_common.glsl`): Extracted common Hi-Z occlusion test logic used by both scene culling and cluster culling
- **Renderer Integration**: Updated `RendererInitPhases`, `RendererSystems`, `FrameGraphBuilder`, and `SceneObjectsDrawable` to initialize and conditionally use V-buffer pipeline
- **Vulkan Features**: Added detection for `VK_KHR_shader_draw_parameters` (gl_DrawID support) and `VK_KHR_draw_indirect_count`

### Supporting Changes
- Added `meshoptimizer` dependency to CMakeLists.txt
- Extended shader bindings for V-buffer resources (visibility buffer, vertex/index/instance/material buffers)
- Updated `PostProcessSystem` to expose HDR depth for sharing with V-buffer system
- Enhanced `Texture` and `Mesh` APIs to support V-buffer integration
- Updated `GPUSceneBuffer` and `GPUCullPass` for cluster-aware rendering

## Notable Implementation Details

- **Shared Depth**: V-buffer can optionally use depth from HDR pass to avoid redundant depth rendering
- **Fallback Path**: CPU-side pre-built indirect commands for bootstrapping when GPU culling hasn't run yet
- **DAG Hierarchy**: Clusters organized in a directed acyclic graph enabling efficient LOD selection without evaluating all clusters
- **Normal Cone Culling**: Per-cluster cone data enables backface rejection at cluster granularity
- **Subgroup Optimizations**: Uses subgroup ball

https://claude.ai/code/session_01WqarjB8Z7So8c8HtGptERp