### PR TITLE
Remove legacy renderable-based tree rendering path

### DIFF
--- a/src/vegetation/TreeBranchCulling.cpp
+++ b/src/vegetation/TreeBranchCulling.cpp
@@ -256,9 +256,8 @@ void TreeBranchCulling::updateTreeData(const TreeSystem& treeSystem, const TreeL
     }
 
     const auto& instances = treeSystem.getTreeInstances();
-    const auto& branchRenderables = treeSystem.getBranchRenderables();
 
-    if (instances.empty() || branchRenderables.empty()) {
+    if (instances.empty()) {
         numTrees_ = 0;
         meshGroups_.clear();
         meshGroupRenderInfo_.clear();
@@ -287,22 +286,22 @@ void TreeBranchCulling::updateTreeData(const TreeSystem& treeSystem, const TreeL
     uint32_t outputOffset = 0;
 
     for (const auto& [meshIndex, treeIndices] : treesByMesh) {
-        if (meshIndex >= branchRenderables.size()) continue;
+        if (meshIndex >= treeSystem.getMeshCount()) continue;
 
-        const auto& renderable = branchRenderables[meshIndex];
-        if (!renderable.mesh) continue;
+        const Mesh& mesh = treeSystem.getBranchMesh(meshIndex);
+        if (mesh.getIndexCount() == 0) continue;
 
         BranchMeshGroupGPU group{};
         group.meshIndex = meshIndex;
         group.firstTree = treeIndices.front();
         group.treeCount = static_cast<uint32_t>(treeIndices.size());
-        group.barkTypeIndex = 0; // Default, could be extracted from barkType string
-        group.indexCount = renderable.mesh->getIndexCount();
+        group.barkTypeIndex = 0;
+        group.indexCount = mesh.getIndexCount();
         group.maxInstances = static_cast<uint32_t>(treeIndices.size());
         group.outputOffset = outputOffset;
 
         // Determine bark type index from string
-        const std::string& barkType = branchRenderables[meshIndex].barkType;
+        const std::string& barkType = treeSystem.getTreeOptions(meshIndex).bark.type;
         if (barkType == "birch") group.barkTypeIndex = 0;
         else if (barkType == "oak") group.barkTypeIndex = 1;
         else if (barkType == "pine") group.barkTypeIndex = 2;

--- a/src/vegetation/TreeSystem.h
+++ b/src/vegetation/TreeSystem.h
@@ -17,7 +17,6 @@
 #include "TreeCollision.h"
 #include "Mesh.h"
 #include "Texture.h"
-#include "RenderableBuilder.h"
 #include "scene/Transform.h"
 #include "ecs/World.h"
 #include "ecs/Components.h"
@@ -106,13 +105,6 @@ public:
     void setECSWorld(ecs::World* world) { world_ = world; }
     ecs::World* getECSWorld() const { return world_; }
 
-    // Get scene objects for rendering (integrated with existing pipeline)
-    const std::vector<Renderable>& getBranchRenderables() const { return branchRenderables_; }
-    std::vector<Renderable>& getBranchRenderables() { return branchRenderables_; }
-
-    const std::vector<Renderable>& getLeafRenderables() const { return leafRenderables_; }
-    std::vector<Renderable>& getLeafRenderables() { return leafRenderables_; }
-
     // Tree management
     uint32_t addTree(const glm::vec3& position, float rotation, float scale, const TreeOptions& options);
 
@@ -167,6 +159,10 @@ public:
     // Get tree instances for physics/other systems
     const std::vector<TreeInstanceData>& getTreeInstances() const { return treeInstances_; }
 
+    // Get tree options for a given tree instance (looks up via meshIndex)
+    const TreeOptions& getTreeOptionsForInstance(uint32_t treeIndex) const {
+        return treeOptions_[treeInstances_[treeIndex].meshIndex];
+    }
     // Get ECS entity for a tree by index
     ecs::Entity getTreeEntity(uint32_t index) const {
         if (index < treeEntities_.size()) return treeEntities_[index];
@@ -221,9 +217,6 @@ private:
                           TreeMeshData* meshDataOut = nullptr);
     bool createSharedLeafQuadMesh();
     bool uploadLeafInstanceBuffer();
-    void createSceneObjects();
-    void rebuildSceneObjects();
-
     // ECS entity creation/destruction for trees
     ecs::Entity createTreeEntity(uint32_t treeIdx, const TreeInstanceData& instance, const TreeOptions& opts, const AABB& bounds);
     void destroyTreeEntity(uint32_t index);
@@ -285,8 +278,4 @@ private:
     // Tree instances (positions, rotations, etc.)
     std::vector<TreeInstanceData> treeInstances_;
     int selectedTreeIndex_ = -1;
-
-    // Scene objects for rendering
-    std::vector<Renderable> branchRenderables_;
-    std::vector<Renderable> leafRenderables_;
 };


### PR DESCRIPTION
## Summary
This PR removes the legacy renderable-based tree rendering system and consolidates all tree rendering to use the ECS-based approach. The `Renderable` objects (`branchRenderables_` and `leafRenderables_`) are no longer created or maintained, simplifying the codebase and eliminating duplicate rendering paths.

## Key Changes

### TreeSystem
- Removed `createSceneObjects()` and `rebuildSceneObjects()` methods that built `Renderable` objects
- Removed `branchRenderables_` and `leafRenderables_` member vectors
- Removed `RenderableBuilder.h` dependency
- Updated `addTree()`, `finalizeLeafInstanceBuffer()`, and `removeTree()` to call `refreshMeshRefs()` instead of `rebuildSceneObjects()`
- Added `getTreeOptionsForInstance()` helper to access tree options by instance index

### TreeRenderer
- **Branch rendering**: Removed the legacy `else` path that iterated `branchRenderables_`; now only uses ECS entity iteration
- **Leaf rendering**: Changed alpha test threshold lookup from `leafRenderables_[0].alphaTestThreshold` to `treeSystem.getTreeOptionsForInstance(0).leaves.alphaTest`
- **Shadow rendering**: 
  - Removed legacy branch shadow rendering path that used `branchRenderables_`
  - Removed legacy leaf shadow rendering path that used `leafRenderables_`
  - Updated mesh access in instanced shadow path to use `treeSystem.getBranchMesh()` instead of `renderable.mesh`
  - Consolidated leaf shadow direct draw path to iterate `treeInstances_` and access options via `getTreeOptionsForInstance()`
- Simplified early-exit checks to use `treeSystem.getTreeCount() == 0` instead of checking if renderables are empty

### TreeLeafCulling
- Updated `updateSpatialIndex()` to iterate `treeInstances_` instead of `leafRenderables_`
- Updated `recordCulling()` to build tree data from `treeInstances_` and access options via `getTreeOptionsForInstance()`
- Changed leaf type and alpha test lookups to use tree options instead of renderable properties

### TreeBranchCulling
- Updated `updateTreeData()` to access meshes via `treeSystem.getBranchMesh()` instead of `branchRenderables_`
- Removed dependency on `branchRenderables_` for mesh validation

### LightSystem
- Added new helper functions for creating child light entities with ECS hierarchy support:
  - `createChildPointLight()`: Point light as child of existing entity
  - `createChildFlickeringPointLight()`: Flickering point light as child
  - `createChildTorch()`: Torch light as child
  - `createChildSpotLight()`: Spot light as child
- These enable lights to automatically follow parent entities via transform hierarchy

### SceneManager
- Updated orb light creation to use `createChildTorch()` when orb entity is available, making the light follow the orb via ECS hierarchy
- Simplified orb light position tracking by syncing ECS Transform from physics instead of manually updating light position
- Added fallback to standalone torch creation if orb entity is unavailable

### SceneBuilder
- Added flag pole → flag cloth hierarchy setup using Parent/Children/HierarchyDepth components
- Flag cloth uses Parent relationship without LocalTransform to preserve cloth simulation's world-space positioning

## Implementation Details
- All tree rendering now exclusively uses the ECS path with `ecsWorld_->view<ecs::TreeTag, ...>()`
- Tree options are accessed through `treeSystem.getTreeOptionsForInstance()` which maps instance index to options via `meshIndex`
- Mesh access is now direct via `treeSystem.getBranchMesh()` and `treeSystem.getMeshCount()`
- The removal of renderables reduces memory overhead and eliminates the need to keep two parallel data structures in sync

https://claude.ai/code/session_01TqhjP45vZF9LDXU4Gt6rfx