### PR TITLE
Architectural review: document refactoring status and fix convention violations

### DIFF
--- a/docs/PLAN-eliminate-two-phase-init.md
+++ b/docs/PLAN-eliminate-two-phase-init.md
@@ -1,8 +1,17 @@
 # Plan: Eliminate Two-Phase Initialization & Adopt Smart Pointers
 
-## Status: COMPLETE ✓
+## Status: IN PROGRESS — residual work documented below
 
-All systems have been converted to RAII factory pattern. The two-phase initialization pattern has been eliminated.
+Most render subsystems (terrain, water, shadow, atmosphere, vegetation,
+post-process) have been converted to the RAII factory pattern. The
+tier-based system registry + `static std::unique_ptr<T> create(...)` is now
+the standard entry point for these systems.
+
+However, 19 headers in `src/` still declare `void destroy()` or `void
+shutdown()` (see [Residual work](#residual-work) below). Some are legitimate
+drain/join APIs that happen to share the name; others are genuine two-phase
+holdovers that should still be converted. The next maintainer to touch this
+plan should split the list and act on the real holdovers.
 
 ### Completed Conversions
 All systems now use `static std::unique_ptr<T> create(...)` factory pattern:
@@ -507,3 +516,63 @@ After each system migration:
 ### Backward Compatibility
 - During migration, can keep deprecated `init()`/`destroy()` that delegate to new pattern
 - Remove deprecated API once all callsites updated
+
+---
+
+## Residual work
+
+<a id="residual-work"></a>
+
+These headers still declare `void destroy()` or `void shutdown()` methods.
+Each one needs a classification pass: is it a legitimate drain/shutdown
+operation that should stay, or a two-phase holdover that should become an
+RAII destructor? Audited 2026-04-17 on branch
+`claude/review-game-engine-15t1V`.
+
+### Likely legitimate (thread join / external-lifetime drain)
+
+These are not two-phase init per se — they're explicit shutdown points that
+block until a background resource finishes. Keep the method, but document
+why it isn't folded into the destructor (e.g. "joins worker threads before
+dtor so exceptions during drain are visible to the caller").
+
+- `src/core/threading/TaskScheduler.h:76` — `void shutdown()`
+- `src/core/vulkan/AsyncTransferManager.h:60` — `void shutdown()`
+- `src/core/vulkan/ThreadedCommandPool.h:53` — `void shutdown()`
+- `src/loading/AsyncStartupLoader.h:121` — `void shutdown()`
+- `src/loading/AsyncSystemLoader.h:157` — `void shutdown()`
+- `src/loading/LoadJobQueue.h:230` — `void shutdown()`
+- `src/loading/LoadJobFactory.h:196` — `void shutdown()`
+
+### Genuine two-phase holdovers (convert to RAII)
+
+- `src/ml/GPUInference.h:64,87` — paired `bool init(...)` + `void destroy()`.
+  Also uses raw `vkCreate*`/`vkDestroy*`. Best next migration target: one
+  unit that resolves two-phase init AND vulkan-hpp migration together.
+- `src/material/DescriptorManager.h:181` — `void destroy()`
+- `src/material/ComposedMaterialRegistry.h:188` — `void destroy()`
+- `src/vegetation/GrassTileManager.h:77` — `void destroy()`
+- `src/vegetation/GrassTileResourcePool.h:50` — `void destroy()`
+- `src/core/TripleBuffering.h:82` — `void destroy()`
+- `src/core/FrameExecutor.h:51` — `void destroy()`
+- `src/core/FrameIndexedBuffers.h:73` — `void destroy()`
+- `src/core/RenderingInfrastructure.h:56` — `void shutdown()`
+- `src/core/pipeline/PipelineCache.h:40` — `void shutdown()`
+- `src/core/vulkan/VulkanContext.h:48` — `void shutdown()` (complex — owns
+  device, so ordering with dependent RAII systems must be preserved before
+  converting)
+
+### Top-level
+
+- `src/scene/Application.h:33` — `void shutdown()`. This is the application
+  entry-point and runs teardown in a specific order; may be the last thing
+  to convert, if at all.
+
+### Verification command
+
+```
+grep -rn "void destroy()\|void shutdown()" src/
+```
+
+Should shrink as each entry above is converted. Update this file when items
+move between categories.

--- a/docs/REVIEW-ARCHITECTURE.md
+++ b/docs/REVIEW-ARCHITECTURE.md
@@ -1,0 +1,243 @@
+# Architectural Review — 2026-04-17
+
+Scope: `src/` of the Vulkan outdoor-rendering engine. Focus is architectural
+health (not performance, not security). File:line references use the tree at
+commit `912c077` on branch `claude/review-game-engine-15t1V`.
+
+## Executive Summary
+
+The engine is well-structured and reflects a lot of deliberate design —
+system registries, RAII wrappers in `VulkanRAII.h`, a FrameGraph abstraction,
+tiered system groups, shader-reflected UBO generation. It is also visibly
+**mid-refactor**. Several migrations are in flight with plans that overstate
+completeness:
+
+- Two-phase init: marked `COMPLETE` in `PLAN-eliminate-two-phase-init.md`,
+  but 19 headers still expose `void destroy()` / `void shutdown()`.
+- FrameGraph: wired as a facade; parallel execution levels advertised in
+  `ARCHITECTURE.md` are not realized.
+- Vulkan-hpp migration: partial. ~399 raw `vk*` call sites remain.
+- ECS: ~3,000 lines of infrastructure, but the render path still iterates
+  legacy `Renderable*` from `SceneManager`.
+
+None of this is a crisis. The biggest risk is **drift between the docs and
+the code** — readers trust docs marked "complete" and then discover the
+pattern they're meant to avoid is still widespread. Fixing that is cheap and
+worth doing first.
+
+---
+
+## 1. Orchestration & God-Object Risk
+
+`src/core/Renderer.cpp` (1017 lines) + `src/core/RendererSystems.cpp` (420)
+form the rendering hub. `RendererSystems` holds ~60 `unique_ptr` subsystems
+via a `SystemRegistry`, grouped into tiered system groups
+(`AtmosphereSystemGroup`, `VegetationSystemGroup`, etc.).
+
+**Verdict:** not a true god-object. Registry indirection and system groups
+keep direct coupling manageable. `Renderer` itself is a 341-line header that
+delegates subsystem ownership out. Pass recorders (`ShadowPassRecorder`,
+`HDRPassRecorder`) were already extracted.
+
+**Residual work:** `Renderer::buildFrame()` still assembles lambdas per
+pass, and `FrameDataBuilder` still lives in `Renderer`. The in-progress
+`RENDERER_REFACTORING_PLAN.md` already names this.
+
+---
+
+## 2. FrameGraph — Facade Rather Than a Scheduler
+
+`src/core/pipeline/FrameGraph.{h,cpp}` exists and `Renderer::setupFrameGraph()`
+builds passes via `FrameGraphBuilder`. But:
+
+- `ARCHITECTURE.md` claims levels 1 (Shadow/Froxel/WaterGBuffer) and 3
+  (SSR/WaterTileCull/HiZ/BilateralGrid) run in parallel. In practice, passes
+  execute in sequence — the FrameGraph orders them, it does not schedule
+  them in parallel.
+- Secondary command buffer parallelism does exist inside the HDR pass (3
+  slots: sky+terrain, scene objects, grass+water), but not between passes.
+
+**Recommendation:** pick one — either drive real dependency-based
+scheduling, or downgrade the claim in `ARCHITECTURE.md` and name FrameGraph
+as an ordering/builder facade. Today a reader is misled about what's
+implemented.
+
+---
+
+## 3. System Lifecycle — RAII Claim vs. Reality
+
+`CLAUDE.md` states: *"do not use init destroy patterns"*, *"prefer to use
+RAII and smart pointers"*.
+
+`docs/PLAN-eliminate-two-phase-init.md` states: **Status: COMPLETE ✓**, "All
+systems have been converted to RAII factory pattern."
+
+The tree disagrees. 19 headers still declare `destroy()` or `shutdown()`:
+
+| File | Line | Method |
+|------|------|--------|
+| `src/core/FrameExecutor.h` | 51 | `void destroy()` |
+| `src/core/FrameIndexedBuffers.h` | 73 | `void destroy()` |
+| `src/core/RenderingInfrastructure.h` | 56 | `void shutdown()` |
+| `src/core/TripleBuffering.h` | 82 | `void destroy()` |
+| `src/core/pipeline/PipelineCache.h` | 40 | `void shutdown()` |
+| `src/core/threading/TaskScheduler.h` | 76 | `void shutdown()` |
+| `src/core/vulkan/AsyncTransferManager.h` | 60 | `void shutdown()` |
+| `src/core/vulkan/ThreadedCommandPool.h` | 53 | `void shutdown()` |
+| `src/core/vulkan/VulkanContext.h` | 48 | `void shutdown()` |
+| `src/loading/AsyncStartupLoader.h` | 121 | `void shutdown()` |
+| `src/loading/AsyncSystemLoader.h` | 157 | `void shutdown()` |
+| `src/loading/LoadJobFactory.h` | 196 | `void shutdown()` |
+| `src/loading/LoadJobQueue.h` | 230 | `void shutdown()` |
+| `src/material/ComposedMaterialRegistry.h` | 188 | `void destroy()` |
+| `src/material/DescriptorManager.h` | 181 | `void destroy()` |
+| `src/ml/GPUInference.h` | 87 | `void destroy()` (paired with `init()` at 64) |
+| `src/scene/Application.h` | 33 | `void shutdown()` |
+| `src/vegetation/GrassTileManager.h` | 77 | `void destroy()` |
+| `src/vegetation/GrassTileResourcePool.h` | 50 | `void destroy()` |
+
+Some of these are legitimate (e.g. `TaskScheduler::shutdown()` is a
+join-threads operation, not a destructor stand-in), but several — notably
+`GPUInference`, `DescriptorManager`, `ComposedMaterialRegistry`,
+`GrassTileManager`, `GrassTileResourcePool`, `TripleBuffering`,
+`FrameIndexedBuffers`, `FrameExecutor` — look like two-phase patterns the
+plan claimed to eliminate.
+
+**Recommendation:** re-open `PLAN-eliminate-two-phase-init.md` with a
+residual-work section distinguishing:
+
+- Thread-join / drain APIs that happen to be named `shutdown()` (keep as-is,
+  document the intent).
+- Genuine two-phase holdovers (convert to RAII destructors).
+
+Fix C in this review updates the plan file accordingly.
+
+---
+
+## 4. Vulkan-hpp Migration
+
+`VULKAN_HPP_MIGRATION_PLAN.md` is in progress. Concrete remaining offenders
+spotted in the tree:
+
+- `src/ml/GPUInference.cpp` — pure C API, init/destroy pattern.
+  Self-contained. Strong candidate for the **next** migration unit.
+- `src/postprocess/BloomSystem.cpp:285-286` — `vkDestroyFramebuffer`,
+  `vkDestroyImageView`.
+- `src/postprocess/GodRaysSystem.cpp:163,167,183` — `vkDestroyShaderModule`,
+  `vkDestroyImageView`.
+- `src/postprocess/ComputeBloomSystem.cpp:221,225,260` —
+  `vkDestroyShaderModule`.
+- `src/gui/GuiSystem.cpp:152` — `vkDestroyDescriptorPool`.
+- `src/debug/GpuProfiler.cpp:138` — `vkDestroyQueryPool`.
+
+**Recommendation:** pick `GPUInference` next (smallest blast radius,
+eliminates init/destroy at the same time). Leave the one-line `vkDestroy*`
+calls until those systems adopt `VulkanRAII` wrappers — migrating them in
+isolation adds churn without structural benefit.
+
+---
+
+## 5. ECS — Parallel Infrastructure, Dormant in Rendering
+
+`src/ecs/` is ~3,000 lines of EnTT-backed infrastructure (`Components.h`
+959, `Systems.h` 656, `EntityFactory.h` 617). There are 237 references to
+`ecsWorld` / `ecs::World` across the codebase, but the hot concentrations
+are in `NPCSimulation`, `SceneControlSubsystem`, and `ECSMaterialDemo`.
+
+The render path does **not** iterate ECS components. `Renderer` stores
+`ecsWorld_` via `setECSWorld()`, but passes still walk legacy `Renderable*`
+collections from `SceneManager`. `Application` even keeps a
+`scenePhysicsBodies` vector alongside ECS.
+
+**Recommendation:** `ECS_MIGRATION_PLAN.md` Phase 1 is the blocker. Either
+commit to migrating one render pass (e.g. static scene objects) end-to-end
+as a proof point, or be explicit that ECS is scoped to NPC/gameplay and
+will not drive rendering. The worst outcome is leaving both systems in
+place indefinitely.
+
+---
+
+## 6. Convention Violations (Concrete)
+
+**`src/core/asset/AssetRegistry.h:196` + `AssetRegistry.cpp:181`** — the
+method is named `loadShader()`, directly contradicting `CLAUDE.md`'s rule:
+*"There is NO `loadShader` method."* No external callers exist. Fix A in
+this review renames it to `loadShaderModule` to match
+`ShaderLoader::loadShaderModule`.
+
+**`src/water/FlowMapGenerator.cpp:263-283`** — hand-rolled bilinear sample
+plus `float worldHeight = h * heightScale;`. Duplicates both the formula
+and the bilinear helper from `src/terrain/TerrainHeight.h`. `CLAUDE.md`
+explicitly forbids this. Fix B replaces the block with
+`TerrainHeight::sampleWorldHeight(...)`.
+
+**`src/controls/*ControlSubsystem.h`** — 7 subsystems inherit from
+`IControl*` interfaces. Called out but **not** changed: single-level
+interface inheritance for polymorphism is a reasonable exception to
+*"prefer composition"* and the churn would outweigh the benefit.
+
+---
+
+## 7. File-Size Outliers
+
+Top six by line count:
+
+| File | Lines |
+|------|-------|
+| `src/scene/Application.cpp` | 1574 |
+| `src/scene/SceneBuilder.cpp` | 1311 |
+| `src/animation/MotionDatabase.cpp` | 1179 |
+| `src/loaders/FBXLoader.cpp` | 1071 |
+| `src/vegetation/TreeRenderer.cpp` | 1064 |
+| `src/animation/AnimatedCharacter.cpp` | 1034 |
+| `src/vegetation/TreeLeafCulling.cpp` | 1042 |
+| `src/core/Renderer.cpp` | 1017 |
+
+`Application.cpp` is the clearest candidate to split — it mixes input
+routing, physics sync, GUI toggling, frame submission, and player state.
+`FBXLoader` and `MotionDatabase` are naturally large (format/algorithm
+code) and less worth splitting unless a specific pain point emerges.
+
+---
+
+## 8. Documentation Sprawl
+
+`docs/` contains 27 markdown files, many overlapping PLAN/ANALYSIS/PROPOSAL
+documents. The duplication makes it hard to tell which plans are current:
+
+- `PLAN.md`, `ARCHITECTURE.md` — current reference
+- `PLAN-eliminate-two-phase-init.md` — marked complete (disputed, §3)
+- `RAII_REFACTOR_PLAN.md` — in progress
+- `VULKAN_HPP_MIGRATION_PLAN.md` — in progress
+- `ECS_MIGRATION_PLAN.md` — Phase 1 incomplete
+- `RENDERER_REFACTORING_PLAN.md` — partial
+- `WATER_AAA_MIGRATION_PLAN.md` — phases 1-6 done
+- `VIRTUAL_TEXTURING_PLAN.md` — phases 1-6 done
+- plus `UNICON_PLAN.md`, `ECS_TREES_PLAN.md`, `SPEEDTREE_ENHANCEMENT_PLAN.md`,
+  `STREAMING_COMPARISON_AND_PLAN.md`, `WATER_RENDERING_PLAN.md`, etc.
+
+**Recommendation:** add a one-line `Status:` header to every plan (Active /
+Complete / Superseded) and move completed plans to `docs/archive/`. Cheap,
+high value for anyone navigating the tree.
+
+---
+
+## Prioritized Punch List
+
+### Applied in this review
+- **A.** Rename `AssetRegistry::loadShader` → `loadShaderModule`.
+- **B.** Replace `FlowMapGenerator.cpp:263-283` with
+  `TerrainHeight::sampleWorldHeight`.
+- **C.** Update `PLAN-eliminate-two-phase-init.md` with a residual-work
+  section.
+
+### Recommended next (not applied here)
+1. Migrate `ml/GPUInference` to vulkan-hpp + RAII — smallest unit that
+   resolves init/destroy and raw-C-API in one step.
+2. Decide FrameGraph's future: real parallel scheduling, or documentation
+   downgrade.
+3. ECS: commit one render pass end-to-end, or scope ECS to gameplay only.
+4. Split `Application.cpp` along input / physics-sync / frame-submit seams.
+5. Audit the 19 `destroy()`/`shutdown()` headers; convert the genuine
+   two-phase cases to RAII destructors.
+6. Add `Status:` headers to all `docs/*PLAN*.md` and archive completed ones.

--- a/src/core/asset/AssetRegistry.cpp
+++ b/src/core/asset/AssetRegistry.cpp
@@ -178,7 +178,7 @@ std::shared_ptr<Mesh> AssetRegistry::getMesh(const std::string& name) {
 // Shader Management
 // ============================================================================
 
-std::shared_ptr<AssetRegistry::ShaderModule> AssetRegistry::loadShader(const std::string& path) {
+std::shared_ptr<AssetRegistry::ShaderModule> AssetRegistry::loadShaderModule(const std::string& path) {
     // Check cache first
     if (auto cached = shaderCache_.get(path)) {
         return cached;

--- a/src/core/asset/AssetRegistry.h
+++ b/src/core/asset/AssetRegistry.h
@@ -193,7 +193,7 @@ public:
      * Load a shader module from file with caching.
      * Returns shared_ptr to RAII wrapper - shader destroyed when last ref released.
      */
-    std::shared_ptr<ShaderModule> loadShader(const std::string& path);
+    std::shared_ptr<ShaderModule> loadShaderModule(const std::string& path);
 
     /**
      * Get shader by path. Returns nullptr if not found or expired.

--- a/src/water/FlowMapGenerator.cpp
+++ b/src/water/FlowMapGenerator.cpp
@@ -3,6 +3,7 @@
 #include "SamplerFactory.h"
 #include "CommandBufferUtils.h"
 #include "core/ImageBuilder.h"
+#include "TerrainHeight.h"
 #include <SDL3/SDL.h>
 #include <vulkan/vulkan.hpp>
 #include <cstring>
@@ -256,31 +257,11 @@ bool FlowMapGenerator::generateSlopeBasedFlow(const std::vector<float>& heightDa
 
     for (uint32_t y = 0; y < res; y++) {
         for (uint32_t x = 0; x < res; x++) {
-            // Sample height from heightmap (bilinear)
             float u = static_cast<float>(x) / (res - 1);
             float v = static_cast<float>(y) / (res - 1);
 
-            // Bilinear sample from heightmap
-            float hx = u * (heightmapSize - 1);
-            float hy = v * (heightmapSize - 1);
-            uint32_t x0 = static_cast<uint32_t>(hx);
-            uint32_t y0 = static_cast<uint32_t>(hy);
-            uint32_t x1 = std::min(x0 + 1, heightmapSize - 1);
-            uint32_t y1 = std::min(y0 + 1, heightmapSize - 1);
-            float fx = hx - x0;
-            float fy = hy - y0;
-
-            float h00 = heightData[y0 * heightmapSize + x0];
-            float h10 = heightData[y0 * heightmapSize + x1];
-            float h01 = heightData[y1 * heightmapSize + x0];
-            float h11 = heightData[y1 * heightmapSize + x1];
-
-            float h = (h00 * (1 - fx) * (1 - fy) +
-                      h10 * fx * (1 - fy) +
-                      h01 * (1 - fx) * fy +
-                      h11 * fx * fy);
-
-            float worldHeight = h * heightScale;
+            float worldHeight = TerrainHeight::sampleWorldHeight(
+                u, v, heightData.data(), heightmapSize, heightScale);
             uint32_t idx = y * res + x;
             heights[idx] = worldHeight;
             waterMask[idx] = (worldHeight < config.waterLevel);


### PR DESCRIPTION
## Summary

This PR documents the results of an architectural review of the rendering engine and applies three concrete fixes to address documentation drift and convention violations.

The review identified that several in-flight refactoring efforts (two-phase init elimination, FrameGraph scheduling, Vulkan-hpp migration, ECS integration) are marked as complete in documentation but still have significant residual work. The biggest risk is readers trusting outdated status markers and discovering the patterns they're meant to avoid are still widespread.

## Changes

**Documentation:**
- Add comprehensive `docs/REVIEW-ARCHITECTURE.md` documenting the current state of major subsystems, identifying 8 key areas of concern, and providing a prioritized punch list for future work
- Update `docs/PLAN-eliminate-two-phase-init.md` to reflect actual status (IN PROGRESS, not COMPLETE) and add a detailed residual-work section that audits all 19 remaining `destroy()`/`shutdown()` methods, classifying each as either legitimate drain/join APIs or genuine two-phase holdovers needing conversion

**Code fixes:**
- Rename `AssetRegistry::loadShader()` → `loadShaderModule()` to match the convention established in `ShaderLoader` and comply with `CLAUDE.md` rule forbidding a `loadShader` method
- Replace hand-rolled bilinear sampling and height-scaling logic in `FlowMapGenerator.cpp:263-283` with call to `TerrainHeight::sampleWorldHeight()`, eliminating code duplication flagged in `CLAUDE.md`

## Notable Details

The review identifies that while the engine is well-structured with deliberate design (system registries, RAII wrappers, FrameGraph abstraction), several migrations are mid-flight with overstated completion claims:
- 19 headers still expose `destroy()`/`shutdown()` despite "COMPLETE" status
- FrameGraph advertises parallel execution that isn't implemented
- ~399 raw `vk*` call sites remain despite ongoing vulkan-hpp migration
- ECS infrastructure exists but render path still uses legacy `Renderable*` collections

The residual-work section in the updated plan provides a verification command and clear next steps for whoever tackles these items next.

https://claude.ai/code/session_01RbA5tCw5Sk25k4fP4y7YoH