### PR TITLE
Add write-after-read barriers for recycled buffer sets

### DIFF
--- a/src/atmosphere/WeatherSystem.cpp
+++ b/src/atmosphere/WeatherSystem.cpp
@@ -402,8 +402,14 @@ void WeatherSystem::recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameInd
         .writeBuffer(4, externalWindBuffers[frameIndex], 0, 32)  // sizeof(WindUniforms)
         .update();
 
-    // Reset indirect buffer before compute dispatch
     vk::CommandBuffer vkCmd(cmd);
+
+    // Write-after-read: this recycled buffer set was read by the previous
+    // frame's indirect draws + vertex shader. Ensure those reads complete
+    // before we reset (transfer) and overwrite (compute) it.
+    BarrierHelpers::indirectDrawAndShaderToComputeWrite(vkCmd);
+
+    // Reset indirect buffer before compute dispatch
     vkCmd.fillBuffer(indirectBuffers.buffers[writeSet], 0, sizeof(VkDrawIndirectCommand), 0);
     BarrierHelpers::fillBufferToCompute(vkCmd);
 

--- a/src/core/vulkan/BarrierHelpers.h
+++ b/src/core/vulkan/BarrierHelpers.h
@@ -275,6 +275,39 @@ inline void computeToIndirectDrawAndShader(vk::CommandBuffer cmd) {
 }
 
 /**
+ * Write-after-read barrier for a recycled (double/triple-buffered) buffer set.
+ *
+ * When buffer sets rotate, the set written by frame N's compute is the same
+ * one that frame N-1's indirect draws + vertex-shader storage reads consumed.
+ * Before frame N overwrites it (fillBuffer reset on transfer, then compute
+ * write), the previous frame's reads must have completed. A WAR hazard needs
+ * only an execution dependency, so no memory/access masks are required.
+ *
+ * Pair with computeToIndirectDrawAndShader (indirect command + storage buffer
+ * read in the vertex shader).
+ */
+inline void indirectDrawAndShaderToComputeWrite(vk::CommandBuffer cmd) {
+    cmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eDrawIndirect | vk::PipelineStageFlagBits::eVertexShader,
+        vk::PipelineStageFlagBits::eTransfer | vk::PipelineStageFlagBits::eComputeShader,
+        {}, {}, {}, {});
+}
+
+/**
+ * Write-after-read barrier for a recycled buffer set consumed via the
+ * vertex-input stage (vertex attribute / index reads).
+ *
+ * Pair with computeToIndirectDrawAndVertex. See
+ * indirectDrawAndShaderToComputeWrite for the hazard description.
+ */
+inline void indirectDrawAndVertexToComputeWrite(vk::CommandBuffer cmd) {
+    cmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eDrawIndirect | vk::PipelineStageFlagBits::eVertexInput,
+        vk::PipelineStageFlagBits::eTransfer | vk::PipelineStageFlagBits::eComputeShader,
+        {}, {}, {}, {});
+}
+
+/**
  * Buffer barrier between compute passes
  */
 inline void bufferComputeToCompute(

--- a/src/ecs/EntityFactory.h
+++ b/src/ecs/EntityFactory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "World.h"
 #include "Components.h"
 #include "material/MaterialId.h"

--- a/src/vegetation/GrassComputePass.cpp
+++ b/src/vegetation/GrassComputePass.cpp
@@ -187,6 +187,11 @@ void GrassComputePass::recordResetAndCompute(vk::CommandBuffer cmd, uint32_t fra
     cmd.pipelineBarrier(vk::PipelineStageFlagBits::eHost, vk::PipelineStageFlagBits::eComputeShader,
                         {}, hostBarrier, {}, {});
 
+    // Write-after-read: this recycled buffer set was read by the previous
+    // frame's indirect draws + vertex shader. Ensure those reads complete
+    // before we reset (transfer) and overwrite (compute) it.
+    BarrierHelpers::indirectDrawAndShaderToComputeWrite(cmd);
+
     // Reset indirect buffer before compute dispatch
     cmd.fillBuffer(buffers.indirectBuffers().buffers[writeSet], 0, sizeof(VkDrawIndirectCommand), 0);
     BarrierHelpers::fillBufferToCompute(cmd);

--- a/src/vegetation/LeafSystem.cpp
+++ b/src/vegetation/LeafSystem.cpp
@@ -532,6 +532,11 @@ void LeafSystem::recordResetAndCompute(VkCommandBuffer cmd, uint32_t frameIndex,
     vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eHost, vk::PipelineStageFlagBits::eComputeShader,
                           {}, hostBarrier, {}, {});
 
+    // Write-after-read: this recycled buffer set was read by the previous
+    // frame's indirect draws + vertex input. Ensure those reads complete
+    // before we reset (transfer) and overwrite (compute) it.
+    BarrierHelpers::indirectDrawAndVertexToComputeWrite(vkCmd);
+
     // Reset indirect buffer before compute dispatch
     vkCmd.fillBuffer(indirectBuffers.buffers[writeSet], 0, sizeof(VkDrawIndirectCommand), 0);
     BarrierHelpers::fillBufferToCompute(vkCmd);


### PR DESCRIPTION
## Summary
Adds synchronization barriers to prevent write-after-read (WAR) hazards when recycled (double/triple-buffered) buffer sets are reused across frames. These barriers ensure that previous frame reads complete before the current frame overwrites the buffers.

## Changes
- **BarrierHelpers.h**: Added two new barrier helper functions:
  - `indirectDrawAndShaderToComputeWrite()`: WAR barrier for buffers consumed by indirect draws and vertex shader storage reads
  - `indirectDrawAndVertexToComputeWrite()`: WAR barrier for buffers consumed by indirect draws and vertex input (attribute/index) reads
  - Both functions use execution-only dependencies (no memory/access masks) since WAR hazards only require ordering

- **WeatherSystem.cpp**: Inserted `indirectDrawAndShaderToComputeWrite()` barrier before resetting and rewriting the indirect buffer

- **GrassComputePass.cpp**: Inserted `indirectDrawAndShaderToComputeWrite()` barrier before resetting and rewriting the indirect buffer

- **LeafSystem.cpp**: Inserted `indirectDrawAndVertexToComputeWrite()` barrier before resetting and rewriting the indirect buffer

## Implementation Details
The barriers address a specific synchronization pattern: when buffer sets rotate in a recycled pool, the set written by frame N's compute shader is the same one consumed by frame N-1's indirect draws and shader reads. Before frame N can overwrite it (via transfer fillBuffer and compute write), frame N-1's reads must complete. These are paired with existing `computeToIndirectDrawAndShader()` and `computeToIndirectDrawAndVertex()` barriers to form complete synchronization cycles.

https://claude.ai/code/session_01HnDfnZswebVgWWUee4vjy3