### PR TITLE
Fix WSI hazard: move render-finished semaphores to per-image indexing

### DIFF
--- a/src/core/FrameExecutor.cpp
+++ b/src/core/FrameExecutor.cpp
@@ -12,8 +12,26 @@ bool FrameExecutor::init(VulkanContext* ctx, uint32_t frameCount) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "FrameExecutor::init: failed to create sync objects");
         return false;
     }
+    // Present-wait semaphores are sized to the swapchain image count, not the
+    // frame-in-flight count (see TripleBuffering binary-semaphore notes).
+    if (!ensurePresentSemaphores()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "FrameExecutor::init: failed to create present semaphores");
+        return false;
+    }
     SDL_Log("FrameExecutor initialized (%u frames in flight)", frameCount);
     return true;
+}
+
+bool FrameExecutor::ensurePresentSemaphores() {
+    uint32_t imageCount = vulkanContext_->getSwapchainImageCount();
+    if (imageCount == 0) {
+        // Swapchain not ready yet (e.g. minimized); nothing to create.
+        return true;
+    }
+    if (frameSync_.presentSemaphoreCount() == imageCount) {
+        return true;
+    }
+    return frameSync_.initPresentSemaphores(imageCount);
 }
 
 void FrameExecutor::destroy() {
@@ -31,6 +49,11 @@ FrameResult FrameExecutor::execute(const FrameBuilder& builder) {
 
     VkExtent2D extent = vulkanContext_->getVkSwapchainExtent();
     if (extent.width == 0 || extent.height == 0) return FrameResult::Skipped;
+
+    // A swapchain recreate (resize) can change the image count. The recreate
+    // path waits for device idle, so it is safe to resize the per-image
+    // present-wait semaphores here before any submit/present this frame.
+    if (!ensurePresentSemaphores()) return FrameResult::Skipped;
 
     // Wait for this frame slot to be available
     frameSync_.waitForCurrentFrameIfNeeded();
@@ -50,7 +73,7 @@ FrameResult FrameExecutor::execute(const FrameBuilder& builder) {
     }
 
     // Submit
-    FrameResult submitResult = submitCommandBuffer(cmd);
+    FrameResult submitResult = submitCommandBuffer(cmd, imageIndex);
     if (submitResult != FrameResult::Success) return submitResult;
 
     // Present
@@ -90,14 +113,16 @@ FrameResult FrameExecutor::acquireImage(uint32_t& imageIndex) {
     return FrameResult::Success;
 }
 
-FrameResult FrameExecutor::submitCommandBuffer(VkCommandBuffer cmd) {
+FrameResult FrameExecutor::submitCommandBuffer(VkCommandBuffer cmd, uint32_t imageIndex) {
     VkQueue graphicsQueue = vulkanContext_->getVkGraphicsQueue();
     vk::CommandBuffer vkCmd(cmd);
 
     vk::Semaphore waitSemaphores[] = {frameSync_.currentImageAvailableSemaphore()};
     vk::PipelineStageFlags waitStages[] = {vk::PipelineStageFlagBits::eColorAttachmentOutput};
+    // Present-wait semaphore is keyed by swapchain image index (not frame slot)
+    // so a pending present is never left waiting on a re-signaled semaphore.
     vk::Semaphore signalSemaphores[] = {
-        frameSync_.currentRenderFinishedSemaphore(),
+        frameSync_.renderFinishedSemaphoreForImage(imageIndex),
         frameSync_.frameTimelineSemaphore()
     };
 
@@ -135,7 +160,7 @@ FrameResult FrameExecutor::present(uint32_t imageIndex) {
     VkQueue presentQueue = vulkanContext_->getVkPresentQueue();
     VkSwapchainKHR swapchain = vulkanContext_->getVkSwapchain();
 
-    vk::Semaphore waitSemaphores[] = {frameSync_.currentRenderFinishedSemaphore()};
+    vk::Semaphore waitSemaphores[] = {frameSync_.renderFinishedSemaphoreForImage(imageIndex)};
     vk::SwapchainKHR swapChains[] = {swapchain};
 
     auto presentInfo = vk::PresentInfoKHR{}

--- a/src/core/FrameExecutor.h
+++ b/src/core/FrameExecutor.h
@@ -69,8 +69,13 @@ public:
 
 private:
     FrameResult acquireImage(uint32_t& imageIndex);
-    FrameResult submitCommandBuffer(VkCommandBuffer cmd);
+    FrameResult submitCommandBuffer(VkCommandBuffer cmd, uint32_t imageIndex);
     FrameResult present(uint32_t imageIndex);
+
+    // Ensure the per-image present-wait semaphores match the current swapchain
+    // image count (recreates them on first use and after a resize that changes
+    // the image count). Returns false if creation failed.
+    bool ensurePresentSemaphores();
 
     TripleBuffering frameSync_;
     VulkanContext* vulkanContext_ = nullptr;

--- a/src/core/TripleBuffering.cpp
+++ b/src/core/TripleBuffering.cpp
@@ -48,9 +48,10 @@ bool TripleBuffering::init(const vk::raii::Device& device, uint32_t frameCount) 
             FrameSyncPrimitives primitives;
 
             try {
-                // Binary semaphores for swapchain acquire/present
+                // Binary semaphore for swapchain acquire (per frame-in-flight slot).
+                // The present-wait (render-finished) semaphore is per swapchain
+                // image instead — see initPresentSemaphores().
                 primitives.imageAvailable.emplace(device, vk::SemaphoreCreateInfo{});
-                primitives.renderFinished.emplace(device, vk::SemaphoreCreateInfo{});
             } catch (const vk::SystemError& e) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                     "TripleBuffering::init: failed to create semaphores for frame %u: %s", i, e.what());
@@ -68,7 +69,7 @@ bool TripleBuffering::init(const vk::raii::Device& device, uint32_t frameCount) 
     // Verify all primitives were created successfully
     for (uint32_t i = 0; i < frameCount; ++i) {
         const auto& p = frames_[i];
-        if (!p.imageAvailable || !p.renderFinished) {
+        if (!p.imageAvailable) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                 "TripleBuffering::init: incomplete primitives for frame %u", i);
             destroy();
@@ -80,9 +81,42 @@ bool TripleBuffering::init(const vk::raii::Device& device, uint32_t frameCount) 
     return true;
 }
 
+bool TripleBuffering::initPresentSemaphores(uint32_t imageCount) {
+    if (!device_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "TripleBuffering::initPresentSemaphores: called before init()");
+        return false;
+    }
+    if (imageCount == 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "TripleBuffering::initPresentSemaphores: imageCount must be > 0");
+        return false;
+    }
+
+    // Recreate from scratch; RAII destroys any previous semaphores. Callers must
+    // ensure the device is idle (e.g. after a swapchain recreate) before resizing
+    // this set, since outstanding presents may still reference the old semaphores.
+    presentSemaphores_.clear();
+    presentSemaphores_.reserve(imageCount);
+    try {
+        for (uint32_t i = 0; i < imageCount; ++i) {
+            presentSemaphores_.emplace_back(*device_, vk::SemaphoreCreateInfo{});
+        }
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+            "TripleBuffering::initPresentSemaphores: failed to create semaphores: %s", e.what());
+        presentSemaphores_.clear();
+        return false;
+    }
+
+    SDL_Log("TripleBuffering: created %u per-image present-wait semaphores", imageCount);
+    return true;
+}
+
 void TripleBuffering::destroy() {
     // RAII handles cleanup - just clear containers and reset pointers
     frames_.clear();
+    presentSemaphores_.clear();
     frameTimeline_.reset();
     frameSignalValues_.fill(0);
     globalFrameCounter_ = 0;

--- a/src/core/TripleBuffering.h
+++ b/src/core/TripleBuffering.h
@@ -38,7 +38,6 @@
 
 struct FrameSyncPrimitives {
     std::optional<vk::raii::Semaphore> imageAvailable;     // Binary semaphore for swapchain acquire
-    std::optional<vk::raii::Semaphore> renderFinished;     // Binary semaphore for present
 
     // Non-copyable (Vulkan resources)
     FrameSyncPrimitives() = default;
@@ -165,24 +164,42 @@ public:
     // =========================================================================
     // Synchronization - Binary Semaphores (for swapchain)
     // =========================================================================
+    //
+    // The image-available semaphore is per-frame-in-flight slot: it is signaled
+    // by vkAcquireNextImageKHR before the image index is known, so it must be
+    // tied to the frame slot.
+    //
+    // The render-finished (present-wait) semaphore is per *swapchain image*, NOT
+    // per frame slot. Present completion is not tracked by the frame timeline
+    // semaphore, so a per-slot semaphore could be re-signaled by a new submit
+    // while an earlier present is still waiting on it (the classic WSI hazard the
+    // validation layers flag as VUID-vkQueuePresentKHR / sync-hazard). Indexing
+    // by image index is safe because the presentation engine cannot return an
+    // image from vkAcquireNextImageKHR until its previous present has completed.
+
+    // (Re)create the per-image present-wait semaphores. Call once the swapchain
+    // image count is known, and again on resize if the image count changed.
+    // Requires init() to have been called first (needs a valid device).
+    bool initPresentSemaphores(uint32_t imageCount);
+
+    // Number of per-image present-wait semaphores currently allocated
+    uint32_t presentSemaphoreCount() const {
+        return static_cast<uint32_t>(presentSemaphores_.size());
+    }
 
     // Get image available semaphore for current frame
     VkSemaphore currentImageAvailableSemaphore() const {
         return **frames_.current().imageAvailable;
     }
 
-    // Get render finished semaphore for current frame
-    VkSemaphore currentRenderFinishedSemaphore() const {
-        return **frames_.current().renderFinished;
+    // Get the render-finished (present-wait) semaphore for a swapchain image
+    VkSemaphore renderFinishedSemaphoreForImage(uint32_t imageIndex) const {
+        return *presentSemaphores_[imageIndex];
     }
 
-    // Get semaphores for any frame index
+    // Get image available semaphore for any frame index
     VkSemaphore imageAvailableSemaphore(uint32_t frameIndex) const {
         return **frames_.at(frameIndex).imageAvailable;
-    }
-
-    VkSemaphore renderFinishedSemaphore(uint32_t frameIndex) const {
-        return **frames_.at(frameIndex).renderFinished;
     }
 
     // =========================================================================
@@ -228,6 +245,11 @@ private:
 
     // Timeline semaphore for frame completion tracking (Vulkan 1.2)
     std::optional<vk::raii::Semaphore> frameTimeline_;
+
+    // Per-swapchain-image present-wait (render-finished) binary semaphores.
+    // Indexed by swapchain image index, not frame-in-flight slot. See the
+    // binary-semaphore section above for the WSI hazard this avoids.
+    std::vector<vk::raii::Semaphore> presentSemaphores_;
 
     // Per-frame signal values (what value was signaled when this frame was submitted)
     std::array<uint64_t, 8> frameSignalValues_{};  // Supports up to 8 frames in flight


### PR DESCRIPTION
## Summary

Fixes a Vulkan synchronization hazard in the WSI (Window System Integration) present path by changing how render-finished semaphores are managed. Previously, these semaphores were indexed by frame-in-flight slot, which could cause a pending present to wait on a semaphore that gets re-signaled by a new frame submission—the classic WSI hazard flagged by validation layers.

The fix indexes render-finished semaphores by swapchain image index instead of frame slot. This is safe because the presentation engine cannot return an image from `vkAcquireNextImageKHR` until its previous present has completed, guaranteeing no re-signaling hazard.

## Key Changes

- **TripleBuffering**: Removed `renderFinished` semaphore from `FrameSyncPrimitives` (per-frame-slot structure)
- **TripleBuffering**: Added `initPresentSemaphores(imageCount)` method to create per-image present-wait semaphores
- **TripleBuffering**: Added `presentSemaphores_` vector indexed by swapchain image index
- **TripleBuffering**: Replaced `currentRenderFinishedSemaphore()` and `renderFinishedSemaphore(frameIndex)` with `renderFinishedSemaphoreForImage(imageIndex)`
- **FrameExecutor**: Added `ensurePresentSemaphores()` to lazily initialize and resize present semaphores when swapchain image count changes
- **FrameExecutor**: Updated `submitCommandBuffer()` and `present()` to use image-indexed semaphores
- **FrameExecutor**: Call `ensurePresentSemaphores()` during init and before each frame execute to handle swapchain resizes

## Implementation Details

- Image-available semaphores remain per-frame-slot (signaled before image index is known)
- Present-wait semaphores are now per-swapchain-image (indexed by image index, not frame slot)
- Semaphore recreation is safe after device idle (e.g., during swapchain recreate on resize)
- Added comprehensive comments explaining the WSI hazard and why per-image indexing is required

https://claude.ai/code/session_01KK3NnKhz8TF66PvgT2A6Ao