### PR TITLE
Fix lost-wakeup race in TaskGroup::decrement()

### DIFF
--- a/src/core/threading/TaskScheduler.h
+++ b/src/core/threading/TaskScheduler.h
@@ -24,6 +24,11 @@ public:
 
     void decrement() {
         if (--pendingCount_ == 0) {
+            // Take the same mutex the waiter holds during its predicate check.
+            // Without this, a decrement-to-zero can land between wait()'s
+            // predicate evaluation and its block, losing the notification and
+            // hanging the waiter forever (lost-wakeup race).
+            std::lock_guard<std::mutex> lock(mutex_);
             cv_.notify_all();
         }
     }

--- a/src/ecs/EntityFactory.h
+++ b/src/ecs/EntityFactory.h
@@ -4,6 +4,9 @@
 #include "Components.h"
 #include "material/MaterialId.h"
 
+#include <cassert>
+#include <optional>
+
 namespace ecs {
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Fixes a critical race condition in the task scheduling system where a decrement-to-zero notification could be lost, causing waiters to hang indefinitely.

## Key Changes
- **TaskScheduler.h**: Added mutex lock in `TaskGroup::decrement()` to synchronize with the condition variable's predicate check. The lock ensures that the notification cannot land between a waiter's predicate evaluation and its blocking wait, eliminating the lost-wakeup race condition.
- **EntityFactory.h**: Added missing includes (`<cassert>` and `<optional>`) for proper compilation.

## Implementation Details
The fix applies the standard pattern for condition variable usage: the same mutex that protects the predicate must be held during both the predicate check and the wait operation. Without the lock in `decrement()`, a race window exists where:
1. Waiter evaluates predicate (pendingCount_ != 0)
2. Decrement thread decrements to zero and calls `notify_all()`
3. Waiter enters wait() but misses the notification
4. Waiter hangs forever

The `std::lock_guard` ensures atomicity between the decrement and notification with respect to the waiter's predicate evaluation.

https://claude.ai/code/session_01F3M5FscoGRYnJf12yQ5DUB