### PR TITLE
Fix inverted third-person movement; controls and camera polish

### DIFF
--- a/src/scene/Application.cpp
+++ b/src/scene/Application.cpp
@@ -612,7 +612,7 @@ void Application::run() {
         gui_->render(guiInterfaces, camera, lastDeltaTime, currentFps);
 
         // Update input system
-        input.update(deltaTime, camera.getYaw());
+        input.update(deltaTime, camera.getForward());
 
         // Apply input to camera
         applyInputToCamera();
@@ -653,8 +653,10 @@ void Application::run() {
             }
 
             glm::vec3 moveDir = input.getMovementDirection();
-            if (glm::length(moveDir) > 0.001f) {
-                moveDir = glm::normalize(moveDir);
+            float moveLen = glm::length(moveDir);
+            if (moveLen > 0.001f) {
+                // Clamp rather than normalize so analog stick magnitude scales speed
+                if (moveLen > 1.0f) moveDir /= moveLen;
                 float currentSpeed = input.isSprinting() ? sprintSpeed : moveSpeed;
                 desiredVelocity = moveDir * currentSpeed;
 
@@ -674,7 +676,7 @@ void Application::run() {
                     float yawRate = (sceneBuilder.hasCharacter() &&
                                      sceneBuilder.getAnimatedCharacter().isUsingMotionMatching())
                                     ? 4.0f : 10.0f;
-                    float smoothedYaw = currentYaw + yawDiff * yawRate * deltaTime;
+                    float smoothedYaw = currentYaw + yawDiff * (1.0f - std::exp(-yawRate * deltaTime));
                     // Keep yaw in reasonable range
                     while (smoothedYaw > 360.0f) smoothedYaw -= 360.0f;
                     while (smoothedYaw < 0.0f) smoothedYaw += 360.0f;
@@ -704,7 +706,7 @@ void Application::run() {
                     while (yawDiff > 180.0f) yawDiff -= 360.0f;
                     while (yawDiff < -180.0f) yawDiff += 360.0f;
                     // Faster rotation for strafe mode responsiveness
-                    float smoothedYaw = currentYaw + yawDiff * 15.0f * deltaTime;
+                    float smoothedYaw = currentYaw + yawDiff * (1.0f - std::exp(-15.0f * deltaTime));
                     while (smoothedYaw > 360.0f) smoothedYaw -= 360.0f;
                     while (smoothedYaw < 0.0f) smoothedYaw += 360.0f;
                     playerTransform.setYaw(smoothedYaw);

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -177,8 +177,11 @@ void Camera::updateThirdPerson(float deltaTime) {
     pitch_ = smoothedPitch_;
     thirdPersonDistance_ = smoothedDistance_;
 
-    // Use collision-adjusted distance if set, otherwise use smoothed distance
-    float effectiveDistance = smoothedDistance_;
+    // Recover the collision distance toward the unobstructed distance each frame.
+    // Pull-in is instant (applyCollisionDistance), recovery is smoothed here.
+    collisionSmoothedDistance_ += (smoothedDistance_ - collisionSmoothedDistance_) * distanceFactor;
+    collisionSmoothedDistance_ = std::min(collisionSmoothedDistance_, smoothedDistance_);
+    float effectiveDistance = collisionSmoothedDistance_;
 
     // Calculate camera position based on smoothed spherical coordinates around target
     float horizontalDist = effectiveDistance * cos(glm::radians(smoothedPitch_));
@@ -196,12 +199,15 @@ void Camera::updateThirdPerson(float deltaTime) {
 }
 
 void Camera::applyCollisionDistance(float distance) {
-    // Apply collision adjustment - pull camera closer to avoid clipping
-    if (distance > 0.0f && distance < smoothedDistance_) {
+    // Pull camera closer to avoid clipping. Pull-in snaps immediately;
+    // recovery toward the unobstructed distance is smoothed in updateThirdPerson.
+    float desired = std::max(thirdPersonMinDistance_, distance - 0.2f);  // Small offset to avoid clipping
+    if (distance > 0.0f && desired < collisionSmoothedDistance_) {
         collisionAdjustedDistance_ = distance;
+        collisionSmoothedDistance_ = desired;
 
         // Recalculate position with adjusted distance
-        float effectiveDistance = std::max(thirdPersonMinDistance_, distance - 0.2f);  // Small offset to avoid clipping
+        float effectiveDistance = desired;
         float horizontalDist = effectiveDistance * cos(glm::radians(smoothedPitch_));
         float verticalOffset = effectiveDistance * sin(glm::radians(smoothedPitch_));
 
@@ -222,6 +228,7 @@ void Camera::resetSmoothing() {
     smoothedYaw_ = targetYaw_;
     smoothedPitch_ = targetPitch_;
     smoothedDistance_ = targetDistance_;
+    collisionSmoothedDistance_ = targetDistance_;
     currentFov_ = targetFov_;
 }
 
@@ -263,6 +270,7 @@ void Camera::initializeThirdPersonFromCurrentPosition(const glm::vec3& target) {
     smoothedPitch_ = calculatedPitch;
     targetDistance_ = distance;
     smoothedDistance_ = distance;
+    collisionSmoothedDistance_ = distance;
 
     // Also update the base yaw/pitch so getYaw() returns correct value
     yaw_ = calculatedYaw;

--- a/src/scene/Camera.h
+++ b/src/scene/Camera.h
@@ -152,4 +152,5 @@ private:
 
     // Camera collision
     float collisionAdjustedDistance_ = -1.0f;  // -1 means no collision adjustment
+    float collisionSmoothedDistance_ = 3.0f;   // pulls in instantly, recovers smoothly
 };

--- a/src/scene/InputSystem.cpp
+++ b/src/scene/InputSystem.cpp
@@ -1,6 +1,5 @@
 #include "InputSystem.h"
 #include "GuiSystem.h"
-#include <glm/gtc/quaternion.hpp>
 #include <cmath>
 
 InputSystem::InputSystem() {
@@ -92,7 +91,7 @@ bool InputSystem::processEvent(const SDL_Event& event) {
     return false;
 }
 
-void InputSystem::update(float deltaTime, float cameraYaw) {
+void InputSystem::update(float deltaTime, const glm::vec3& cameraForward) {
     // Reset input accumulators
     movementDirection = glm::vec3(0.0f);
     jumpRequested = false;
@@ -119,10 +118,10 @@ void InputSystem::update(float deltaTime, float cameraYaw) {
     keyboardState = SDL_GetKeyboardState(nullptr);
 
     // Process keyboard input
-    processKeyboardInput(deltaTime, cameraYaw);
+    processKeyboardInput(deltaTime, cameraForward);
 
     // Process gamepad input
-    processGamepadInput(deltaTime, cameraYaw);
+    processGamepadInput(deltaTime, cameraForward);
 }
 
 bool InputSystem::isKeyPressed(SDL_Scancode scancode) const {
@@ -137,11 +136,11 @@ bool InputSystem::isGuiBlocking() const {
     return false;
 }
 
-void InputSystem::processKeyboardInput(float deltaTime, float cameraYaw) {
+void InputSystem::processKeyboardInput(float deltaTime, const glm::vec3& cameraForward) {
     if (!keyboardState) return;
 
     if (thirdPersonMode) {
-        processThirdPersonKeyboard(deltaTime, cameraYaw, keyboardState);
+        processThirdPersonKeyboard(deltaTime, cameraForward, keyboardState);
     } else {
         processFreeCameraKeyboard(deltaTime, keyboardState);
     }
@@ -189,11 +188,11 @@ void InputSystem::processFreeCameraKeyboard(float deltaTime, const bool* keyStat
     }
 }
 
-void InputSystem::processThirdPersonKeyboard(float deltaTime, float cameraYaw, const bool* keyState) {
-    // Calculate movement direction based on camera facing using quaternion rotation
-    glm::quat yawRot = glm::angleAxis(glm::radians(cameraYaw), glm::vec3(0.0f, 1.0f, 0.0f));
-    glm::vec3 forward = yawRot * glm::vec3(1.0f, 0.0f, 0.0f);
-    glm::vec3 right = yawRot * glm::vec3(0.0f, 0.0f, 1.0f);
+void InputSystem::processThirdPersonKeyboard(float deltaTime, const glm::vec3& cameraForward, const bool* keyState) {
+    // Movement is relative to the camera: project its forward onto the ground
+    // plane (third-person pitch is clamped, so this never degenerates)
+    glm::vec3 forward = glm::normalize(glm::vec3(cameraForward.x, 0.0f, cameraForward.z));
+    glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3(0.0f, 1.0f, 0.0f)));
 
     glm::vec3 move(0.0f);
     if (keyState[SDL_SCANCODE_W]) move += forward;
@@ -250,11 +249,11 @@ void InputSystem::processThirdPersonKeyboard(float deltaTime, float cameraYaw, c
     orientationLockHeld = (mouseState & SDL_BUTTON_MMASK) != 0;
 }
 
-void InputSystem::processGamepadInput(float deltaTime, float cameraYaw) {
+void InputSystem::processGamepadInput(float deltaTime, const glm::vec3& cameraForward) {
     if (!gamepad) return;
 
     if (thirdPersonMode) {
-        processThirdPersonGamepad(deltaTime, cameraYaw);
+        processThirdPersonGamepad(deltaTime, cameraForward);
     } else {
         processFreeCameraGamepad(deltaTime);
     }
@@ -309,7 +308,7 @@ void InputSystem::processFreeCameraGamepad(float deltaTime) {
     }
 }
 
-void InputSystem::processThirdPersonGamepad(float deltaTime, float cameraYaw) {
+void InputSystem::processThirdPersonGamepad(float deltaTime, const glm::vec3& cameraForward) {
     // Left stick moves player relative to camera facing
     float leftX = SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTX) / 32767.0f;
     float leftY = SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_LEFTY) / 32767.0f;
@@ -318,11 +317,10 @@ void InputSystem::processThirdPersonGamepad(float deltaTime, float cameraYaw) {
     if (std::abs(leftX) < stickDeadzone) leftX = 0.0f;
     if (std::abs(leftY) < stickDeadzone) leftY = 0.0f;
 
-    // Accumulate movement direction from gamepad using quaternion rotation
+    // Accumulate movement direction relative to the camera's ground-plane facing
     if (leftX != 0.0f || leftY != 0.0f) {
-        glm::quat yawRot = glm::angleAxis(glm::radians(cameraYaw), glm::vec3(0.0f, 1.0f, 0.0f));
-        glm::vec3 forward = yawRot * glm::vec3(1.0f, 0.0f, 0.0f);
-        glm::vec3 right = yawRot * glm::vec3(0.0f, 0.0f, 1.0f);
+        glm::vec3 forward = glm::normalize(glm::vec3(cameraForward.x, 0.0f, cameraForward.z));
+        glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3(0.0f, 1.0f, 0.0f)));
 
         movementDirection += forward * (-leftY) + right * leftX;
     }

--- a/src/scene/InputSystem.h
+++ b/src/scene/InputSystem.h
@@ -21,8 +21,8 @@ public:
 
     // Update continuous input state (call once per frame before reading input)
     // deltaTime is used for input that accumulates over time
-    // cameraYaw is needed to calculate movement direction relative to camera facing
-    void update(float deltaTime, float cameraYaw);
+    // cameraForward is needed to calculate movement direction relative to camera facing
+    void update(float deltaTime, const glm::vec3& cameraForward);
 
     // Query if GUI wants input (blocks game input)
     void setGuiSystem(GuiSystem* gui) { guiSystem = gui; }
@@ -80,12 +80,12 @@ private:
     void scanForGamepads();
 
     // Input processing helpers
-    void processKeyboardInput(float deltaTime, float cameraYaw);
-    void processGamepadInput(float deltaTime, float cameraYaw);
+    void processKeyboardInput(float deltaTime, const glm::vec3& cameraForward);
+    void processGamepadInput(float deltaTime, const glm::vec3& cameraForward);
     void processFreeCameraKeyboard(float deltaTime, const bool* keyState);
-    void processThirdPersonKeyboard(float deltaTime, float cameraYaw, const bool* keyState);
+    void processThirdPersonKeyboard(float deltaTime, const glm::vec3& cameraForward, const bool* keyState);
     void processFreeCameraGamepad(float deltaTime);
-    void processThirdPersonGamepad(float deltaTime, float cameraYaw);
+    void processThirdPersonGamepad(float deltaTime, const glm::vec3& cameraForward);
 
     // Check if GUI is consuming input
     bool isGuiBlocking() const;


### PR DESCRIPTION
The trig-to-quaternion refactor (6c5a5e8) rotated the movement basis
about +Y, but the camera's yaw convention (front = (cos yaw, 0, sin yaw))
is a rotation about -Y, so camera-relative movement was mirrored: with
the camera behind the player, W walked toward the camera and A/D were
swapped. Derive the basis directly from the camera's forward vector
projected onto the ground plane instead of converting through a yaw
angle, so the two systems can no longer disagree about angle conventions.

Also:
- Preserve analog stick magnitude (clamp instead of normalize) so a
  half-tilted stick walks instead of running
- Make player yaw smoothing frame-rate independent using the same
  1-exp(-rate*dt) form the camera uses
- Smooth camera collision recovery: pull-in stays instant to avoid
  clipping, but the camera now eases back out when the obstacle clears

https://claude.ai/code/session_01AwhD1CyZGGkqP7p2tQuunB