### PR TITLE
Fix invisible water: init displacement maps, valid env cubemap placeholder

### DIFF
--- a/shaders/water_tile_cull.comp
+++ b/shaders/water_tile_cull.comp
@@ -38,9 +38,10 @@ layout(binding = BINDING_WATER_CULL_TILES, std430) writeonly buffer TileBuffer {
     TileData tiles[];
 };
 
-// Atomic counter for visible tiles
+// Atomic counter for visible tiles, one slot per frame-in-flight
+// (the CPU resets and reads back the slot for the current frame index)
 layout(binding = BINDING_WATER_CULL_COUNTER, std430) buffer CounterBuffer {
-    uint visibleCount;
+    uint visibleCounts[];
 };
 
 // Indirect draw command
@@ -67,7 +68,7 @@ layout(push_constant) uniform TileCullParams {
     float nearPlane;
     float farPlane;
     uint maxTiles;       // Output buffer capacity
-    uint _pad0;
+    uint frameIndex;     // Frame-in-flight index (selects counter slot)
 };
 
 // Check if a point is below water
@@ -157,7 +158,7 @@ void main() {
     uint baseIdx = 0;
     uint slotsAllocated = 0;
     if (visibleInSubgroup > 0 && subgroupElect()) {
-        uint expected = visibleCount;
+        uint expected = visibleCounts[frameIndex];
         while (true) {
             uint available = (expected >= maxTiles) ? 0 : maxTiles - expected;
             slotsAllocated = min(visibleInSubgroup, available);
@@ -166,7 +167,7 @@ void main() {
                 break;
             }
             uint desired = expected + slotsAllocated;
-            uint actual = atomicCompSwap(visibleCount, expected, desired);
+            uint actual = atomicCompSwap(visibleCounts[frameIndex], expected, desired);
             if (actual == expected) {
                 baseIdx = expected;
                 break;

--- a/src/water/WaterDisplacement.cpp
+++ b/src/water/WaterDisplacement.cpp
@@ -7,6 +7,7 @@
 #include "core/vulkan/PipelineLayoutBuilder.h"
 #include "core/vulkan/DescriptorSetLayoutBuilder.h"
 #include "core/vulkan/BarrierHelpers.h"
+#include "core/vulkan/CommandBufferUtils.h"
 #include "core/ImageBuilder.h"
 #include <SDL3/SDL_log.h>
 #include <vulkan/vulkan.hpp>
@@ -142,6 +143,39 @@ bool WaterDisplacement::createDisplacementMap() {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create displacement sampler");
         return false;
     }
+
+    // The water vertex shader samples the displacement map every frame, but the
+    // compute pass that writes it only runs when splash particles exist. Clear both
+    // maps to zero and move them to shader-read layout so they are valid to sample
+    // before (or without) any compute dispatch.
+    CommandScope initCmd(vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue));
+    if (!initCmd.begin()) {
+        return false;
+    }
+    for (VkImage image : {displacementMap, prevDisplacementMap}) {
+        BarrierHelpers::transitionImageLayout(initCmd.get(), image,
+            vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal,
+            vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
+            {}, vk::AccessFlagBits::eTransferWrite);
+
+        auto clearRange = vk::ImageSubresourceRange{}
+            .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setLevelCount(1)
+            .setLayerCount(1);
+        initCmd.get().clearColorImage(image, vk::ImageLayout::eTransferDstOptimal,
+                                      vk::ClearColorValue{0.0f, 0.0f, 0.0f, 0.0f}, clearRange);
+
+        BarrierHelpers::transitionImageLayout(initCmd.get(), image,
+            vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal,
+            vk::PipelineStageFlagBits::eTransfer,
+            vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eFragmentShader |
+                vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlagBits::eTransferWrite, vk::AccessFlagBits::eShaderRead);
+    }
+    if (!initCmd.end()) {
+        return false;
+    }
+
     return true;
 }
 

--- a/src/water/WaterDisplacement.cpp
+++ b/src/water/WaterDisplacement.cpp
@@ -148,7 +148,7 @@ bool WaterDisplacement::createDisplacementMap() {
     // compute pass that writes it only runs when splash particles exist. Clear both
     // maps to zero and move them to shader-read layout so they are valid to sample
     // before (or without) any compute dispatch.
-    CommandScope initCmd(vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue));
+    CommandScope initCmd{vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue)};
     if (!initCmd.begin()) {
         return false;
     }

--- a/src/water/WaterSystem.cpp
+++ b/src/water/WaterSystem.cpp
@@ -3,6 +3,8 @@
 #include "GraphicsPipelineFactory.h"
 #include "VmaBufferFactory.h"
 #include "DescriptorManager.h"
+#include "core/vulkan/BarrierHelpers.h"
+#include "core/vulkan/CommandBufferUtils.h"
 #include "debug/QueueSubmitDiagnostics.h"
 #include <vulkan/vulkan.hpp>
 #include <SDL3/SDL.h>
@@ -93,6 +95,7 @@ bool WaterSystem::initInternal(const InitInfo& info) {
     if (!createUniformBuffers()) return false;
     if (!loadFoamTexture()) return false;
     if (!loadCausticsTexture()) return false;
+    if (!createEnvPlaceholderCube()) return false;
 
     return true;
 }
@@ -103,6 +106,7 @@ void WaterSystem::cleanup() {
     // Destroy RAII-managed resources
     foamTexture.reset();
     causticsTexture.reset();
+    envPlaceholderCube_.reset();
     waterMesh.reset();
 
     // Destroy uniform buffers (RAII-managed)
@@ -383,6 +387,45 @@ bool WaterSystem::loadCausticsTexture() {
     return true;
 }
 
+bool WaterSystem::createEnvPlaceholderCube() {
+    ImageBuilder builder(allocator);
+    builder.setExtent(1, 1)
+           .setFormat(VK_FORMAT_R8G8B8A8_UNORM)
+           .asTexture()
+           .asCubeMap();
+    envPlaceholderCube_ = createImageWithView(*raiiDevice_, builder);
+    if (!envPlaceholderCube_.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create env placeholder cubemap");
+        return false;
+    }
+
+    // Clear all 6 faces to black and move to shader-read layout
+    CommandScope initCmd(vk::Device(device), vk::CommandPool(commandPool), vk::Queue(graphicsQueue));
+    if (!initCmd.begin()) {
+        return false;
+    }
+    BarrierHelpers::transitionImageLayout(initCmd.get(), envPlaceholderCube_.getImage(),
+        vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal,
+        vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
+        {}, vk::AccessFlagBits::eTransferWrite,
+        vk::ImageAspectFlagBits::eColor, 0, 1, 0, 6);
+
+    auto clearRange = vk::ImageSubresourceRange{}
+        .setAspectMask(vk::ImageAspectFlagBits::eColor)
+        .setLevelCount(1)
+        .setLayerCount(6);
+    initCmd.get().clearColorImage(envPlaceholderCube_.getImage(), vk::ImageLayout::eTransferDstOptimal,
+                                  vk::ClearColorValue{0.0f, 0.0f, 0.0f, 1.0f}, clearRange);
+
+    BarrierHelpers::transitionImageLayout(initCmd.get(), envPlaceholderCube_.getImage(),
+        vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eFragmentShader,
+        vk::AccessFlagBits::eTransferWrite, vk::AccessFlagBits::eShaderRead,
+        vk::ImageAspectFlagBits::eColor, 0, 1, 0, 6);
+
+    return initCmd.end();
+}
+
 bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
                                         VkDeviceSize uniformBufferSize,
                                         ShadowSystem& shadowSystem,
@@ -464,8 +507,9 @@ bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffe
         if (envCubemapView != VK_NULL_HANDLE && envCubemapSampler != VK_NULL_HANDLE) {
             writer.writeImage(22, envCubemapView, envCubemapSampler);
         } else {
-            // Use displacement map as placeholder (will fall back to procedural sky in shader)
-            writer.writeImage(22, displacementMapView, displacementMapSampler);
+            // Black 1x1 cube placeholder (shader falls back to procedural sky).
+            // Must be a cube view: the shader binding is samplerCube.
+            writer.writeImage(22, envPlaceholderCube_.getView(), foamTexture->getSampler());
         }
 
         writer.update();
@@ -531,10 +575,12 @@ void WaterSystem::recordDraw(VkCommandBuffer cmd, uint32_t frameIndex) {
         waterUniforms.waterExtent.y
     ));
     // useFFTOcean and oceanSize values are set via setUseFFTOcean()
-    // Push constants are used by vertex shader (non-tess) or both vertex + tess eval shaders
+    // Stage flags must match the pipeline layout's push constant range exactly
     vkCmd.pushConstants<PushConstants>(
         **pipelineLayout_,
-        vk::ShaderStageFlagBits::eVertex,
+        vk::ShaderStageFlagBits::eVertex |
+            vk::ShaderStageFlagBits::eTessellationControl |
+            vk::ShaderStageFlagBits::eTessellationEvaluation,
         0, pushConstants);
 
     // Bind water mesh and draw

--- a/src/water/WaterSystem.cpp
+++ b/src/water/WaterSystem.cpp
@@ -400,7 +400,7 @@ bool WaterSystem::createEnvPlaceholderCube() {
     }
 
     // Clear all 6 faces to black and move to shader-read layout
-    CommandScope initCmd(vk::Device(device), vk::CommandPool(commandPool), vk::Queue(graphicsQueue));
+    CommandScope initCmd{vk::Device(device), vk::CommandPool(commandPool), vk::Queue(graphicsQueue)};
     if (!initCmd.begin()) {
         return false;
     }

--- a/src/water/WaterSystem.h
+++ b/src/water/WaterSystem.h
@@ -15,6 +15,7 @@
 #include "DescriptorManager.h"
 #include "VmaBuffer.h"
 #include "core/FrameBuffered.h"
+#include "core/ImageBuilder.h"
 #include "material/MaterialComponents.h"
 #include "interfaces/IRecordable.h"
 
@@ -370,6 +371,7 @@ private:
     bool createUniformBuffers();
     bool loadFoamTexture();
     bool loadCausticsTexture();
+    bool createEnvPlaceholderCube();
 
     // Initialization info
     VkDevice device = VK_NULL_HANDLE;
@@ -410,6 +412,12 @@ private:
 
     // Caustics texture (Phase 9) - RAII-managed
     std::unique_ptr<Texture> causticsTexture;
+
+    // 1x1 black cubemap bound at binding 22 when no real environment cubemap is
+    // supplied. The shader declares samplerCube there, so the placeholder must be
+    // a cube view (a 2D view is an invalid descriptor and breaks the draw on Metal).
+    // Black is treated as "no cubemap" by the shader, which falls back to procedural sky.
+    ImageWithView envPlaceholderCube_;
 
     // Tidal parameters
     float baseWaterLevel = 0.0f;  // Mean sea level

--- a/src/water/WaterTileCull.cpp
+++ b/src/water/WaterTileCull.cpp
@@ -275,9 +275,9 @@ void WaterTileCull::recordTileCull(VkCommandBuffer cmd, uint32_t frameIndex,
     pc.waterLevel = waterLevel;
     pc.tileSize = static_cast<float>(tileSize);
     pc.nearPlane = 0.1f;
-    pc.farPlane = 1000.0f;
+    pc.farPlane = 50000.0f;  // Must match camera far plane (see Camera.cpp / setCameraPlanes)
     pc.maxTiles = tileCount.x * tileCount.y;  // Output buffer capacity
-    pc._pad0 = 0;
+    pc.frameIndex = frameIndex;
 
     // Bind pipeline
     vk::CommandBuffer vkCmd(cmd);

--- a/src/water/WaterTileCull.h
+++ b/src/water/WaterTileCull.h
@@ -63,7 +63,7 @@ public:
         float nearPlane;
         float farPlane;
         uint32_t maxTiles;        // Output buffer capacity
-        uint32_t _pad0;
+        uint32_t frameIndex;      // Frame-in-flight index (selects counter slot)
     };
 
     // Indirect draw command for Vulkan


### PR DESCRIPTION
The water surface never rendered due to two defects in resources the water
shaders sample every frame:

1. WaterDisplacement's compute pass has no call sites (the splash system is
   orphaned), so its R16F displacement maps were never written, cleared, or
   transitioned out of UNDEFINED layout. The water vertex shader samples the
   map each frame and adds the value straight to the surface height, so
   uninitialized contents (up to +/-65k in half float) could throw the whole
   mesh out of the frustum. Clear both maps to zero and move them to
   shader-read layout at init so they are valid with or without a dispatch.

2. water.frag declares samplerCube envCubemap (binding 22) and samples it
   unconditionally, but no caller supplies a cubemap and the fallback bound
   the 2D displacement view there - an invalid descriptor that breaks the
   draw on Metal/MoltenVK. Bind a 1x1 black cube placeholder instead; black
   already means "no cubemap" to the shader, which falls back to procedural
   sky.

Also fix related water defects found during review:
- Tile-cull counter: shader declared a single uint (always slot 0) while the
  CPU reset/read counter[frameIndex], so two of every three frames read a
  slot the GPU never wrote. Index the counter array by frame via the spare
  push-constant slot.
- recordDraw pushed constants with eVertex only against a range declared for
  vertex+tessellation stages (validation failure; undefined push constants
  in the tessellation path).
- Tile-cull far plane was hardcoded to 1000 vs the camera's 50000, skewing
  depth linearization in the high-altitude cull path.

https://claude.ai/code/session_01T4HwVyzif35GEif37MxcEp