### PR TITLE
Fix synchronization for statically-bound render resources

### DIFF
--- a/shaders/grass.comp
+++ b/shaders/grass.comp
@@ -71,15 +71,17 @@ layout(std430, binding = BINDING_GRASS_COMPUTE_TILE_INFO) readonly buffer TileIn
 // Include tile cache common after defining prerequisites
 #include "tile_cache_common.glsl"
 
+// Must match TiledGrassPushConstants (GrassTypes.h) and grass_tiled.comp;
+// the same pipeline layout dispatches either shader.
 layout(push_constant) uniform PushConstants {
     float time;
     float tileOriginX;   // World X origin of this tile (0 for non-tiled mode)
     float tileOriginZ;   // World Z origin of this tile (0 for non-tiled mode)
     float tileSize;      // Tile size in world units (varies by LOD: 64, 128, 256)
-    float spacingMult;   // Spacing multiplier for this LOD (1.0, 2.0, 4.0)
-    uint lodLevel;       // LOD level (0 = high detail, 1 = medium, 2 = low)
-    float tileLoadTime;  // Time when this tile was first loaded (for fade-in)
-    float padding;
+    float spacing;       // Blade spacing (unused in non-tiled mode)
+    uint tileIndex;      // Tile index for debugging (unused in non-tiled mode)
+    float unused1;
+    float unused2;
 } push;
 
 // Check if we're in tiled mode (tile origin is non-zero or explicitly set)

--- a/src/atmosphere/AtmosphereLUTCompute.cpp
+++ b/src/atmosphere/AtmosphereLUTCompute.cpp
@@ -13,8 +13,14 @@ void AtmosphereLUTSystem::computeTransmittanceLUT(VkCommandBuffer cmd) {
 
     vk::CommandBuffer vkCmd(cmd);
 
-    // Transition to GENERAL layout for compute write
-    BarrierHelpers::imageToGeneral(vkCmd, transmittanceLUT);
+    // Transition to GENERAL layout for compute write. Source stages cover in-flight
+    // sampling (sky fragment shading + LUT compute) so a runtime recompute does not
+    // overwrite the image while a previous frame still reads it.
+    BarrierHelpers::transitionImageLayout(vkCmd, transmittanceLUT,
+        vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+        vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::AccessFlags{}, vk::AccessFlagBits::eShaderWrite);
 
     // Bind pipeline and dispatch
     vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, transmittancePipeline);
@@ -25,8 +31,9 @@ void AtmosphereLUTSystem::computeTransmittanceLUT(VkCommandBuffer cmd) {
     uint32_t groupCountY = (TRANSMITTANCE_HEIGHT + 15) / 16;
     vkCmd.dispatch(groupCountX, groupCountY, 1);
 
-    // Transition to SHADER_READ for sampling in later stages
-    BarrierHelpers::imageToShaderRead(vkCmd, transmittanceLUT, vk::PipelineStageFlagBits::eComputeShader);
+    // Sampled by the sky-view/multiscatter/irradiance compute passes AND by sky.frag
+    BarrierHelpers::imageToShaderRead(vkCmd, transmittanceLUT,
+        vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eFragmentShader);
 
     SDL_Log("Computed transmittance LUT (%dx%d)", TRANSMITTANCE_WIDTH, TRANSMITTANCE_HEIGHT);
 }
@@ -39,8 +46,13 @@ void AtmosphereLUTSystem::computeMultiScatterLUT(VkCommandBuffer cmd) {
 
     vk::CommandBuffer vkCmd(cmd);
 
-    // Transition to GENERAL layout for compute write
-    BarrierHelpers::imageToGeneral(vkCmd, multiScatterLUT);
+    // Transition to GENERAL layout for compute write (see computeTransmittanceLUT
+    // for why source stages include fragment + compute sampling)
+    BarrierHelpers::transitionImageLayout(vkCmd, multiScatterLUT,
+        vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+        vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::AccessFlags{}, vk::AccessFlagBits::eShaderWrite);
 
     // Bind pipeline and dispatch
     vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, multiScatterPipeline);
@@ -51,8 +63,9 @@ void AtmosphereLUTSystem::computeMultiScatterLUT(VkCommandBuffer cmd) {
     uint32_t groupCountY = (MULTISCATTER_SIZE + 7) / 8;
     vkCmd.dispatch(groupCountX, groupCountY, 1);
 
-    // Transition to SHADER_READ for sampling
-    BarrierHelpers::imageToShaderRead(vkCmd, multiScatterLUT, vk::PipelineStageFlagBits::eComputeShader);
+    // Sampled by the sky-view compute pass AND by sky.frag
+    BarrierHelpers::imageToShaderRead(vkCmd, multiScatterLUT,
+        vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eFragmentShader);
 
     SDL_Log("Computed multi-scatter LUT (%dx%d)", MULTISCATTER_SIZE, MULTISCATTER_SIZE);
 }
@@ -178,8 +191,9 @@ void AtmosphereLUTSystem::computeCloudMapLUT(VkCommandBuffer cmd, const glm::vec
     uint32_t groupCountY = (CLOUDMAP_SIZE + 15) / 16;
     vkCmd.dispatch(groupCountX, groupCountY, 1);
 
-    // Transition to SHADER_READ for sampling in sky.frag
-    BarrierHelpers::imageToShaderRead(vkCmd, cloudMapLUT, vk::PipelineStageFlagBits::eFragmentShader);
+    // Sampled by sky.frag AND by cloud_shadow.comp
+    BarrierHelpers::imageToShaderRead(vkCmd, cloudMapLUT,
+        vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader);
 
     SDL_Log("Computed cloud map LUT (%dx%d)", CLOUDMAP_SIZE, CLOUDMAP_SIZE);
 }
@@ -215,8 +229,10 @@ void AtmosphereLUTSystem::updateCloudMapLUT(VkCommandBuffer cmd, uint32_t frameI
 
     vk::CommandBuffer vkCmd(cmd);
 
-    // Transition from SHADER_READ_ONLY to GENERAL for compute write
-    BarrierHelpers::shaderReadToGeneral(vkCmd, cloudMapLUT);
+    // Transition from SHADER_READ_ONLY to GENERAL for compute write.
+    // Prior readers are sky.frag (fragment) and cloud_shadow.comp (compute).
+    BarrierHelpers::shaderReadToGeneral(vkCmd, cloudMapLUT,
+        vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader);
 
     // Bind pipeline and per-frame descriptor set (double-buffered)
     vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, cloudMapPipeline);
@@ -227,8 +243,9 @@ void AtmosphereLUTSystem::updateCloudMapLUT(VkCommandBuffer cmd, uint32_t frameI
     uint32_t groupCountY = (CLOUDMAP_SIZE + 15) / 16;
     vkCmd.dispatch(groupCountX, groupCountY, 1);
 
-    // Transition back to SHADER_READ for sampling in sky.frag
-    BarrierHelpers::imageToShaderRead(vkCmd, cloudMapLUT, vk::PipelineStageFlagBits::eFragmentShader);
+    // Sampled by sky.frag AND by cloud_shadow.comp (next frame's compute pass)
+    BarrierHelpers::imageToShaderRead(vkCmd, cloudMapLUT,
+        vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader);
 }
 
 void AtmosphereLUTSystem::recomputeStaticLUTs(VkCommandBuffer cmd) {
@@ -250,8 +267,15 @@ void AtmosphereLUTSystem::recomputeStaticLUTs(VkCommandBuffer cmd) {
 
 void AtmosphereLUTSystem::barrierIrradianceLUTsForCompute(VkCommandBuffer cmd) {
     vk::CommandBuffer vkCmd(cmd);
-    BarrierHelpers::imageToGeneral(vkCmd, rayleighIrradianceLUT);
-    BarrierHelpers::imageToGeneral(vkCmd, mieIrradianceLUT);
+    // Wait for any in-flight fragment sampling before a runtime recompute overwrites
+    // the LUTs (contents are discarded via UNDEFINED).
+    for (VkImage lut : {rayleighIrradianceLUT, mieIrradianceLUT}) {
+        BarrierHelpers::transitionImageLayout(vkCmd, lut,
+            vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+            vk::PipelineStageFlagBits::eFragmentShader,
+            vk::PipelineStageFlagBits::eComputeShader,
+            vk::AccessFlags{}, vk::AccessFlagBits::eShaderWrite);
+    }
 }
 
 void AtmosphereLUTSystem::barrierIrradianceLUTsForSampling(VkCommandBuffer cmd) {

--- a/src/lighting/FroxelSystem.cpp
+++ b/src/lighting/FroxelSystem.cpp
@@ -276,6 +276,40 @@ bool FroxelSystem::createIntegrationPipeline() {
         .buildInto(integrationPipeline_);
 }
 
+void FroxelSystem::recordInitialClearIfNeeded(VkCommandBuffer cmd) {
+    if (integratedVolumeInitialized_) return;
+    integratedVolumeInitialized_ = true;
+
+    vk::CommandBuffer vkCmd(cmd);
+    auto range = vk::ImageSubresourceRange{vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1};
+
+    auto toTransfer = vk::ImageMemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eNone)
+        .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setOldLayout(vk::ImageLayout::eUndefined)
+        .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setImage(integratedVolume_.get())
+        .setSubresourceRange(range);
+    vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe,
+                          vk::PipelineStageFlagBits::eTransfer,
+                          {}, {}, {}, toTransfer);
+
+    // Zero scattering / zero opacity = no fog contribution in the composite
+    vkCmd.clearColorImage(integratedVolume_.get(), vk::ImageLayout::eTransferDstOptimal,
+                          vk::ClearColorValue(std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}), range);
+
+    auto toSampled = vk::ImageMemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+        .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+        .setImage(integratedVolume_.get())
+        .setSubresourceRange(range);
+    vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+                          vk::PipelineStageFlagBits::eFragmentShader,
+                          {}, {}, {}, toSampled);
+}
+
 void FroxelSystem::recordFroxelUpdate(VkCommandBuffer cmd, uint32_t frameIndex,
                                        const glm::mat4& view, const glm::mat4& proj,
                                        const glm::vec3& cameraPos,
@@ -283,7 +317,12 @@ void FroxelSystem::recordFroxelUpdate(VkCommandBuffer cmd, uint32_t frameIndex,
                                        const glm::vec3& sunColor,
                                        const glm::mat4* cascadeMatrices,
                                        const glm::vec4& cascadeSplits) {
-    if (!enabled) return;
+    if (!enabled) {
+        // The post-process composite statically binds the integrated volume; keep it valid
+        recordInitialClearIfNeeded(cmd);
+        return;
+    }
+    integratedVolumeInitialized_ = true;
 
     // Update uniform buffer
     glm::mat4 viewProj = proj * view;

--- a/src/lighting/FroxelSystem.h
+++ b/src/lighting/FroxelSystem.h
@@ -75,6 +75,13 @@ public:
                            const glm::mat4* cascadeMatrices,
                            const glm::vec4& cascadeSplits);
 
+    /**
+     * Clear the integrated volume and move it to SHADER_READ_ONLY_OPTIMAL if the
+     * froxel update has never run. The post-process composite statically binds the
+     * integrated volume, so it must be valid even while froxel updates are disabled.
+     */
+    void recordInitialClearIfNeeded(VkCommandBuffer cmd);
+
     // Get the scattering volume (raw, pre-integration) - returns current frame's output
     VkImageView getScatteringVolumeView() const { return scatteringVolumeViews_[frameCounter % 2] ? **scatteringVolumeViews_[frameCounter % 2] : VK_NULL_HANDLE; }
     // Get the integrated volume for compositing (front-to-back integrated result)
@@ -158,6 +165,7 @@ private:
     // Integrated scattering volume (front-to-back integrated) - RAII-managed
     ManagedImage integratedVolume_;
     std::optional<vk::raii::ImageView> integratedVolumeView_;
+    bool integratedVolumeInitialized_ = false;
 
     // Volume sampler (trilinear filtering)
     std::optional<vk::raii::Sampler> volumeSampler_;

--- a/src/lighting/ShadowSystem.cpp
+++ b/src/lighting/ShadowSystem.cpp
@@ -172,6 +172,28 @@ bool ShadowSystem::createShadowResources() {
     return true;
 }
 
+void ShadowSystem::recordInitialClearIfNeeded(VkCommandBuffer cmd) {
+    if (csmInitialized_) return;
+    csmInitialized_ = true;
+
+    // Empty render passes clear each cascade to depth 1.0 (fully lit) and leave the
+    // image in SHADER_READ_ONLY_OPTIMAL via the render pass final layout, matching
+    // what the regular shadow pass produces.
+    vk::CommandBuffer vkCmd(cmd);
+    vk::ClearValue shadowClear;
+    shadowClear.depthStencil = vk::ClearDepthStencilValue{1.0f, 0};
+
+    for (uint32_t cascade = 0; cascade < NUM_SHADOW_CASCADES; cascade++) {
+        auto passInfo = vk::RenderPassBeginInfo{}
+            .setRenderPass(shadowRenderPass)
+            .setFramebuffer(cascadeFramebuffers[cascade])
+            .setRenderArea({{0, 0}, {SHADOW_MAP_SIZE, SHADOW_MAP_SIZE}})
+            .setClearValues(shadowClear);
+        vkCmd.beginRenderPass(passInfo, vk::SubpassContents::eInline);
+        vkCmd.endRenderPass();
+    }
+}
+
 bool ShadowSystem::createShadowPipelineCommon(
     const std::string& vertShader,
     const std::string& fragShader,
@@ -843,6 +865,9 @@ void ShadowSystem::recordShadowPass(VkCommandBuffer cmd, uint32_t frameIndex,
                                      const ComputeCallback& preCascadeComputeCallback,
                                      const IndirectShadowParams& indirect) {
     vk::CommandBuffer vkCmd(cmd);
+
+    // Each cascade render pass below clears and writes the shadow map
+    csmInitialized_ = true;
 
     // GPU-driven indirect scene-object path (per-cascade frustum culling + indirect draw).
     // When active it replaces the instanced/per-object scene-object draw below.

--- a/src/lighting/ShadowSystem.h
+++ b/src/lighting/ShadowSystem.h
@@ -103,6 +103,14 @@ public:
                           const IndirectShadowParams& indirect = {});
 
     /**
+     * Record empty depth-clear render passes for each cascade if the shadow map
+     * has never been rendered. The cascade shadow map is statically sampled by the
+     * main scene shaders, so it must hold valid contents (depth = 1.0, no shadow)
+     * even on frames where the shadow pass is skipped (e.g. sun below horizon).
+     */
+    void recordInitialClearIfNeeded(VkCommandBuffer cmd);
+
+    /**
      * Initialize GPU-driven indirect shadow resources (pipeline + per-frame instance
      * descriptor sets bound to the GPUSceneBuffer instance buffer). Requires the
      * GPUSceneBuffer to already exist. Safe to skip; the CPU/instanced path remains.
@@ -287,6 +295,7 @@ private:
     VkDescriptorPool indirectShadowPool = VK_NULL_HANDLE;
     std::vector<vk::DescriptorSet> indirectInstanceDescriptorSets;  // per frame -> instance SSBO
     bool indirectShadowReady_ = false;
+    bool csmInitialized_ = false;
 
     // Draw scene objects for one cascade via per-cascade indirect commands.
     void recordShadowSceneIndirect(VkCommandBuffer cmd, uint32_t frameIndex, uint32_t cascade,

--- a/src/passes/ComputePasses.cpp
+++ b/src/passes/ComputePasses.cpp
@@ -181,6 +181,9 @@ PassIds addPasses(PassScheduler& graph, RendererSystems& systems, const Config& 
                 renderCtx->frame.nearPlane, renderCtx->frame.farPlane);
 
             if (!perfToggles->froxelFog && !perfToggles->atmosphereLUT) {
+                // The post-process composite statically binds the integrated froxel
+                // volume; initialize it even when froxel updates never run.
+                systems.froxel().recordInitialClearIfNeeded(cmd);
                 return;
             }
 

--- a/src/passes/PostPasses.cpp
+++ b/src/passes/PostPasses.cpp
@@ -54,9 +54,13 @@ PassIds addPasses(PassScheduler& graph, RendererSystems& systems, const Config& 
     ids.godRays = graph.addPass({
         .name = "GodRays",
         .execute = [&systems](PassScheduler::RenderContext& ctx) {
-            if (!systems.hasGodRays() || !systems.postProcess().isGodRaysEnabled()) return;
+            if (!systems.hasGodRays()) return;
             RenderContext* renderCtx = static_cast<RenderContext*>(ctx.userData);
             if (!renderCtx) return;
+            // The composite pass statically binds the god-rays output, so the image
+            // must be initialized even while the effect itself is disabled.
+            systems.godRays().recordInitialClearIfNeeded(ctx.commandBuffer);
+            if (!systems.postProcess().isGodRaysEnabled()) return;
             systems.profiler().beginGpuZone(ctx.commandBuffer, "GodRays");
             // Forward sun screen position and parameters to GodRaysSystem
             auto& godRays = systems.godRays();

--- a/src/passes/ShadowPasses.cpp
+++ b/src/passes/ShadowPasses.cpp
@@ -6,6 +6,7 @@
 #include "PerformanceToggles.h"
 #include "ScreenSpaceShadowSystem.h"
 #include "ShadowPassRecorder.h"
+#include "ShadowSystem.h"
 #include "vulkan/VulkanContext.h"
 
 #include <cstdlib>
@@ -59,6 +60,10 @@ PassIds addPasses(PassScheduler& graph, RendererSystems& systems, const Config& 
 
                 systems.profiler().endGpuZone(ctx.commandBuffer, "ShadowPass");
                 systems.profiler().endCpuZone("ShadowRecord");
+            } else {
+                // Skipped (sun down / toggled off): make sure the statically-sampled
+                // cascade shadow map holds valid contents instead of UNDEFINED memory.
+                systems.shadow().recordInitialClearIfNeeded(ctx.commandBuffer);
             }
         },
         .canUseSecondary = false,

--- a/src/postprocess/GodRaysSystem.cpp
+++ b/src/postprocess/GodRaysSystem.cpp
@@ -93,7 +93,8 @@ bool GodRaysSystem::createResources() {
         .setArrayLayers(1)
         .setSamples(vk::SampleCountFlagBits::e1)
         .setTiling(vk::ImageTiling::eOptimal)
-        .setUsage(vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eSampled)
+        .setUsage(vk::ImageUsageFlagBits::eStorage | vk::ImageUsageFlagBits::eSampled |
+                  vk::ImageUsageFlagBits::eTransferDst)
         .setSharingMode(vk::SharingMode::eExclusive)
         .setInitialLayout(vk::ImageLayout::eUndefined);
 
@@ -119,7 +120,41 @@ bool GodRaysSystem::createResources() {
         return false;
     }
 
+    outputNeedsInitialClear_ = true;
     return true;
+}
+
+void GodRaysSystem::recordInitialClearIfNeeded(VkCommandBuffer cmd) {
+    if (!outputNeedsInitialClear_) return;
+    outputNeedsInitialClear_ = false;
+
+    vk::CommandBuffer vkCmd(cmd);
+    auto range = vk::ImageSubresourceRange{vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1};
+
+    auto toTransfer = vk::ImageMemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eNone)
+        .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setOldLayout(vk::ImageLayout::eUndefined)
+        .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setImage(outputImage_)
+        .setSubresourceRange(range);
+    vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe,
+                          vk::PipelineStageFlagBits::eTransfer,
+                          {}, {}, {}, toTransfer);
+
+    vkCmd.clearColorImage(outputImage_, vk::ImageLayout::eTransferDstOptimal,
+                          vk::ClearColorValue(std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}), range);
+
+    auto toSampled = vk::ImageMemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+        .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+        .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+        .setImage(outputImage_)
+        .setSubresourceRange(range);
+    vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+                          vk::PipelineStageFlagBits::eFragmentShader,
+                          {}, {}, {}, toSampled);
 }
 
 bool GodRaysSystem::createPipeline() {
@@ -197,6 +232,9 @@ void GodRaysSystem::destroyResources() {
 
 void GodRaysSystem::recordGodRaysPass(VkCommandBuffer cmd, VkImageView hdrView, VkImageView depthView) {
     vk::CommandBuffer vkCmd(cmd);
+
+    // The dispatch below overwrites every texel, so no separate initial clear is needed
+    outputNeedsInitialClear_ = false;
 
     // Transition output image to GENERAL
     {

--- a/src/postprocess/GodRaysSystem.h
+++ b/src/postprocess/GodRaysSystem.h
@@ -53,6 +53,13 @@ public:
      */
     void recordGodRaysPass(VkCommandBuffer cmd, VkImageView hdrView, VkImageView depthView);
 
+    /**
+     * Clear the output image and move it to SHADER_READ_ONLY_OPTIMAL if it has
+     * never been written. The post-process composite statically binds this image,
+     * so it must be valid even while the god rays pass itself is skipped/disabled.
+     */
+    void recordInitialClearIfNeeded(VkCommandBuffer cmd);
+
     VkImageView getGodRaysOutput() const { return outputImageView_; }
     VkSampler getSampler() const { return sampler_ ? **sampler_ : VK_NULL_HANDLE; }
 
@@ -88,6 +95,7 @@ private:
     VmaAllocation outputAllocation_ = VK_NULL_HANDLE;
     VkImageView outputImageView_ = VK_NULL_HANDLE;
     VkExtent2D quarterExtent_ = {0, 0};
+    bool outputNeedsInitialClear_ = true;
 
     std::optional<vk::raii::Sampler> sampler_;
     std::optional<vk::raii::DescriptorSetLayout> descSetLayout_;


### PR DESCRIPTION
## Summary
Fixes synchronization issues where render resources (shadow maps, god rays output, froxel integrated volume) are statically bound by post-process and main scene shaders but may not be initialized or properly transitioned when their update passes are skipped or disabled.

## Key Changes

**Atmosphere LUT Compute (AtmosphereLUTCompute.cpp)**
- Enhanced pipeline stage synchronization for transmittance and multi-scatter LUT transitions to account for both fragment shader sampling (sky.frag) and compute shader sampling (other LUT passes)
- Updated cloud map LUT barriers to include compute shader stages (cloud_shadow.comp reads it)
- Modified irradiance LUT barrier to explicitly wait for fragment shader stages before overwriting with compute
- Replaced simple `imageToGeneral()` calls with explicit `transitionImageLayout()` to specify correct source pipeline stages

**Shadow System (ShadowSystem.cpp/h)**
- Added `recordInitialClearIfNeeded()` method that records empty render passes to initialize cascade shadow maps to depth 1.0 (fully lit) when the shadow pass is skipped
- Tracks initialization state with `csmInitialized_` flag
- Called from shadow pass scheduler when shadow rendering is skipped (e.g., sun below horizon)

**Froxel System (FroxelSystem.cpp/h)**
- Added `recordInitialClearIfNeeded()` method to clear and transition the integrated volume to SHADER_READ_ONLY_OPTIMAL when froxel updates are disabled
- Tracks initialization with `integratedVolumeInitialized_` flag
- Called from compute pass scheduler when froxel fog is disabled

**God Rays System (GodRaysSystem.cpp/h)**
- Added `recordInitialClearIfNeeded()` method to initialize the output image when the god rays pass is skipped
- Added `eTransferDst` usage flag to output image for clear operations
- Tracks initialization with `outputNeedsInitialClear_` flag
- Called from post-process pass scheduler regardless of god rays enabled state

**Pass Schedulers (ShadowPasses.cpp, ComputePasses.cpp, PostPasses.cpp)**
- Updated shadow pass scheduler to call `recordInitialClearIfNeeded()` when shadow pass is skipped
- Updated compute pass scheduler to call `recordInitialClearIfNeeded()` when froxel updates are disabled
- Updated post-process pass scheduler to always call god rays initialization before checking if effect is enabled

**Shader Updates (grass.comp)**
- Updated push constant documentation to clarify layout matches between grass.comp and grass_tiled.comp
- Renamed push constant fields for clarity (spacingMult → spacing, lodLevel → tileIndex, added unused fields)

## Implementation Details

The core issue is that post-process compositing and main scene shaders statically bind certain resources (cascade shadow maps, god rays output, froxel integrated volume) in their descriptor sets. These resources must contain valid data even when their update passes are skipped or disabled, otherwise the shaders read from UNDEFINED memory.

The solution adds initialization passes that:
1. Transition resources from UNDEFINED to their required layout (SHADER_READ_ONLY_OPTIMAL)
2. Clear them to sensible defaults (depth 1.0 for shadows = no shadow, 0.0 for color = no contribution)
3. Run only once per resource lifetime via initialization flags

Pipeline stage synchronization in atmosphere LUT passes was also corrected to account for all consumers (both fragment and compute shaders), preventing data races when LUTs are recomputed at runtime while previous frames still sample them.

https://claude.ai/code/session_014ZLRPA8Z2rVfmjVt88Yizu