### PR TITLE
Consolidate virtual texture page table into single array image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,19 +574,53 @@ add_custom_target(roads_gen DEPENDS ${ROADS_JSON} ${ROADS_BIN} ${ROADS_META})
 add_dependencies(roads_gen road_generator biome_gen)
 
 # ============================================================================
+# SEQUENTIAL PHASE: tile_generator runs after roads complete
+# Virtual texture tiles composite biome materials, riverbeds and roads
+# ============================================================================
+
+# Virtual texture tile outputs. Parameters must match the runtime
+# VirtualTextureConfig in TerrainSystem (8192px virtual = 64 tiles/axis of
+# 128px, 6 mips) and the terrain/VT_WORLD_SIZE of 16384m.
+set(VT_TILES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/generated/vt_tiles)
+set(VT_TILES_STAMP ${VT_TILES_DIR}/vt_tiles.stamp)
+
+add_custom_command(
+    OUTPUT ${VT_TILES_STAMP}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${VT_TILES_DIR}
+    COMMAND $<TARGET_FILE:tile_generator>
+        --heightmap ${TERRAIN_HEIGHTMAP}
+        --biomemap ${BIOME_MAP_PNG}
+        --roads ${ROADS_JSON}
+        --output ${VT_TILES_DIR}
+        --materials ${CMAKE_CURRENT_SOURCE_DIR}/assets/textures
+        --terrain-size 16384
+        --tile-res 128
+        --tiles-per-axis 64
+        --max-mip 6
+    COMMAND ${CMAKE_COMMAND} -E touch ${VT_TILES_STAMP}
+    DEPENDS ${TERRAIN_HEIGHTMAP} ${BIOME_MAP_PNG} ${ROADS_JSON}
+    COMMENT "Generating virtual texture tiles (after roads)"
+)
+
+# Explicit target for virtual texture tile generation
+add_custom_target(vt_tiles_gen DEPENDS ${VT_TILES_STAMP})
+add_dependencies(vt_tiles_gen tile_generator roads_gen)
+
+# ============================================================================
 # UMBRELLA TARGET: terrain_preprocessing depends on all outputs
 # ============================================================================
 
 # Custom target that depends on all preprocessing outputs
 add_custom_target(terrain_preprocessing
-    DEPENDS ${TERRAIN_TILES_META} ${WATERSHED_RIVERS_SVG} ${BIOME_MAP_PNG} ${ROADS_BIN}
+    DEPENDS ${TERRAIN_TILES_META} ${WATERSHED_RIVERS_SVG} ${BIOME_MAP_PNG} ${ROADS_BIN} ${VT_TILES_STAMP}
 )
 
 # Dependencies ensure correct build order:
 # - terrain_tiles_gen and watershed_gen can run in parallel
 # - biome_gen runs after watershed_gen completes
 # - roads_gen runs after biome_gen completes
-add_dependencies(terrain_preprocessing terrain_tiles_gen watershed_gen biome_gen roads_gen)
+# - vt_tiles_gen runs after roads_gen completes
+add_dependencies(terrain_preprocessing terrain_tiles_gen watershed_gen biome_gen roads_gen vt_tiles_gen)
 
 # Foam noise texture generation
 set(FOAM_TEXTURE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/assets/textures)
@@ -897,6 +931,7 @@ set(TERRAIN_SHADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_sum_reduction_batched.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.vert.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.frag.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_vt.frag.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow.vert.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow.frag.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow_cull.comp.spv
@@ -1178,6 +1213,18 @@ if(SHADER_COMPILE_CMD)
         )
     endforeach()
 
+    # Virtual texture variant of the terrain fragment shader: same source
+    # compiled with USE_VIRTUAL_TEXTURE so it samples the megatexture cache
+    # instead of triplanar albedo
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_vt.frag.spv
+        COMMAND ${GLSLANG_VALIDATOR} --target-env vulkan1.2 -DUSE_VIRTUAL_TEXTURE -I${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain -I${CMAKE_CURRENT_SOURCE_DIR}/shaders -V -o ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_vt.frag.spv ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.frag
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.frag
+                ${CMAKE_CURRENT_SOURCE_DIR}/shaders/virtual_texture.glsl
+                ${BINDINGS_DEPS}
+        COMMENT "Compiling terrain shader variant: terrain_vt.frag"
+    )
+
     # Catmull-Clark subdivision shaders
     set(CATMULLCLARK_SIMPLE_SHADERS
         catmullclark_subdivision.comp.glsl
@@ -1273,6 +1320,7 @@ if(SHADER_COMPILE_CMD)
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_sum_reduction_batched.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.vert.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain.frag.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_vt.frag.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow.vert.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow.frag.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_shadow_cull.comp.spv

--- a/shaders/terrain/terrain.frag
+++ b/shaders/terrain/terrain.frag
@@ -334,12 +334,15 @@ void main() {
         albedo = mix(albedo, farGrassColor, farLodBlend * grassGrowthFactor);
     }
 
+    // Material roughness constants - used by both VT and non-VT paths for
+    // the slope-based roughness blend below
+    float rockRoughness = 0.95;
+    float grassRoughness = 0.8;
+
 #ifndef USE_VIRTUAL_TEXTURE
     // === MATERIAL LAYER BLENDING (Composable Material System) ===
     // Blend terrain materials based on configured layers or fallback to slope-based
     vec3 rockColor = vec3(0.4, 0.35, 0.3);
-    float rockRoughness = 0.95;
-    float grassRoughness = 0.8;
 
     if (materialLayerUbo.numMaterialLayers > 0) {
         // Use configured material layers from UBO

--- a/shaders/virtual_texture.glsl
+++ b/shaders/virtual_texture.glsl
@@ -66,6 +66,12 @@ float vtCalculateMipLevel(vec2 virtualUV) {
 
 // Write tile request to feedback buffer
 void vtWriteFeedback(uvec2 tileCoord, uint mipLevel) {
+    // Decimate: only 1 in 16 pixels writes feedback, so a full-screen miss
+    // doesn't saturate the 4096-entry buffer with duplicates of a few tiles
+    if ((uint(gl_FragCoord.x) & 3u) != 0u || (uint(gl_FragCoord.y) & 3u) != 0u) {
+        return;
+    }
+
     uint packed = vtPackTileId(tileCoord, mipLevel);
 
     // Atomically increment counter and get index
@@ -77,59 +83,64 @@ void vtWriteFeedback(uvec2 tileCoord, uint mipLevel) {
     }
 }
 
-// Sample virtual texture with automatic mip selection
+// Sample virtual texture at the given mip level, falling back to coarser
+// mips when the requested tile is not resident. Iterative because GLSL
+// forbids recursion.
 vec4 sampleVirtualTexture(vec2 virtualUV, float mipLevel) {
     // Clamp to valid mip range
-    uint mip = clamp(uint(mipLevel + 0.5), 0u, vtParams.maxMipLevel);
+    uint requestedMip = clamp(uint(mipLevel + 0.5), 0u, vtParams.maxMipLevel);
 
-    // Calculate number of tiles at this mip level
     float tileSize = vtParams.tileSizeAndBorder.x;
     float virtualSize = vtParams.virtualTextureSizeAndInverse.x;
-    float tilesAtMip = virtualSize / (tileSize * float(1u << mip));
 
-    // Calculate tile coordinates
-    vec2 tileCoordF = virtualUV * tilesAtMip;
-    ivec2 tileCoord = ivec2(floor(tileCoordF));
+    for (uint mip = requestedMip; mip <= vtParams.maxMipLevel; ++mip) {
+        // Calculate number of tiles at this mip level
+        float tilesAtMip = virtualSize / (tileSize * float(1u << mip));
 
-    // Clamp tile coordinates to valid range
-    int maxTileCoord = int(tilesAtMip) - 1;
-    tileCoord = clamp(tileCoord, ivec2(0), ivec2(maxTileCoord));
+        // Calculate tile coordinates
+        vec2 tileCoordF = virtualUV * tilesAtMip;
+        ivec2 tileCoord = ivec2(floor(tileCoordF));
 
-    // Calculate UV within the tile [0, 1]
-    vec2 inTileUV = fract(tileCoordF);
+        // Clamp tile coordinates to valid range
+        int maxTileCoord = int(tilesAtMip) - 1;
+        tileCoord = clamp(tileCoord, ivec2(0), ivec2(maxTileCoord));
 
-    // Fetch page table entry from texture array
-    // Each mip level is stored as a separate layer in the texture array
-    // Entry format: R = cacheX, G = cacheY, B = unused, A = valid
-    uvec4 pageEntry = texelFetch(vtPageTable, ivec3(tileCoord.x, tileCoord.y, int(mip)), 0);
+        // Calculate UV within the tile [0, 1]
+        vec2 inTileUV = fract(tileCoordF);
 
-    // Check if tile is loaded (valid flag in alpha channel)
-    if (pageEntry.a == 0u) {
-        // Tile not loaded - write feedback request
-        vtWriteFeedback(uvec2(tileCoord), mip);
+        // Fetch page table entry from texture array
+        // Each mip level is stored as a layer in the texture array, with the
+        // mip's entries occupying the top-left tilesAtMip x tilesAtMip corner
+        // Entry format: R = cacheX, G = cacheY, B = unused, A = valid
+        uvec4 pageEntry = texelFetch(vtPageTable, ivec3(tileCoord.x, tileCoord.y, int(mip)), 0);
 
-        // Try to use coarser mip level as fallback
-        if (mip < vtParams.maxMipLevel) {
-            return sampleVirtualTexture(virtualUV, float(mip + 1u));
+        // Check if tile is loaded (valid flag in alpha channel)
+        if (pageEntry.a == 0u) {
+            // Tile not loaded - request the mip we actually wanted, then
+            // keep walking up the chain looking for a resident fallback
+            if (mip == requestedMip) {
+                vtWriteFeedback(uvec2(tileCoord), mip);
+            }
+            continue;
         }
 
-        // Ultimate fallback - return placeholder color (pink/magenta for debugging)
-        return vec4(1.0, 0.0, 1.0, 1.0);
+        // Transform to physical cache coordinates
+        vec2 cachePos = vec2(pageEntry.xy);  // Cache tile position (in tiles)
+        float border = vtParams.tileSizeAndBorder.y;
+        float tileWithBorder = vtParams.tileSizeAndBorder.z;
+        float cacheSize = vtParams.physicalCacheSizeAndInverse.x;
+
+        // Calculate physical UV: tiles are stored at a stride of tileWithBorder,
+        // with the usable content offset by the border
+        vec2 physicalUV = (cachePos * tileWithBorder + border + inTileUV * tileSize) / cacheSize;
+
+        // Explicit LOD: the cache is single-mip and implicit derivatives are
+        // undefined inside this non-uniform loop
+        return textureLod(vtCache, physicalUV, 0.0);
     }
 
-    // Transform to physical cache coordinates
-    vec2 cachePos = vec2(pageEntry.xy);  // Cache tile position (in tiles)
-    float border = vtParams.tileSizeAndBorder.y;
-    float tileWithBorder = vtParams.tileSizeAndBorder.z;
-    float cacheSize = vtParams.physicalCacheSizeAndInverse.x;
-
-    // Calculate physical UV
-    // Each tile in cache includes border pixels for filtering
-    // The actual tile content is (tileSize - 2*border) in the center
-    float usableTileSize = tileSize;  // We use the full tile but account for border in UV
-    vec2 physicalUV = (cachePos * tileWithBorder + border + inTileUV * usableTileSize) / cacheSize;
-
-    return texture(vtCache, physicalUV);
+    // Ultimate fallback - return placeholder color (pink/magenta for debugging)
+    return vec4(1.0, 0.0, 1.0, 1.0);
 }
 
 // Convenience function with automatic mip calculation

--- a/src/core/RendererBuilder.cpp
+++ b/src/core/RendererBuilder.cpp
@@ -781,6 +781,11 @@ std::vector<Loading::SystemInitTask> RendererBuilder::buildInitTasks(Renderer& r
             terrainFactoryConfig.shadowMapSize = r.systems_->shadow().getShadowMapSize();
             terrainFactoryConfig.resourcePath = r.resourcePath;
 
+            // VT feedback needs fragment shader SSBO atomics
+            terrainFactoryConfig.useVirtualTexture =
+                terrainFactoryConfig.useVirtualTexture &&
+                r.vulkanContext_->hasFragmentStoresAndAtomics();
+
             // Yield callback keeps the window responsive during heavy terrain loading
             terrainFactoryConfig.yieldCallback = [&r](float subProgress, const char* phase) {
                 float overallProgress = 0.20f + subProgress * 0.08f;

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -210,6 +210,12 @@ bool VulkanContext::selectPhysicalDevice() {
     multiDrawFeature.multiDrawIndirect = VK_TRUE;
     hasMultiDrawIndirect_ = vkbPhysicalDevice.enable_features_if_present(multiDrawFeature);
 
+    // Fragment shader SSBO writes/atomics - required by the virtual texture
+    // feedback buffer (terrain fragment shader requests tiles via atomicAdd)
+    VkPhysicalDeviceFeatures fragmentStoresFeature{};
+    fragmentStoresFeature.fragmentStoresAndAtomics = VK_TRUE;
+    hasFragmentStoresAndAtomics_ = vkbPhysicalDevice.enable_features_if_present(fragmentStoresFeature);
+
     VkPhysicalDeviceVulkan12Features drawCountFeature{};
     drawCountFeature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
     drawCountFeature.drawIndirectCount = VK_TRUE;
@@ -217,6 +223,7 @@ bool VulkanContext::selectPhysicalDevice() {
 
     SDL_Log("Indirect draw features: drawIndirectFirstInstance=%d multiDrawIndirect=%d drawIndirectCount=%d",
         hasDrawIndirectFirstInstance_, hasMultiDrawIndirect_, hasDrawIndirectCount_);
+    SDL_Log("Fragment stores and atomics (virtual texture feedback): %d", hasFragmentStoresAndAtomics_);
 
     // Create RAII wrapper for physical device (non-owning - physical devices aren't destroyed)
     raiiPhysicalDevice_ = std::make_unique<vk::raii::PhysicalDevice>(*raiiInstance_, physicalDevice);

--- a/src/core/vulkan/VulkanContext.h
+++ b/src/core/vulkan/VulkanContext.h
@@ -133,6 +133,8 @@ public:
     bool hasMultiDrawIndirect() const { return hasMultiDrawIndirect_; }
     // firstInstance != 0 in (indexed) indirect draws -> required for per-object gl_InstanceIndex.
     bool hasDrawIndirectFirstInstance() const { return hasDrawIndirectFirstInstance_; }
+    // Fragment shader SSBO writes/atomics -> required for virtual texture feedback.
+    bool hasFragmentStoresAndAtomics() const { return hasFragmentStoresAndAtomics_; }
 
 private:
     bool createInstance();
@@ -168,6 +170,7 @@ private:
     bool hasDrawIndirectCount_ = false;
     bool hasMultiDrawIndirect_ = false;
     bool hasDrawIndirectFirstInstance_ = false;
+    bool hasFragmentStoresAndAtomics_ = false;
 
     VmaAllocator allocator = VK_NULL_HANDLE;
 

--- a/src/passes/HDRPassRecorder.cpp
+++ b/src/passes/HDRPassRecorder.cpp
@@ -57,6 +57,10 @@ void HDRPassRecorder::record(VkCommandBuffer cmd, uint32_t frameIndex, float tim
 
     vkCmd.endRenderPass();
 
+    if (postPassCallback_) {
+        postPassCallback_(cmd, frameIndex);
+    }
+
     profiler_.endGpuZone(cmd, "HDRPass");
 }
 
@@ -76,6 +80,10 @@ void HDRPassRecorder::recordWithSecondaries(VkCommandBuffer cmd, uint32_t frameI
     }
 
     vkCmd.endRenderPass();
+
+    if (postPassCallback_) {
+        postPassCallback_(cmd, frameIndex);
+    }
 
     profiler_.endGpuZone(cmd, "HDRPass");
 }

--- a/src/passes/HDRPassRecorder.h
+++ b/src/passes/HDRPassRecorder.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <functional>
 
 #include "interfaces/IHDRDrawable.h"
 
@@ -76,6 +77,13 @@ public:
     void recordSecondarySlot(VkCommandBuffer cmd, uint32_t frameIndex, float time,
                              uint32_t slot, const Params& params);
 
+    // Callback recorded into the primary command buffer right after the HDR
+    // render pass ends (outside any render pass) - used for transfer work that
+    // depends on the pass's fragment output, e.g. the virtual texture
+    // feedback readback copy.
+    using PostPassCallback = std::function<void(VkCommandBuffer cmd, uint32_t frameIndex)>;
+    void setPostPassCallback(PostPassCallback callback) { postPassCallback_ = std::move(callback); }
+
 private:
     struct RegisteredDrawable {
         std::unique_ptr<IHDRDrawable> drawable;
@@ -89,4 +97,5 @@ private:
     Profiler& profiler_;
     PostProcessSystem& postProcess_;
     std::vector<RegisteredDrawable> drawables_;
+    PostPassCallback postPassCallback_;
 };

--- a/src/passes/SceneComposition.cpp
+++ b/src/passes/SceneComposition.cpp
@@ -29,6 +29,14 @@ std::unique_ptr<HDRPassRecorder> buildHDRPassRecorder(
     auto recorder = std::make_unique<HDRPassRecorder>(
         systems.profiler(), systems.postProcess());
 
+    // Virtual texture feedback: copy the GPU feedback buffer (written by the
+    // terrain fragment shader during the HDR pass) to its CPU readback buffer
+    recorder->setPostPassCallback([&systems](VkCommandBuffer cmd, uint32_t frameIndex) {
+        if (systems.terrain().hasVirtualTexture() && systems.terrain().isTerrainEnabled()) {
+            systems.terrain().recordVirtualTextureFeedbackCopy(cmd, frameIndex);
+        }
+    });
+
     // Draw order constants - controls rendering sequence within the HDR pass.
     // Slot assignment groups drawables for parallel secondary command buffer recording.
     // Slot 0: geometry base, Slot 1: scene meshes, Slot 2: effects/vegetation/debug

--- a/src/terrain/TerrainDescriptorSets.cpp
+++ b/src/terrain/TerrainDescriptorSets.cpp
@@ -4,6 +4,7 @@
 #include "TerrainTextures.h"
 #include "TerrainTileCache.h"
 #include "TerrainEffects.h"
+#include "VirtualTextureSystem.h"
 #include "DescriptorManager.h"
 #include "UBOs.h"
 #include <vulkan/vulkan.hpp>
@@ -56,6 +57,7 @@ bool TerrainDescriptorSets::createLayouts() {
     // 17: snow UBO, 18: cloud shadow UBO, 19: tile array, 20: tile info
     // 21: caustics, 22: caustics UBO, 29: liquid UBO, 30: material layer UBO
     // 31: screen-space shadow
+    // 24-28: virtual texture (page table, cache, feedback, counter, params)
     renderLayout_ = DescriptorManager::LayoutBuilder(device_)
         .addBinding(0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_VERTEX_BIT)
         .addBinding(3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
@@ -77,6 +79,11 @@ bool TerrainDescriptorSets::createLayouts() {
         .addBinding(20, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_VERTEX_BIT)
         .addBinding(21, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)
         .addBinding(22, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
+        .addBinding(24, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)
+        .addBinding(25, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)
+        .addBinding(26, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
+        .addBinding(27, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
+        .addBinding(28, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
         .addBinding(29, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
         .addBinding(30, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_SHADER_STAGE_FRAGMENT_BIT)
         .addBinding(31, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_SHADER_STAGE_FRAGMENT_BIT)
@@ -152,7 +159,8 @@ void TerrainDescriptorSets::updateRenderBindings(TerrainCBT* cbt,
                                                    vk::ImageView shadowMapView,
                                                    vk::Sampler shadowSampler,
                                                    const std::vector<vk::Buffer>& snowUBOBuffers,
-                                                   const std::vector<vk::Buffer>& cloudShadowUBOBuffers) {
+                                                   const std::vector<vk::Buffer>& cloudShadowUBOBuffers,
+                                                   VirtualTexture::VirtualTextureSystem* virtualTexture) {
     for (uint32_t i = 0; i < framesInFlight_; i++) {
         auto writer = DescriptorManager::SetWriter(device_, renderSets_[i]);
 
@@ -218,6 +226,22 @@ void TerrainDescriptorSets::updateRenderBindings(TerrainCBT* cbt,
 
         constexpr VkDeviceSize causticsUBOSize = 32;
         writer.writeBuffer(22, buffers->getCausticsUniformBuffer(i), 0, causticsUBOSize);
+
+        // Virtual texture bindings (feedback buffers are per frame in flight)
+        if (virtualTexture) {
+            writer.writeImage(24, virtualTexture->getPageTableImageView(),
+                             virtualTexture->getPageTableSampler(),
+                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            writer.writeImage(25, virtualTexture->getCacheImageView(),
+                             virtualTexture->getCacheSampler(),
+                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+            writer.writeBuffer(26, virtualTexture->getFeedbackBuffer(i), 0, VK_WHOLE_SIZE,
+                              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+            writer.writeBuffer(27, virtualTexture->getCounterBuffer(i), 0, VK_WHOLE_SIZE,
+                              VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+            writer.writeBuffer(28, virtualTexture->getParamsBuffer(), 0,
+                              sizeof(VirtualTexture::VTParamsUBO));
+        }
 
         constexpr VkDeviceSize liquidUBOSize = 128;
         writer.writeBuffer(29, buffers->getLiquidUniformBuffer(i), 0, liquidUBOSize);

--- a/src/terrain/TerrainDescriptorSets.h
+++ b/src/terrain/TerrainDescriptorSets.h
@@ -11,6 +11,7 @@ class TerrainBuffers;
 class TerrainTextures;
 class TerrainTileCache;
 class TerrainEffects;
+namespace VirtualTexture { class VirtualTextureSystem; }
 
 /**
  * TerrainDescriptorSets - Owns and manages Vulkan descriptor set layouts and sets
@@ -54,6 +55,8 @@ public:
     void writeInitialComputeBindings(TerrainCBT* cbt, TerrainBuffers* buffers, TerrainTileCache* tileCache);
 
     // Write full render descriptor bindings with shared external resources
+    // virtualTexture may be null (VT bindings are then left unwritten; the
+    // non-VT pipeline doesn't statically use them)
     void updateRenderBindings(TerrainCBT* cbt,
                               TerrainBuffers* buffers,
                               TerrainTextures* textures,
@@ -63,7 +66,8 @@ public:
                               vk::ImageView shadowMapView,
                               vk::Sampler shadowSampler,
                               const std::vector<vk::Buffer>& snowUBOBuffers,
-                              const std::vector<vk::Buffer>& cloudShadowUBOBuffers);
+                              const std::vector<vk::Buffer>& cloudShadowUBOBuffers,
+                              VirtualTexture::VirtualTextureSystem* virtualTexture = nullptr);
 
     // Individual texture binding updates (called when external systems provide resources)
     void writeSnowMask(vk::ImageView view, vk::Sampler sampler);

--- a/src/terrain/TerrainPipelines.cpp
+++ b/src/terrain/TerrainPipelines.cpp
@@ -33,6 +33,7 @@ bool TerrainPipelines::initInternal(const InitInfo& info) {
     useMeshlets = info.useMeshlets;
     meshletIndexCount = info.meshletIndexCount;
     subgroupCaps = info.subgroupCaps;
+    useVirtualTexture = info.useVirtualTexture;
 
     if (!createDispatcherPipeline()) return false;
     if (!createSubdivisionPipeline()) return false;
@@ -206,10 +207,15 @@ bool TerrainPipelines::createRenderPipeline() {
     }
     renderPipelineLayout_ = std::move(layoutOpt);
 
-    // Create filled render pipeline
+    // Create filled render pipeline. The VT variant is terrain.frag compiled
+    // with USE_VIRTUAL_TEXTURE (sampling the megatexture instead of triplanar).
+    const std::string fragShader = useVirtualTexture
+        ? shaderPath + "/terrain/terrain_vt.frag.spv"
+        : shaderPath + "/terrain/terrain.frag.spv";
+
     PipelineBuilder builder(device);
     builder.addShaderStage(shaderPath + "/terrain/terrain.vert.spv", VK_SHADER_STAGE_VERTEX_BIT)
-           .addShaderStage(shaderPath + "/terrain/terrain.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT);
+           .addShaderStage(fragShader, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     VkPipeline rawPipeline = VK_NULL_HANDLE;
     if (!builder.buildGraphicsPipeline(PipelinePresets::filled(renderPass), **renderPipelineLayout_, rawPipeline)) {
@@ -258,9 +264,13 @@ bool TerrainPipelines::createShadowPipeline() {
 }
 
 bool TerrainPipelines::createMeshletRenderPipeline() {
+    const std::string fragShader = useVirtualTexture
+        ? shaderPath + "/terrain/terrain_vt.frag.spv"
+        : shaderPath + "/terrain/terrain.frag.spv";
+
     PipelineBuilder builder(device);
     builder.addShaderStage(shaderPath + "/terrain/terrain_meshlet.vert.spv", VK_SHADER_STAGE_VERTEX_BIT)
-           .addShaderStage(shaderPath + "/terrain/terrain.frag.spv", VK_SHADER_STAGE_FRAGMENT_BIT);
+           .addShaderStage(fragShader, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     auto cfg = PipelinePresets::filled(renderPass);
     cfg.useMeshletVertexInput = true;

--- a/src/terrain/TerrainPipelines.h
+++ b/src/terrain/TerrainPipelines.h
@@ -29,6 +29,7 @@ public:
         bool useMeshlets;
         uint32_t meshletIndexCount;  // From TerrainMeshlet::getIndexCount()
         const SubgroupCapabilities* subgroupCaps;  // For optimized compute paths
+        bool useVirtualTexture = false;  // Use the VT fragment shader variant
     };
 
     /**
@@ -115,6 +116,7 @@ private:
     bool useMeshlets = false;
     uint32_t meshletIndexCount = 0;
     const SubgroupCapabilities* subgroupCaps = nullptr;
+    bool useVirtualTexture = false;
 
     // Compute pipelines
     std::optional<vk::raii::PipelineLayout> dispatcherPipelineLayout_;

--- a/src/terrain/TerrainRecording.cpp
+++ b/src/terrain/TerrainRecording.cpp
@@ -73,6 +73,15 @@ void TerrainSystem::updateUniforms(uint32_t frameIndex, const glm::vec3& cameraP
 }
 
 void TerrainSystem::recordCompute(vk::CommandBuffer cmd, uint32_t frameIndex, GpuProfiler* profiler) {
+    // Virtual texture frame work: process last completed frame's feedback,
+    // record tile/page-table uploads, then clear this frame's feedback buffer.
+    // Must run before the early-out below - VT streaming continues even when
+    // subdivision compute is skipped.
+    if (virtualTexture) {
+        virtualTexture->update(cmd, frameIndex);
+        virtualTexture->beginFrame(cmd, frameIndex);
+    }
+
     // Update tile info buffer binding to the correct frame's buffer (triple-buffered to avoid CPU-GPU sync)
     descriptorSets_->writeTileInfoCompute(frameIndex, tileCache.get());
 
@@ -323,6 +332,14 @@ void TerrainSystem::recordDraw(vk::CommandBuffer cmd, uint32_t frameIndex) {
         // Direct vertex draw (no vertex buffer - vertices generated from gl_VertexIndex)
         vkCmd.drawIndirect(buffers->getIndirectDrawBuffer(), 0, 1, sizeof(VkDrawIndirectCommand));
         DIAG_RECORD_DRAW();
+    }
+}
+
+void TerrainSystem::recordVirtualTextureFeedbackCopy(vk::CommandBuffer cmd, uint32_t frameIndex) {
+    // Copies this frame's GPU feedback buffer to its CPU readback buffer.
+    // Must be recorded after the HDR render pass (outside any render pass).
+    if (virtualTexture) {
+        virtualTexture->endFrame(cmd, frameIndex);
     }
 }
 

--- a/src/terrain/TerrainSystem.cpp
+++ b/src/terrain/TerrainSystem.cpp
@@ -112,7 +112,9 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
         vtConfig.virtualSizePixels = 8192;  // 64 * 128 = 8192
         vtConfig.tileSizePixels = 128;
         vtConfig.cacheSizePixels = 2048;    // 16x16 tiles in cache
-        vtConfig.borderPixels = 4;
+        // Tiles are generated without gutters and the cache places them at a
+        // tileSize stride, so the border must be 0 (see VirtualTextureConfig)
+        vtConfig.borderPixels = 0;
         vtConfig.maxMipLevels = 6;
 
         VirtualTexture::VirtualTextureSystem::InitInfo vtInfo;
@@ -173,6 +175,7 @@ bool TerrainSystem::initInternal(const InitInfo& info, const TerrainConfig& cfg)
     pipelineInfo.useMeshlets = config.useMeshlets;
     pipelineInfo.meshletIndexCount = config.useMeshlets && meshlet ? meshlet->getIndexCount() : 0;
     pipelineInfo.subgroupCaps = &subgroupCaps;
+    pipelineInfo.useVirtualTexture = virtualTexture != nullptr;
     pipelines = TerrainPipelines::create(pipelineInfo);
     if (!pipelines) return false;
 
@@ -365,7 +368,8 @@ void TerrainSystem::updateDescriptorSets(vk::Device device,
     descriptorSets_->updateRenderBindings(cbt.get(), buffers.get(), textures.get(),
                                            tileCache.get(), &effects,
                                            sceneUniformBuffers, shadowMapView, shadowSampler,
-                                           snowUBOBuffers, cloudShadowUBOBuffers);
+                                           snowUBOBuffers, cloudShadowUBOBuffers,
+                                           virtualTexture.get());
 }
 
 void TerrainSystem::setSnowMask(vk::Device device, vk::ImageView snowMaskView, vk::Sampler snowMaskSampler) {

--- a/src/terrain/TerrainSystem.h
+++ b/src/terrain/TerrainSystem.h
@@ -247,6 +247,14 @@ public:
         recordDraw(vk::CommandBuffer(cmd), frameIndex);
     }
 
+    // Record the virtual texture feedback copy (GPU feedback -> CPU readback).
+    // Call once per frame after the HDR render pass, outside any render pass.
+    // No-op when virtual texturing is disabled.
+    void recordVirtualTextureFeedbackCopy(vk::CommandBuffer cmd, uint32_t frameIndex);
+
+    // Whether virtual texturing is active for this terrain
+    bool hasVirtualTexture() const { return virtualTexture != nullptr; }
+
     // Record shadow pass for terrain
     void recordShadowDraw(vk::CommandBuffer cmd, uint32_t frameIndex,
                           const glm::mat4& lightViewProj, int cascadeIndex);

--- a/src/terrain/virtual_texture/VirtualTextureCache.cpp
+++ b/src/terrain/virtual_texture/VirtualTextureCache.cpp
@@ -48,6 +48,8 @@ VirtualTextureCache::VirtualTextureCache(VirtualTextureCache&& other) noexcept
     , cacheSampler_(std::move(other.cacheSampler_))
     , stagingBuffers_(std::move(other.stagingBuffers_))
     , stagingMapped_(std::move(other.stagingMapped_))
+    , stagingCursor_(other.stagingCursor_)
+    , maxUploadsPerFrame_(other.maxUploadsPerFrame_)
     , framesInFlight_(other.framesInFlight_)
     , slots(std::move(other.slots))
     , tileToSlot(std::move(other.tileToSlot))
@@ -79,6 +81,8 @@ VirtualTextureCache& VirtualTextureCache::operator=(VirtualTextureCache&& other)
         cacheSampler_ = std::move(other.cacheSampler_);
         stagingBuffers_ = std::move(other.stagingBuffers_);
         stagingMapped_ = std::move(other.stagingMapped_);
+        stagingCursor_ = other.stagingCursor_;
+        maxUploadsPerFrame_ = other.maxUploadsPerFrame_;
         framesInFlight_ = other.framesInFlight_;
         slots = std::move(other.slots);
         tileToSlot = std::move(other.tileToSlot);
@@ -130,14 +134,11 @@ bool VirtualTextureCache::initInternal(const InitInfo& info) {
         return false;
     }
 
-    // Create per-frame staging buffers to avoid race conditions with in-flight frames
-    // BC1: 8 bytes per 4x4 block = 0.5 bytes per pixel
-    // RGBA8: 4 bytes per pixel
-    uint32_t blockWidth = (config.tileSizePixels + 3) / 4;
-    uint32_t blockHeight = (config.tileSizePixels + 3) / 4;
-    VkDeviceSize stagingSize = useCompression_
-        ? (blockWidth * blockHeight * 8)  // BC1: 8 bytes per block
-        : (config.tileSizePixels * config.tileSizePixels * 4);  // RGBA8
+    // Create per-frame staging buffers to avoid race conditions with in-flight
+    // frames. Each buffer holds one region per upload that can be recorded in
+    // a frame, since the copy commands execute after recording finishes.
+    maxUploadsPerFrame_ = info.maxUploadsPerFrame;
+    VkDeviceSize stagingSize = getTileStagingSize() * maxUploadsPerFrame_;
 
     stagingBuffers_.resize(framesInFlight_);
     stagingMapped_.resize(framesInFlight_);
@@ -234,7 +235,8 @@ bool VirtualTextureCache::createSampler(VkDevice device) {
     return true;
 }
 
-CacheSlot* VirtualTextureCache::allocateSlot(TileId id, uint32_t currentFrame) {
+CacheSlot* VirtualTextureCache::allocateSlot(TileId id, uint32_t currentFrame,
+                                             std::optional<TileId>* evictedTile) {
     uint32_t packed = id.pack();
 
     // Check if already in cache
@@ -256,11 +258,15 @@ CacheSlot* VirtualTextureCache::allocateSlot(TileId id, uint32_t currentFrame) {
     }
 
     // No empty slots, evict LRU
-    size_t lruIndex = findLRUSlot();
+    size_t lruIndex = findLRUSlot(currentFrame);
     if (lruIndex < slots.size()) {
-        // Remove old mapping
-        uint32_t oldPacked = slots[lruIndex].tileId.pack();
-        tileToSlot.erase(oldPacked);
+        // Remove old mapping and report the eviction so the caller can
+        // invalidate the evicted tile's page table entry
+        TileId oldTile = slots[lruIndex].tileId;
+        tileToSlot.erase(oldTile.pack());
+        if (evictedTile) {
+            *evictedTile = oldTile;
+        }
 
         // Set new tile
         slots[lruIndex].tileId = id;
@@ -291,12 +297,16 @@ const CacheSlot* VirtualTextureCache::getSlot(TileId id) const {
     return nullptr;
 }
 
-size_t VirtualTextureCache::findLRUSlot() const {
-    size_t lruIndex = 0;
+size_t VirtualTextureCache::findLRUSlot(uint32_t currentFrame) const {
+    size_t lruIndex = slots.size();
     uint32_t oldestFrame = UINT32_MAX;
 
     for (size_t i = 0; i < slots.size(); ++i) {
-        if (slots[i].occupied && slots[i].lastUsedFrame < oldestFrame) {
+        if (!slots[i].occupied) continue;
+        // Skip slots in-flight frames may still sample: their page table
+        // version still maps this slot until those frames complete
+        if (slots[i].lastUsedFrame + framesInFlight_ > currentFrame) continue;
+        if (slots[i].lastUsedFrame < oldestFrame) {
             oldestFrame = slots[i].lastUsedFrame;
             lruIndex = i;
         }
@@ -305,14 +315,29 @@ size_t VirtualTextureCache::findLRUSlot() const {
     return lruIndex;
 }
 
-void VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
+VkDeviceSize VirtualTextureCache::getTileStagingSize() const {
+    if (useCompression_) {
+        // BC1: 8 bytes per 4x4 block
+        uint32_t blockWidth = (config.tileSizePixels + 3) / 4;
+        uint32_t blockHeight = (config.tileSizePixels + 3) / 4;
+        return blockWidth * blockHeight * 8;
+    }
+    // RGBA8: 4 bytes per pixel
+    return config.tileSizePixels * config.tileSizePixels * 4;
+}
+
+void VirtualTextureCache::beginFrame() {
+    stagingCursor_ = 0;
+}
+
+bool VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
                                             uint32_t width, uint32_t height,
                                             TileFormat format, VkCommandBuffer cmd, uint32_t frameIndex) {
     // Find the slot for this tile
     auto it = tileToSlot.find(id.pack());
     if (it == tileToSlot.end()) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Cannot upload tile not in cache");
-        return;
+        return false;
     }
 
     // Check format compatibility
@@ -322,14 +347,21 @@ void VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
             "Tile format mismatch: tile is %s, cache is %s",
             tileIsCompressed ? "compressed" : "RGBA8",
             useCompression_ ? "BC1" : "RGBA8");
-        return;
+        return false;
+    }
+
+    // An oversized tile would overwrite neighboring cache slots
+    if (width > config.tileSizePixels || height > config.tileSizePixels) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+            "Tile %ux%u exceeds cache slot size %u", width, height, config.tileSizePixels);
+        return false;
     }
 
     // Select the staging buffer for this frame to avoid race conditions
     uint32_t bufferIndex = frameIndex % framesInFlight_;
     if (bufferIndex >= stagingBuffers_.size() || !stagingMapped_[bufferIndex]) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Invalid staging buffer index %u", bufferIndex);
-        return;
+        return false;
     }
 
     size_t slotIndex = it->second;
@@ -349,8 +381,20 @@ void VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
         dataSize = width * height * 4;
     }
 
-    // Copy to per-frame staging buffer
-    std::memcpy(stagingMapped_[bufferIndex], pixelData, dataSize);
+    // Sub-allocate a region of the per-frame staging buffer. Regions can't be
+    // reused within a frame: the copy commands execute long after recording.
+    VkDeviceSize stagingCapacity = getTileStagingSize() * maxUploadsPerFrame_;
+    if (stagingCursor_ + dataSize > stagingCapacity) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "VT staging buffer exhausted for this frame (%u uploads max)",
+                    maxUploadsPerFrame_);
+        return false;
+    }
+    VkDeviceSize stagingOffset = stagingCursor_;
+    stagingCursor_ += dataSize;
+
+    std::memcpy(static_cast<uint8_t*>(stagingMapped_[bufferIndex]) + stagingOffset,
+                pixelData, dataSize);
 
     vk::CommandBuffer vkCmd(cmd);
 
@@ -378,7 +422,7 @@ void VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
     // Copy buffer to image region at tile slot position
     {
         auto region = vk::BufferImageCopy{}
-            .setBufferOffset(0)
+            .setBufferOffset(stagingOffset)
             .setBufferRowLength(0)
             .setBufferImageHeight(0)
             .setImageSubresource(vk::ImageSubresourceLayers{}
@@ -413,6 +457,8 @@ void VirtualTextureCache::recordTileUpload(TileId id, const void* pixelData,
                               vk::PipelineStageFlagBits::eFragmentShader,
                               {}, {}, {}, barrier);
     }
+
+    return true;
 }
 
 uint32_t VirtualTextureCache::getUsedSlotCount() const {

--- a/src/terrain/virtual_texture/VirtualTextureCache.h
+++ b/src/terrain/virtual_texture/VirtualTextureCache.h
@@ -35,6 +35,8 @@ public:
         VirtualTextureConfig config;
         uint32_t framesInFlight = 3;
         bool useCompression = false;
+        // Staging capacity: maximum tile uploads recorded per frame
+        uint32_t maxUploadsPerFrame = 16;
     };
 
     // Factory method - returns nullptr on failure
@@ -48,9 +50,14 @@ public:
     VirtualTextureCache(const VirtualTextureCache&) = delete;
     VirtualTextureCache& operator=(const VirtualTextureCache&) = delete;
 
-    // Allocate a slot for a new tile, evicting LRU if needed
-    // Returns the cache slot coordinates, or nullptr if allocation failed
-    CacheSlot* allocateSlot(TileId id, uint32_t currentFrame);
+    // Allocate a slot for a new tile, evicting LRU if needed.
+    // Slots used within the last framesInFlight frames are never evicted
+    // (in-flight frames may still sample them), so allocation can fail.
+    // If an eviction occurred, evictedTile receives the evicted tile's id so
+    // the caller can invalidate its page table entry.
+    // Returns the cache slot, or nullptr if allocation failed.
+    CacheSlot* allocateSlot(TileId id, uint32_t currentFrame,
+                            std::optional<TileId>* evictedTile = nullptr);
 
     // Mark a tile as used this frame (for LRU tracking)
     void markUsed(TileId id, uint32_t currentFrame);
@@ -73,9 +80,15 @@ public:
      * @param format Tile format (RGBA8 or BC1)
      * @param cmd Command buffer to record into (must be in recording state)
      * @param frameIndex Current frame index for staging buffer selection
+     * @return false if the upload could not be recorded (format mismatch,
+     *         staging capacity exhausted, tile not in cache)
      */
-    void recordTileUpload(TileId id, const void* pixelData, uint32_t width, uint32_t height,
+    bool recordTileUpload(TileId id, const void* pixelData, uint32_t width, uint32_t height,
                           TileFormat format, VkCommandBuffer cmd, uint32_t frameIndex);
+
+    // Reset the staging sub-allocation cursor for this frame. Must be called
+    // once per frame before any recordTileUpload calls.
+    void beginFrame();
 
     // Check if the cache is using compressed BC1 format
     bool isCompressed() const { return useCompression_; }
@@ -108,8 +121,12 @@ public:
 private:
     bool initInternal(const InitInfo& info);
 
-    // Find LRU slot for eviction
-    size_t findLRUSlot() const;
+    // Find LRU slot for eviction, skipping slots that in-flight frames may
+    // still sample. Returns slots.size() if no slot is evictable.
+    size_t findLRUSlot(uint32_t currentFrame) const;
+
+    // Bytes needed to stage one tile in the cache's format
+    VkDeviceSize getTileStagingSize() const;
 
     // Create the cache texture
     bool createCacheTexture(VkDevice device, VmaAllocator allocator,
@@ -130,9 +147,14 @@ private:
     VmaImageHandle cacheImage_{};
     std::optional<vk::raii::Sampler> cacheSampler_;
 
-    // Per-frame staging buffers to avoid race conditions with in-flight frames
+    // Per-frame staging buffers to avoid race conditions with in-flight frames.
+    // Each buffer holds maxUploadsPerFrame_ tile regions; stagingCursor_ tracks
+    // the next free region within the current frame's buffer, because copy
+    // commands execute long after recording and regions must not be reused.
     std::vector<VmaBuffer> stagingBuffers_;
     std::vector<void*> stagingMapped_;
+    VkDeviceSize stagingCursor_ = 0;
+    uint32_t maxUploadsPerFrame_ = 16;
     uint32_t framesInFlight_ = 3;
 
     // Cache slot management

--- a/src/terrain/virtual_texture/VirtualTextureFeedback.cpp
+++ b/src/terrain/virtual_texture/VirtualTextureFeedback.cpp
@@ -86,9 +86,10 @@ void VirtualTextureFeedback::clear(VkCommandBuffer cmd, uint32_t frameIndex) {
     vk::CommandBuffer vkCmd(cmd);
     vkCmd.fillBuffer(fb.counterBuffer.get(), 0, sizeof(uint32_t), 0);
     {
+        // atomicAdd is a read-modify-write, so the shader both reads and writes
         auto barrier = vk::MemoryBarrier{}
             .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
-            .setDstAccessMask(vk::AccessFlagBits::eShaderRead);
+            .setDstAccessMask(vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite);
         vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
                               vk::PipelineStageFlagBits::eFragmentShader,
                               {}, barrier, {}, {});
@@ -163,13 +164,11 @@ void VirtualTextureFeedback::readback(uint32_t frameIndex) {
         return;
     }
 
-    // Read tile IDs and deduplicate
+    // Read tile IDs and deduplicate. The counter bounds the valid entries, so
+    // every value is a real request - including 0, which is tile (0,0) mip 0.
     const uint32_t* tileIds = static_cast<const uint32_t*>(fb.readbackMapped);
     for (uint32_t i = 0; i < count; ++i) {
-        uint32_t packed = tileIds[i];
-        if (packed != 0) { // 0 might be invalid/empty
-            requestedTilePacked.insert(packed);
-        }
+        requestedTilePacked.insert(tileIds[i]);
     }
 
     // Convert to TileId and sort by priority (lower mip first)

--- a/src/terrain/virtual_texture/VirtualTexturePageTable.cpp
+++ b/src/terrain/virtual_texture/VirtualTexturePageTable.cpp
@@ -72,9 +72,10 @@ bool VirtualTexturePageTable::initInternal(const InitInfo& info) {
         return false;
     }
 
-    // Create per-frame staging buffers (sized for largest mip level)
-    uint32_t maxMipSize = mipSizes[0];
-    VkDeviceSize stagingSize = maxMipSize * sizeof(uint32_t); // RGBA8 packed
+    // Create per-frame staging buffers, sized for the worst case of every
+    // mip level being dirty in the same frame (each dirty mip gets its own
+    // region of the buffer)
+    VkDeviceSize stagingSize = totalEntries * sizeof(uint32_t); // RGBA8 packed
     stagingBuffers_.resize(framesInFlight_);
     stagingMapped_.resize(framesInFlight_);
 
@@ -94,8 +95,6 @@ bool VirtualTexturePageTable::initInternal(const InitInfo& info) {
 
 void VirtualTexturePageTable::cleanup() {
     if (device_ == VK_NULL_HANDLE) return;  // Not initialized
-    VkDevice device = device_;
-    VmaAllocator allocator = allocator_;
     // VmaBuffer cleanup - unmap first
     for (size_t i = 0; i < stagingBuffers_.size(); ++i) {
         if (stagingMapped_[i]) {
@@ -108,14 +107,7 @@ void VirtualTexturePageTable::cleanup() {
     stagingMapped_.clear();
 
     pageTableSampler_.reset();
-
-    vk::Device vkDevice(device);
-    if (combinedImageView != VK_NULL_HANDLE) {
-        vkDevice.destroyImageView(combinedImageView);
-        combinedImageView = VK_NULL_HANDLE;
-    }
-
-    pageTableImages_.clear();
+    pageTableImage_.reset();
 
     cpuData.clear();
     mipOffsets.clear();
@@ -125,55 +117,51 @@ void VirtualTexturePageTable::cleanup() {
 
 bool VirtualTexturePageTable::createPageTableTextures(VkDevice device, VmaAllocator allocator,
                                                        VkCommandPool commandPool, VkQueue queue) {
-    pageTableImages_.resize(config.maxMipLevels);
+    // Single array image: every layer is sized for mip 0; mip N's entries
+    // occupy the top-left corner of layer N. This wastes a little memory but
+    // lets the shader address all mips through one usampler2DArray.
+    uint32_t tilesPerAxis = config.getTilesPerAxis();
 
-    for (uint32_t mip = 0; mip < config.maxMipLevels; ++mip) {
-        uint32_t tilesAtMip = config.getTilesAtMip(mip);
+    VmaImageSpec spec{};
+    spec = spec.withFormat(vk::Format::eR8G8B8A8Uint)
+        .withExtent(vk::Extent3D{tilesPerAxis, tilesPerAxis, 1})
+        .withMipLevels(1)
+        .withArrayLayers(config.maxMipLevels)
+        .withUsage(vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eSampled)
+        .withView(vk::ImageViewType::e2DArray, vk::ImageAspectFlagBits::eColor,
+                  0, 1, 0, config.maxMipLevels)
+        .withRequiredFlags(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-        VmaImageSpec spec{};
-        spec = spec.withFormat(vk::Format::eR8G8B8A8Uint)
-            .withExtent(vk::Extent3D{tilesAtMip, tilesAtMip, 1})
-            .withMipLevels(1)
-            .withUsage(vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eSampled)
-            .withView(vk::ImageViewType::e2D, vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1)
-            .withRequiredFlags(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-        pageTableImages_[mip] = spec.build(allocator, device);
-        if (!pageTableImages_[mip].isValid()) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create page table image for mip %u", mip);
-            return false;
-        }
+    pageTableImage_ = spec.build(allocator, device);
+    if (!pageTableImage_.isValid()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create page table array image");
+        return false;
     }
 
-    // Transition all images to shader read layout
+    // Transition all layers to shader read layout
     {
         CommandScope cmdScope(device, commandPool, queue);
         if (!cmdScope.begin()) return false;
 
         vk::CommandBuffer vkCmd(cmdScope.get());
-        std::vector<vk::ImageMemoryBarrier> barriers;
-        barriers.reserve(config.maxMipLevels);
-
-        for (uint32_t mip = 0; mip < config.maxMipLevels; ++mip) {
-            barriers.push_back(vk::ImageMemoryBarrier{}
-                .setSrcAccessMask(vk::AccessFlags{})
-                .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
-                .setOldLayout(vk::ImageLayout::eUndefined)
-                .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
-                .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setImage(pageTableImages_[mip].getImage())
-                .setSubresourceRange(vk::ImageSubresourceRange{}
-                    .setAspectMask(vk::ImageAspectFlagBits::eColor)
-                    .setBaseMipLevel(0)
-                    .setLevelCount(1)
-                    .setBaseArrayLayer(0)
-                    .setLayerCount(1)));
-        }
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setSrcAccessMask(vk::AccessFlags{})
+            .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+            .setOldLayout(vk::ImageLayout::eUndefined)
+            .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+            .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setImage(pageTableImage_.getImage())
+            .setSubresourceRange(vk::ImageSubresourceRange{}
+                .setAspectMask(vk::ImageAspectFlagBits::eColor)
+                .setBaseMipLevel(0)
+                .setLevelCount(1)
+                .setBaseArrayLayer(0)
+                .setLayerCount(config.maxMipLevels));
 
         vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTopOfPipe,
                               vk::PipelineStageFlagBits::eFragmentShader,
-                              {}, {}, {}, barriers);
+                              {}, {}, {}, barrier);
 
         if (!cmdScope.end()) return false;
     }
@@ -235,11 +223,6 @@ PageTableEntry VirtualTexturePageTable::getEntry(TileId id) const {
     return cpuData[index];
 }
 
-VkImageView VirtualTexturePageTable::getImageView(uint32_t mipLevel) const {
-    if (mipLevel >= pageTableImages_.size()) return VK_NULL_HANDLE;
-    return pageTableImages_[mipLevel].getView();
-}
-
 void VirtualTexturePageTable::recordUpload(VkCommandBuffer cmd, uint32_t frameIndex) {
     if (!dirty) return;
 
@@ -250,80 +233,80 @@ void VirtualTexturePageTable::recordUpload(VkCommandBuffer cmd, uint32_t frameIn
         return;
     }
 
+    vk::CommandBuffer vkCmd(cmd);
+
+    auto fullRange = vk::ImageSubresourceRange{}
+        .setAspectMask(vk::ImageAspectFlagBits::eColor)
+        .setBaseMipLevel(0)
+        .setLevelCount(1)
+        .setBaseArrayLayer(0)
+        .setLayerCount(config.maxMipLevels);
+
+    // Transition all layers to transfer dst
+    {
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setSrcAccessMask(vk::AccessFlagBits::eShaderRead)
+            .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
+            .setOldLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+            .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setImage(pageTableImage_.getImage())
+            .setSubresourceRange(fullRange);
+        vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eFragmentShader,
+                              vk::PipelineStageFlagBits::eTransfer,
+                              {}, {}, {}, barrier);
+    }
+
+    // Each dirty mip gets its own region of the staging buffer; the copy
+    // commands execute long after this function returns, so regions must
+    // not be reused within a frame
+    uint32_t* staging = static_cast<uint32_t*>(stagingMapped_[bufferIndex]);
+    size_t stagingCursor = 0;
+
     for (uint32_t mip = 0; mip < config.maxMipLevels; ++mip) {
         if (!mipDirty[mip]) continue;
 
         uint32_t tilesAtMip = config.getTilesAtMip(mip);
         size_t numEntries = mipSizes[mip];
 
-        // Pack entries into per-frame staging buffer
-        uint32_t* packed = static_cast<uint32_t*>(stagingMapped_[bufferIndex]);
         for (size_t i = 0; i < numEntries; ++i) {
-            packed[i] = cpuData[mipOffsets[mip] + i].packRGBA8();
+            staging[stagingCursor + i] = cpuData[mipOffsets[mip] + i].packRGBA8();
         }
 
-        vk::CommandBuffer vkCmd(cmd);
+        // Copy into this mip's layer (data sits in the top-left corner)
+        auto region = vk::BufferImageCopy{}
+            .setBufferOffset(stagingCursor * sizeof(uint32_t))
+            .setBufferRowLength(0)
+            .setBufferImageHeight(0)
+            .setImageSubresource(vk::ImageSubresourceLayers{}
+                .setAspectMask(vk::ImageAspectFlagBits::eColor)
+                .setMipLevel(0)
+                .setBaseArrayLayer(mip)
+                .setLayerCount(1))
+            .setImageOffset({0, 0, 0})
+            .setImageExtent({tilesAtMip, tilesAtMip, 1});
+        vkCmd.copyBufferToImage(stagingBuffers_[bufferIndex].get(), pageTableImage_.getImage(),
+                                vk::ImageLayout::eTransferDstOptimal, region);
 
-        // Transition to transfer dst
-        {
-            auto barrier = vk::ImageMemoryBarrier{}
-                .setSrcAccessMask(vk::AccessFlagBits::eShaderRead)
-                .setDstAccessMask(vk::AccessFlagBits::eTransferWrite)
-                .setOldLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
-                .setNewLayout(vk::ImageLayout::eTransferDstOptimal)
-                .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setImage(pageTableImages_[mip].getImage())
-                .setSubresourceRange(vk::ImageSubresourceRange{}
-                    .setAspectMask(vk::ImageAspectFlagBits::eColor)
-                    .setBaseMipLevel(0)
-                    .setLevelCount(1)
-                    .setBaseArrayLayer(0)
-                    .setLayerCount(1));
-            vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eFragmentShader,
-                                  vk::PipelineStageFlagBits::eTransfer,
-                                  {}, {}, {}, barrier);
-        }
-
-        // Copy buffer to page table image
-        {
-            auto region = vk::BufferImageCopy{}
-                .setBufferOffset(0)
-                .setBufferRowLength(0)
-                .setBufferImageHeight(0)
-                .setImageSubresource(vk::ImageSubresourceLayers{}
-                    .setAspectMask(vk::ImageAspectFlagBits::eColor)
-                    .setMipLevel(0)
-                    .setBaseArrayLayer(0)
-                    .setLayerCount(1))
-                .setImageOffset({0, 0, 0})
-                .setImageExtent({tilesAtMip, tilesAtMip, 1});
-            vkCmd.copyBufferToImage(stagingBuffers_[bufferIndex].get(), pageTableImages_[mip].getImage(),
-                                    vk::ImageLayout::eTransferDstOptimal, region);
-        }
-
-        // Transition back to shader read
-        {
-            auto barrier = vk::ImageMemoryBarrier{}
-                .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
-                .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
-                .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
-                .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
-                .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
-                .setImage(pageTableImages_[mip].getImage())
-                .setSubresourceRange(vk::ImageSubresourceRange{}
-                    .setAspectMask(vk::ImageAspectFlagBits::eColor)
-                    .setBaseMipLevel(0)
-                    .setLevelCount(1)
-                    .setBaseArrayLayer(0)
-                    .setLayerCount(1));
-            vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
-                                  vk::PipelineStageFlagBits::eFragmentShader,
-                                  {}, {}, {}, barrier);
-        }
-
+        stagingCursor += numEntries;
         mipDirty[mip] = false;
+    }
+
+    // Transition back to shader read
+    {
+        auto barrier = vk::ImageMemoryBarrier{}
+            .setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+            .setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+            .setOldLayout(vk::ImageLayout::eTransferDstOptimal)
+            .setNewLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+            .setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+            .setImage(pageTableImage_.getImage())
+            .setSubresourceRange(fullRange);
+        vkCmd.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+                              vk::PipelineStageFlagBits::eFragmentShader,
+                              {}, {}, {}, barrier);
     }
 
     dirty = false;

--- a/src/terrain/virtual_texture/VirtualTexturePageTable.h
+++ b/src/terrain/virtual_texture/VirtualTexturePageTable.h
@@ -71,14 +71,11 @@ public:
     // Check if any entries have changed
     bool isDirty() const { return dirty; }
 
-    // Get the image view for a mip level
-    VkImageView getImageView(uint32_t mipLevel) const;
-
     // Get the sampler for the page table
     VkSampler getSampler() const { return pageTableSampler_ ? **pageTableSampler_ : VK_NULL_HANDLE; }
 
-    // Get the combined image view (array of all mip levels)
-    VkImageView getCombinedImageView() const { return combinedImageView; }
+    // Get the combined image view (texture array, one layer per mip level)
+    VkImageView getCombinedImageView() const { return pageTableImage_.getView(); }
 
 
 private:
@@ -100,11 +97,10 @@ private:
     VmaAllocator allocator_ = VK_NULL_HANDLE;
     const vk::raii::Device* raiiDevice_ = nullptr;
 
-    // One image per mip level
-    std::vector<VmaImageHandle> pageTableImages_;
-
-    // Combined image view (texture array)
-    VkImageView combinedImageView = VK_NULL_HANDLE;
+    // Single array image: one layer per mip level, all layers sized for mip 0.
+    // Mip N's entries occupy the top-left corner of layer N, matching the
+    // shader's texelFetch(vtPageTable, ivec3(x, y, mip)) addressing.
+    VmaImageHandle pageTableImage_;
     std::optional<vk::raii::Sampler> pageTableSampler_;
 
     // Per-frame staging buffers to avoid race conditions with in-flight frames

--- a/src/terrain/virtual_texture/VirtualTextureSystem.cpp
+++ b/src/terrain/virtual_texture/VirtualTextureSystem.cpp
@@ -1,7 +1,9 @@
 #include "VirtualTextureSystem.h"
+#include "VmaBufferFactory.h"
 #include <vulkan/vulkan.hpp>
 #include <SDL3/SDL_log.h>
 #include <algorithm>
+#include <cstring>
 
 namespace VirtualTexture {
 
@@ -31,6 +33,7 @@ bool VirtualTextureSystem::init(const InitInfo& info) {
     cacheInfo.config = config;
     cacheInfo.framesInFlight = framesInFlight_;
     cacheInfo.useCompression = false;
+    cacheInfo.maxUploadsPerFrame = MAX_UPLOADS_PER_FRAME;
 
     cache = VirtualTextureCache::create(cacheInfo);
     if (!cache) {
@@ -68,6 +71,18 @@ bool VirtualTextureSystem::init(const InitInfo& info) {
         return false;
     }
 
+    // Create and fill the params UBO (constant for the system's lifetime)
+    if (!VmaBufferFactory::createUniformBuffer(info.allocator, sizeof(VTParamsUBO), paramsBuffer_)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create VT params UBO");
+        return false;
+    }
+    {
+        VTParamsUBO params = getParams();
+        void* mapped = paramsBuffer_.map();
+        std::memcpy(mapped, &params, sizeof(params));
+        paramsBuffer_.unmap();
+    }
+
     SDL_Log("VirtualTextureSystem initialized successfully");
     return true;
 }
@@ -78,7 +93,9 @@ void VirtualTextureSystem::destroy(VkDevice device, VmaAllocator allocator) {
     feedback.reset();
     pageTable.reset();
     cache.reset();
+    paramsBuffer_.reset();
     pendingTiles.clear();
+    pendingUploads_.clear();
 }
 
 void VirtualTextureSystem::beginFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
@@ -104,13 +121,14 @@ void VirtualTextureSystem::endFrame(VkCommandBuffer cmd, uint32_t frameIndex) {
 void VirtualTextureSystem::update(VkCommandBuffer cmd, uint32_t frameIndex) {
     currentFrame++;
 
-    // Process feedback from a COMPLETED frame.
-    // With N frames in flight, we read back from frame (currentFrame - framesInFlight)
-    // to ensure the GPU has finished writing to it.
-    // For the first few frames, we skip feedback processing since no frames have completed yet.
-    if (currentFrame >= framesInFlight_) {
-        uint32_t readbackFrameIndex = (frameIndex + framesInFlight_ - 1) % framesInFlight_;
-        processFeedback(readbackFrameIndex);
+    // Process feedback from a COMPLETED frame. The only fence-safe slot is
+    // frameIndex itself: it was last written framesInFlight frames ago and
+    // the caller has just waited on that frame's fence. Any other slot may
+    // still be in flight on the GPU.
+    // For the first few frames, we skip feedback processing since the slot
+    // hasn't been written yet.
+    if (currentFrame > framesInFlight_) {
+        processFeedback(frameIndex);
     }
 
     // Record upload commands for any tiles that finished loading
@@ -224,49 +242,62 @@ void VirtualTextureSystem::processFeedback(uint32_t frameIndex) {
 }
 
 void VirtualTextureSystem::recordPendingTileUploads(VkCommandBuffer cmd, uint32_t frameIndex) {
-    // Get tiles that finished loading
-    std::vector<LoadedTile> loaded = tileLoader->getLoadedTiles();
+    // Collect tiles that finished loading; anything beyond this frame's
+    // upload budget stays in the queue and is retried next frame
+    for (auto& tile : tileLoader->getLoadedTiles()) {
+        pendingUploads_.push_back(std::move(tile));
+    }
 
-    if (loaded.empty()) {
+    if (pendingUploads_.empty()) {
         return;
     }
 
+    cache->beginFrame();
+
+    uint32_t slotsPerAxis = config.getCacheTilesPerAxis();
     uint32_t uploaded = 0;
-    for (auto& tile : loaded) {
-        if (uploaded >= MAX_UPLOADS_PER_FRAME) {
-            // Re-queue remaining tiles for next frame
-            // In a real implementation, we'd keep them in a local buffer
+
+    while (!pendingUploads_.empty() && uploaded < MAX_UPLOADS_PER_FRAME) {
+        LoadedTile& tile = pendingUploads_.front();
+        uint32_t packed = tile.id.pack();
+
+        // Allocate cache slot, invalidating the evicted tile's page table
+        // entry if eviction occurred
+        std::optional<TileId> evicted;
+        CacheSlot* slot = cache->allocateSlot(tile.id, currentFrame, &evicted);
+        if (!slot) {
+            // Every slot is occupied by recently-used tiles; retry next frame
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "VT: Cache full, deferring %zu tile uploads", pendingUploads_.size());
             break;
         }
-
-        // Allocate cache slot
-        CacheSlot* slot = cache->allocateSlot(tile.id, currentFrame);
-        if (!slot) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "VT: Failed to allocate cache slot for tile");
-            continue;
+        if (evicted) {
+            pageTable->clearEntry(*evicted);
         }
 
         // Record tile upload commands into the main command buffer
         // This uses per-frame staging buffers to avoid race conditions
-        cache->recordTileUpload(tile.id, tile.pixels.data(),
-                                   tile.width, tile.height,
-                                   tile.format, cmd, frameIndex);
-
-        // Update page table (CPU-side, will be uploaded via recordUpload)
-        uint32_t slotsPerAxis = config.getCacheTilesPerAxis();
-        uint32_t packed = tile.id.pack();
-        auto slotIt = cache->getTileSlotIndex(tile.id);
-
-        if (slotIt != UINT32_MAX) {
-            uint16_t cacheX = slotIt % slotsPerAxis;
-            uint16_t cacheY = slotIt / slotsPerAxis;
-            pageTable->setEntry(tile.id, cacheX, cacheY);
+        bool ok = cache->recordTileUpload(tile.id, tile.pixels.data(),
+                                          tile.width, tile.height,
+                                          tile.format, cmd, frameIndex);
+        if (ok) {
+            // Update page table (CPU-side, will be uploaded via recordUpload)
+            uint32_t slotIndex = cache->getTileSlotIndex(tile.id);
+            if (slotIndex != UINT32_MAX) {
+                uint16_t cacheX = slotIndex % slotsPerAxis;
+                uint16_t cacheY = slotIndex / slotsPerAxis;
+                pageTable->setEntry(tile.id, cacheX, cacheY);
+            }
+            uploaded++;
+        } else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "VT: Dropping tile (%u,%u) mip %u - upload failed",
+                        tile.id.x, tile.id.y, tile.id.mipLevel);
         }
 
-        // Remove from pending set
+        // Whether uploaded or dropped, this tile is no longer pending
         pendingTiles.erase(packed);
-        uploaded++;
+        pendingUploads_.pop_front();
     }
 
     if (uploaded > 0) {

--- a/src/terrain/virtual_texture/VirtualTextureSystem.h
+++ b/src/terrain/virtual_texture/VirtualTextureSystem.h
@@ -10,6 +10,7 @@
 #include <vk_mem_alloc.h>
 #include <string>
 #include <vector>
+#include <deque>
 #include <unordered_set>
 #include <optional>
 
@@ -102,10 +103,10 @@ public:
     VkSampler getCacheSampler() const { return cache->getCacheSampler(); }
 
     /**
-     * Get page table textures for shader binding
+     * Get page table texture array (one layer per mip level) for shader binding
      */
-    VkImageView getPageTableImageView(uint32_t mipLevel) const {
-        return pageTable->getImageView(mipLevel);
+    VkImageView getPageTableImageView() const {
+        return pageTable->getCombinedImageView();
     }
     VkSampler getPageTableSampler() const { return pageTable->getSampler(); }
 
@@ -123,6 +124,12 @@ public:
      * Get UBO data for shader binding
      */
     VTParamsUBO getParams() const;
+
+    /**
+     * Get the GPU uniform buffer holding VTParamsUBO (filled at init;
+     * the params are constant for the lifetime of the system)
+     */
+    VkBuffer getParamsBuffer() const { return paramsBuffer_.get(); }
 
     /**
      * Get configuration
@@ -158,9 +165,16 @@ private:
     std::unique_ptr<VirtualTextureFeedback> feedback;
     std::unique_ptr<VirtualTextureTileLoader> tileLoader;
 
+    // Uniform buffer holding VTParamsUBO for shader binding
+    VmaBuffer paramsBuffer_;
+
     uint32_t currentFrame = 0;
     uint32_t framesInFlight_ = 3;
     std::unordered_set<uint32_t> pendingTiles; // Tiles currently being loaded
+
+    // Tiles that finished loading but haven't been uploaded yet (upload
+    // throughput is capped per frame; the remainder is retried next frame)
+    std::deque<LoadedTile> pendingUploads_;
 
     // Over-budget penalty scheme (Ghost of Tsushima style)
     // When cache is under pressure, we increase the penalty to request coarser mips

--- a/src/terrain/virtual_texture/VirtualTextureTileLoader.cpp
+++ b/src/terrain/virtual_texture/VirtualTextureTileLoader.cpp
@@ -175,15 +175,15 @@ void VirtualTextureTileLoader::workerLoop() {
         if (loadTileFromDisk(request.id, tile)) {
             totalBytesLoaded += tile.pixels.size();
 
+            // Invoke callback before the tile is moved into the loaded list
+            if (loadedCallback) {
+                loadedCallback(tile);
+            }
+
             // Add to loaded list
             {
                 std::lock_guard<std::mutex> lock(loadedMutex);
                 loadedTiles.push_back(std::move(tile));
-            }
-
-            // Invoke callback if set
-            if (loadedCallback) {
-                loadedCallback(tile);
             }
         }
     }

--- a/src/terrain/virtual_texture/VirtualTextureTypes.h
+++ b/src/terrain/virtual_texture/VirtualTextureTypes.h
@@ -10,7 +10,10 @@ struct VirtualTextureConfig {
     uint32_t virtualSizePixels = 65536;     // Virtual texture size (64K x 64K)
     uint32_t tileSizePixels = 128;          // Size of each tile (128x128)
     uint32_t cacheSizePixels = 4096;        // Physical cache size (4K x 4K)
-    uint32_t borderPixels = 4;              // Tile border for filtering
+    // Tile border for filtering. Must stay 0 until tile_generator bakes
+    // gutters and the cache places tiles at a (tileSize + 2*border) stride;
+    // the shader's stride math derives from this value.
+    uint32_t borderPixels = 0;
     uint32_t maxMipLevels = 9;              // log2(512) = 9 mip levels
 
     // Calculated values

--- a/tests/test_virtual_texture_types.cpp
+++ b/tests/test_virtual_texture_types.cpp
@@ -118,7 +118,9 @@ TEST_SUITE("VirtualTextureConfig") {
         CHECK(config.virtualSizePixels == 65536);
         CHECK(config.tileSizePixels == 128);
         CHECK(config.cacheSizePixels == 4096);
-        CHECK(config.borderPixels == 4);
+        // Border must be 0 until tiles are baked with gutters and the cache
+        // places tiles at a (tileSize + 2*border) stride
+        CHECK(config.borderPixels == 0);
         CHECK(config.maxMipLevels == 9);
     }
 


### PR DESCRIPTION
## Summary
Refactors the virtual texture page table from separate per-mip images to a single 2D array texture, with each mip level stored as a layer. This simplifies shader binding, reduces image management overhead, and improves the staging buffer allocation strategy.

## Key Changes

**Page Table Storage**
- Changed from `std::vector<VmaImageHandle> pageTableImages_` (one per mip) to single `VmaImageHandle pageTableImage_` (array texture)
- Each mip's entries occupy the top-left corner of their corresponding layer; unused space is wasted but acceptable
- Shader now samples `usampler2DArray` instead of managing multiple image views

**Staging Buffer Allocation**
- Increased staging buffer size from `maxMipSize` to `totalEntries * sizeof(uint32_t)` to handle worst-case scenario where all mips are dirty in one frame
- Each dirty mip gets its own region of the staging buffer; regions are not reused within a frame to avoid race conditions with in-flight copy commands
- Added `stagingCursor_` tracking and `beginFrame()` method to reset cursor per frame

**Upload Recording**
- Consolidated per-mip image layout transitions into single transitions for the entire array
- All dirty mips transition to transfer-dst together, then back to shader-read together
- Copy commands now target specific layers via `baseArrayLayer` instead of separate images

**Cache Eviction Safety**
- Enhanced `findLRUSlot()` to skip slots used within the last `framesInFlight` frames (in-flight frames may still sample them)
- `allocateSlot()` now reports evicted tiles via optional output parameter so caller can invalidate page table entries
- Allocation can now fail if all slots are in-flight; caller retries next frame

**Shader Changes**
- Converted `sampleVirtualTexture()` from recursive to iterative loop (GLSL forbids recursion)
- Feedback writing now decimates to 1-in-16 pixels to avoid saturating the 4096-entry feedback buffer
- Uses `textureLod(..., 0.0)` for explicit LOD inside the non-uniform loop

**System Integration**
- Added `VTParamsUBO` uniform buffer created at init and filled with constant parameters
- Virtual texture update now runs before subdivision compute (continues even when compute is skipped)
- Feedback copy callback integrated into HDR pass recorder's post-pass hook
- Descriptor set bindings added for page table array, cache, feedback buffer, counter, and params UBO

## Testing
Build with `cmake --preset debug && cmake --build build/debug`, then run with `./run-debug.sh`. The terrain should render with virtual texture streaming:
- Tiles load progressively as the camera moves
- Page table updates reflect loaded tiles
- Feedback decimation prevents buffer overflow
- No visual artifacts from mip transitions or cache evictions

https://claude.ai/code/session_012jsm7StaGoF5v1d6FtWQrh