### PR TITLE
Fix water rendering foundations and restore FFT ocean simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,14 @@ assets/textures/downloads
 /town_map.svg
 /town_output.svg
 /test_town.svg
+
+# Runtime artifacts written to the working directory when running the app
+# from the repository root (atmosphere LUT debug exports, pipeline cache)
+/cloudmap_lut.png
+/multiscatter_lut.png
+/skyview_lut.png
+/transmittance_lut.png
+/pipeline_cache.bin
+
+# Local convenience symlink to assets/textures for running from the repo root
+/textures

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ set(SOURCES
     src/water/FlowMapGenerator.cpp
     src/water/WaterGBuffer.cpp
     src/water/WaterDisplacement.cpp
+    src/water/OceanFFT.cpp
     src/water/FoamBuffer.cpp
     src/water/WaterTileCull.cpp
     src/water/WaterSystemGroup.cpp
@@ -881,6 +882,10 @@ set(SHADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_position.vert.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_position.frag.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_displacement.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_spectrum.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_time_evolution.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_fft.comp.spv
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_displacement.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/foam_blur.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ssr.comp.spv
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ssr_blur.comp.spv
@@ -978,6 +983,7 @@ if(SHADER_COMPILE_CMD)
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ubo_cloud_shadow.glsl
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/scene_instance_common.glsl
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/pbr_flags_common.glsl
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_complex_common.glsl
     )
 
     # Simple shaders using SHADER_COMPILE_CMD (no includes)
@@ -1030,6 +1036,7 @@ if(SHADER_COMPILE_CMD)
         hiz_culling.comp
         scene_cull.comp
         bloom_compute.comp bloom_upsample_compute.comp bloom_spd.comp godrays_compute.comp
+        ocean_spectrum.comp ocean_time_evolution.comp ocean_fft.comp ocean_displacement.comp
     )
 
     foreach(SHADER ${SHADERS_WITH_BINDINGS})
@@ -1309,6 +1316,10 @@ if(SHADER_COMPILE_CMD)
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_position.vert.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_position.frag.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/water_displacement.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_spectrum.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_time_evolution.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_fft.comp.spv
+        ${CMAKE_CURRENT_SOURCE_DIR}/shaders/ocean_displacement.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/foam_blur.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_dispatcher.comp.spv
         ${CMAKE_CURRENT_SOURCE_DIR}/shaders/terrain/terrain_subdivision.comp.spv

--- a/shaders/ocean_displacement.comp
+++ b/shaders/ocean_displacement.comp
@@ -39,10 +39,22 @@ layout(push_constant) uniform PushConstants {
     float normalStrength;   // Normal map intensity
 };
 
-// Sample displacement with wrapping (tiling)
-vec2 sampleDisp(readonly image2D img, ivec2 coord) {
+// Component selectors for sampleDisp (GLSL forbids image function parameters
+// with format qualifiers, so the image is selected inside the helper)
+#define DISP_Y 0
+#define DISP_X 1
+#define DISP_Z 2
+
+// Sample displacement with wrapping (tiling).
+// The spectrum stores DC at texel (N/2, N/2), so by the Fourier shift theorem
+// the IFFT output is modulated by (-1)^(x+y); undo that here.
+vec2 sampleDisp(int component, ivec2 coord) {
     coord = coord & (resolution - 1);  // Wrap using power-of-2 mask
-    return imageLoad(img, coord).xy;
+    float texelSign = ((coord.x + coord.y) & 1) == 0 ? 1.0 : -1.0;
+    vec2 v = (component == DISP_Y) ? imageLoad(dispY, coord).xy
+           : (component == DISP_X) ? imageLoad(dispX, coord).xy
+                                   : imageLoad(dispZ, coord).xy;
+    return v * texelSign;
 }
 
 void main() {
@@ -53,9 +65,9 @@ void main() {
     // Read displacement values
     // FFT output is complex, but for real input the imaginary part should be ~0
     // We take the real part as our displacement
-    float dy = sampleDisp(dispY, coord).x * heightScale;
-    float dx = sampleDisp(dispX, coord).x;
-    float dz = sampleDisp(dispZ, coord).x;
+    float dy = sampleDisp(DISP_Y, coord).x * heightScale;
+    float dx = sampleDisp(DISP_X, coord).x;
+    float dz = sampleDisp(DISP_Z, coord).x;
 
     // Store combined displacement
     vec3 displacement = vec3(dx, dy, dz);
@@ -64,20 +76,20 @@ void main() {
     float texelSize = oceanSize / float(resolution);
 
     // Sample neighbors for gradient calculation
-    float dy_px = sampleDisp(dispY, coord + ivec2(1, 0)).x * heightScale;
-    float dy_nx = sampleDisp(dispY, coord + ivec2(-1, 0)).x * heightScale;
-    float dy_py = sampleDisp(dispY, coord + ivec2(0, 1)).x * heightScale;
-    float dy_ny = sampleDisp(dispY, coord + ivec2(0, -1)).x * heightScale;
+    float dy_px = sampleDisp(DISP_Y, coord + ivec2(1, 0)).x * heightScale;
+    float dy_nx = sampleDisp(DISP_Y, coord + ivec2(-1, 0)).x * heightScale;
+    float dy_py = sampleDisp(DISP_Y, coord + ivec2(0, 1)).x * heightScale;
+    float dy_ny = sampleDisp(DISP_Y, coord + ivec2(0, -1)).x * heightScale;
 
-    float dx_px = sampleDisp(dispX, coord + ivec2(1, 0)).x;
-    float dx_nx = sampleDisp(dispX, coord + ivec2(-1, 0)).x;
-    float dx_py = sampleDisp(dispX, coord + ivec2(0, 1)).x;
-    float dx_ny = sampleDisp(dispX, coord + ivec2(0, -1)).x;
+    float dx_px = sampleDisp(DISP_X, coord + ivec2(1, 0)).x;
+    float dx_nx = sampleDisp(DISP_X, coord + ivec2(-1, 0)).x;
+    float dx_py = sampleDisp(DISP_X, coord + ivec2(0, 1)).x;
+    float dx_ny = sampleDisp(DISP_X, coord + ivec2(0, -1)).x;
 
-    float dz_px = sampleDisp(dispZ, coord + ivec2(1, 0)).x;
-    float dz_nx = sampleDisp(dispZ, coord + ivec2(-1, 0)).x;
-    float dz_py = sampleDisp(dispZ, coord + ivec2(0, 1)).x;
-    float dz_ny = sampleDisp(dispZ, coord + ivec2(0, -1)).x;
+    float dz_px = sampleDisp(DISP_Z, coord + ivec2(1, 0)).x;
+    float dz_nx = sampleDisp(DISP_Z, coord + ivec2(-1, 0)).x;
+    float dz_py = sampleDisp(DISP_Z, coord + ivec2(0, 1)).x;
+    float dz_ny = sampleDisp(DISP_Z, coord + ivec2(0, -1)).x;
 
     // Height gradients (for normal calculation)
     float dydx = (dy_px - dy_nx) / (2.0 * texelSize);

--- a/shaders/ocean_fft.comp
+++ b/shaders/ocean_fft.comp
@@ -33,6 +33,11 @@ layout(push_constant) uniform PushConstants {
     int inverse;     // 1 = inverse FFT, 0 = forward FFT
 };
 
+// Reverse the low `bits` bits of i (for the DIT input permutation)
+int bitReverse(int i, int bits) {
+    return int(bitfieldReverse(uint(i)) >> (32 - bits));
+}
+
 void main() {
     ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
 
@@ -70,16 +75,27 @@ void main() {
         bottomIndex = index;
     }
 
+    // This is a decimation-in-time butterfly, which requires its input in
+    // bit-reversed order. Instead of a separate permutation pass, stage 0
+    // reads its inputs through the bit-reversal directly.
+    int readTop = topIndex;
+    int readBottom = bottomIndex;
+    if (stage == 0) {
+        int bits = findMSB(resolution);
+        readTop = bitReverse(topIndex, bits);
+        readBottom = bitReverse(bottomIndex, bits);
+    }
+
     // Read input values
     ivec2 topCoord, bottomCoord;
     if (direction == 0) {
         // Horizontal FFT
-        topCoord = ivec2(topIndex, coord.y);
-        bottomCoord = ivec2(bottomIndex, coord.y);
+        topCoord = ivec2(readTop, coord.y);
+        bottomCoord = ivec2(readBottom, coord.y);
     } else {
         // Vertical FFT
-        topCoord = ivec2(coord.x, topIndex);
-        bottomCoord = ivec2(coord.x, bottomIndex);
+        topCoord = ivec2(coord.x, readTop);
+        bottomCoord = ivec2(coord.x, readBottom);
     }
 
     vec2 a = imageLoad(inputBuffer, topCoord).xy;

--- a/shaders/ocean_spectrum.comp
+++ b/shaders/ocean_spectrum.comp
@@ -61,8 +61,8 @@ vec2 gaussianRandom(vec2 uniform_rand) {
 
 // Hash function for pseudo-random numbers
 // Based on pcg hash
-uint pcg_hash(uint input) {
-    uint state = input * 747796405u + 2891336453u;
+uint pcg_hash(uint value) {
+    uint state = value * 747796405u + 2891336453u;
     uint word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
     return (word >> 22u) ^ word;
 }

--- a/shaders/water.frag
+++ b/shaders/water.frag
@@ -763,8 +763,10 @@ void main() {
     // =========================================================================
     {
         // Calculate linear depth of water surface
+        // NDC z is used as-is: the depth buffer stores raw NDC z (no remap happens
+        // in the viewport transform), so remapping here would not match sceneDepthTexture.
         vec4 clipPos = ubo.proj * ubo.view * vec4(fragWorldPos, 1.0);
-        float waterLinearDepth = linearizeDepth(clipPos.z / clipPos.w * 0.5 + 0.5, ubo.cameraNear, ubo.cameraFar);
+        float waterLinearDepth = linearizeDepth(clipPos.z / clipPos.w, ubo.cameraNear, ubo.cameraFar);
 
         // Get scene depth and calculate soft edge
         float sceneLinearDepth = getSceneDepth(screenUV, ubo.cameraNear, ubo.cameraFar);

--- a/src/controls/WaterControlSubsystem.cpp
+++ b/src/controls/WaterControlSubsystem.cpp
@@ -17,3 +17,11 @@ WaterTileCull& WaterControlSubsystem::getWaterTileCull() {
 const WaterTileCull& WaterControlSubsystem::getWaterTileCull() const {
     return waterTileCull_;
 }
+
+OceanFFT* WaterControlSubsystem::getOceanFFT() {
+    return oceanFFT_;
+}
+
+const OceanFFT* WaterControlSubsystem::getOceanFFT() const {
+    return oceanFFT_;
+}

--- a/src/controls/WaterControlSubsystem.h
+++ b/src/controls/WaterControlSubsystem.h
@@ -4,23 +4,28 @@
 
 class WaterSystem;
 class WaterTileCull;
+class OceanFFT;
 
 /**
  * WaterControlSubsystem - Implements IWaterControl
- * Wraps WaterSystem and WaterTileCull for water rendering control.
+ * Wraps WaterSystem, WaterTileCull, and OceanFFT for water rendering control.
  */
 class WaterControlSubsystem : public IWaterControl {
 public:
-    WaterControlSubsystem(WaterSystem& water, WaterTileCull& waterTileCull)
+    WaterControlSubsystem(WaterSystem& water, WaterTileCull& waterTileCull, OceanFFT* oceanFFT)
         : water_(water)
-        , waterTileCull_(waterTileCull) {}
+        , waterTileCull_(waterTileCull)
+        , oceanFFT_(oceanFFT) {}
 
     WaterSystem& getWaterSystem() override;
     const WaterSystem& getWaterSystem() const override;
     WaterTileCull& getWaterTileCull() override;
     const WaterTileCull& getWaterTileCull() const override;
+    OceanFFT* getOceanFFT() override;
+    const OceanFFT* getOceanFFT() const override;
 
 private:
     WaterSystem& water_;
     WaterTileCull& waterTileCull_;
+    OceanFFT* oceanFFT_ = nullptr;  // Optional
 };

--- a/src/core/PerformanceToggles.h
+++ b/src/core/PerformanceToggles.h
@@ -27,6 +27,7 @@ struct PerformanceToggles {
     bool leafCompute = true;
     bool foamCompute = true;
     bool cloudShadowCompute = true;
+    bool oceanFFTCompute = true;
 
     // HDR stage draw calls
     bool skyDraw = true;
@@ -53,7 +54,7 @@ struct PerformanceToggles {
     bool froxelFog = true;
     bool atmosphereLUT = true;
     bool ssr = true;
-    bool waterGBuffer = true;
+    bool waterGBuffer = false;  // Mini G-buffer output is not consumed by anything yet
     bool waterTileCull = true;
 
     // Synchronization barriers (for debugging sync issues)
@@ -77,6 +78,7 @@ struct PerformanceToggles {
             {"leafCompute", "Compute", &leafCompute},
             {"foamCompute", "Compute", &foamCompute},
             {"cloudShadowCompute", "Compute", &cloudShadowCompute},
+            {"oceanFFTCompute", "Compute", &oceanFFTCompute},
 
             // HDR Draw
             {"skyDraw", "HDR Draw", &skyDraw},

--- a/src/core/RendererBuilder.cpp
+++ b/src/core/RendererBuilder.cpp
@@ -56,6 +56,7 @@
 #include "FoamBuffer.h"
 #include "WaterTileCull.h"
 #include "WaterGBuffer.h"
+#include "OceanFFT.h"
 #include "WaterSystemGroup.h"
 #include "SSRSystem.h"
 #include "DebugLineSystem.h"
@@ -988,6 +989,7 @@ std::vector<Loading::SystemInitTask> RendererBuilder::buildInitTasks(Renderer& r
             r.systems_->setSSR(std::move(waterBundle->ssr));
             if (waterBundle->tileCull) r.systems_->setWaterTileCull(std::move(waterBundle->tileCull));
             if (waterBundle->gBuffer) r.systems_->setWaterGBuffer(std::move(waterBundle->gBuffer));
+            if (waterBundle->oceanFFT) r.systems_->setOceanFFT(std::move(waterBundle->oceanFFT));
 
             // Configure water subsystems
             TerrainFactory::Config terrainFactoryConfig{};

--- a/src/core/RendererSystems.cpp
+++ b/src/core/RendererSystems.cpp
@@ -42,6 +42,7 @@
 #include "SSRSystem.h"
 #include "WaterTileCull.h"
 #include "WaterGBuffer.h"
+#include "OceanFFT.h"
 #include "ErosionDataLoader.h"
 #include "RoadNetworkLoader.h"
 #include "RoadRiverVisualization.h"
@@ -190,6 +191,10 @@ void RendererSystems::setWaterGBuffer(std::unique_ptr<WaterGBuffer> system) {
     registry_.add<WaterGBuffer>(std::move(system));
 }
 
+void RendererSystems::setOceanFFT(std::unique_ptr<OceanFFT> system) {
+    registry_.add<OceanFFT>(std::move(system));
+}
+
 void RendererSystems::setCatmullClark(std::unique_ptr<CatmullClarkSystem> system) {
     registry_.add<CatmullClarkSystem>(std::move(system));
 }
@@ -332,7 +337,7 @@ void RendererSystems::initControlSubsystems(VulkanContext& vulkanContext, Perfor
         registry_.get<LeafSystem>(), registry_.get<CloudShadowSystem>(),
         registry_.get<PostProcessSystem>(), registry_.get<EnvironmentSettings>()));
     registry_.add<WaterControlSubsystem>(std::make_unique<WaterControlSubsystem>(
-        registry_.get<WaterSystem>(), registry_.get<WaterTileCull>()));
+        registry_.get<WaterSystem>(), registry_.get<WaterTileCull>(), registry_.find<OceanFFT>()));
     registry_.add<TreeControlSubsystem>(std::make_unique<TreeControlSubsystem>(
         registry_.find<TreeSystem>(), *this));
     registry_.add<GrassControlAdapter>(std::make_unique<GrassControlAdapter>(

--- a/src/core/RendererSystems.h
+++ b/src/core/RendererSystems.h
@@ -79,6 +79,7 @@ class FoamBuffer;
 class SSRSystem;
 class WaterTileCull;
 class WaterGBuffer;
+class OceanFFT;
 class ErosionDataLoader;
 class RoadNetworkLoader;
 class RoadRiverVisualization;
@@ -251,6 +252,10 @@ public:
     WaterGBuffer& waterGBuffer() { return registry_.get<WaterGBuffer>(); }
     const WaterGBuffer& waterGBuffer() const { return registry_.get<WaterGBuffer>(); }
     void setWaterGBuffer(std::unique_ptr<WaterGBuffer> system);
+    OceanFFT& oceanFFT() { return registry_.get<OceanFFT>(); }
+    const OceanFFT& oceanFFT() const { return registry_.get<OceanFFT>(); }
+    bool hasOceanFFT() const { return registry_.has<OceanFFT>(); }
+    void setOceanFFT(std::unique_ptr<OceanFFT> system);
 
     // Geometry processing
     CatmullClarkSystem& catmullClark() { return registry_.get<CatmullClarkSystem>(); }
@@ -402,7 +407,8 @@ public:
             registry_.find<FoamBuffer>(),
             registry_.find<SSRSystem>(),
             registry_.find<WaterTileCull>(),
-            registry_.find<WaterGBuffer>()
+            registry_.find<WaterGBuffer>(),
+            registry_.find<OceanFFT>()
         };
     }
 

--- a/src/core/interfaces/IWaterControl.h
+++ b/src/core/interfaces/IWaterControl.h
@@ -2,6 +2,7 @@
 
 class WaterSystem;
 class WaterTileCull;
+class OceanFFT;
 
 /**
  * Interface for water system controls.
@@ -18,4 +19,8 @@ public:
     // Water tile culling (performance optimization)
     virtual WaterTileCull& getWaterTileCull() = 0;
     virtual const WaterTileCull& getWaterTileCull() const = 0;
+
+    // FFT ocean simulation (optional - may be null)
+    virtual OceanFFT* getOceanFFT() = 0;
+    virtual const OceanFFT* getOceanFFT() const = 0;
 };

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -115,11 +115,33 @@ bool VulkanContext::createInstance() {
         SDL_Log("Vulkan validation layers disabled");
     }
 
-    auto instRet = builder.set_app_name("Vulkan Game")
+    // Enable the surface extensions SDL's active video driver requires.
+    // vk-bootstrap only enables the compile-time platform defaults, which
+    // misses drivers like SDL's offscreen backend (VK_EXT_headless_surface).
+    builder.set_app_name("Vulkan Game")
         .request_validation_layers(enableValidation)
         .use_default_debug_messenger()
-        .require_api_version(1, 2, 0)
-        .build();
+        .require_api_version(1, 2, 0);
+
+    // The extension list is only complete after SDL has loaded its Vulkan
+    // library (refcounted; window creation loads it again later).
+    if (!SDL_Vulkan_LoadLibrary(nullptr)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "SDL_Vulkan_LoadLibrary failed: %s", SDL_GetError());
+    }
+
+    Uint32 sdlExtensionCount = 0;
+    const char* const* sdlExtensions = SDL_Vulkan_GetInstanceExtensions(&sdlExtensionCount);
+    if (sdlExtensions) {
+        for (Uint32 i = 0; i < sdlExtensionCount; i++) {
+            builder.enable_extension(sdlExtensions[i]);
+        }
+    } else {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "SDL_Vulkan_GetInstanceExtensions failed: %s", SDL_GetError());
+    }
+
+    auto instRet = builder.build();
 
     if (!instRet) {
         SDL_Log("Failed to create Vulkan instance: %s", instRet.error().message().c_str());
@@ -184,7 +206,7 @@ bool VulkanContext::selectPhysicalDevice() {
     }
 
     SDL_Log("Selected physical device: %s (Vulkan %u.%u.%u)",
-        props.deviceName, major, minor, VK_API_VERSION_PATCH(props.apiVersion));
+        props.deviceName.data(), major, minor, VK_API_VERSION_PATCH(props.apiVersion));
 
     // Verify timeline semaphore support (should always be true if we got here)
     auto featuresChain = vk::PhysicalDevice(physicalDevice)

--- a/src/core/vulkan/VulkanContext.cpp
+++ b/src/core/vulkan/VulkanContext.cpp
@@ -171,6 +171,8 @@ bool VulkanContext::createSurface() {
 bool VulkanContext::selectPhysicalDevice() {
     VkPhysicalDeviceFeatures features{};
     features.samplerAnisotropy = VK_FALSE;
+    // Point-light shadows use cube-array image views and SampledCubeArray shaders
+    features.imageCubeArray = VK_TRUE;
 
     // Vulkan 1.2 features - timeline semaphores are core in 1.2
     VkPhysicalDeviceVulkan12Features vulkan12Features{};

--- a/src/gui/GuiWaterTab.cpp
+++ b/src/gui/GuiWaterTab.cpp
@@ -2,9 +2,11 @@
 #include "core/interfaces/IWaterControl.h"
 #include "WaterSystem.h"
 #include "WaterTileCull.h"
+#include "OceanFFT.h"
 
 #include <imgui.h>
 #include <glm/glm.hpp>
+#include <cmath>
 
 void GuiWaterTab::render(IWaterControl& waterControl) {
     ImGui::Spacing();
@@ -51,12 +53,68 @@ void GuiWaterTab::render(IWaterControl& waterControl) {
     ImGui::PopStyleColor();
 
     // FFT Ocean toggle
+    OceanFFT* ocean = waterControl.getOceanFFT();
     bool useFFT = water.getUseFFTOcean();
     if (ImGui::Checkbox("FFT Ocean (Tessendorf)", &useFFT)) {
         water.setUseFFTOcean(useFFT);
     }
     if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip("Use FFT-based ocean simulation instead of Gerstner waves");
+    }
+    if (!ocean && useFFT) {
+        ImGui::TextDisabled("OceanFFT system unavailable - cascades are placeholders");
+    }
+
+    if (ocean && useFFT) {
+        ImGui::Spacing();
+        ImGui::Text("FFT Ocean Parameters:");
+
+        float windSpeed = ocean->getWindSpeed();
+        if (ImGui::SliderFloat("Wind Speed", &windSpeed, 1.0f, 30.0f, "%.1f m/s")) {
+            ocean->setWindSpeed(windSpeed);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Higher wind = larger waves (regenerates spectrum)");
+        }
+
+        glm::vec2 windDir = ocean->getWindDirection();
+        float windAngle = glm::degrees(std::atan2(windDir.y, windDir.x));
+        if (ImGui::SliderFloat("Wind Direction", &windAngle, -180.0f, 180.0f, "%.0f deg")) {
+            float rad = glm::radians(windAngle);
+            ocean->setWindDirection(glm::vec2(std::cos(rad), std::sin(rad)));
+        }
+
+        float fftAmplitude = ocean->getAmplitude();
+        if (ImGui::SliderFloat("Spectrum Amplitude", &fftAmplitude, 1.0f, 2000.0f, "%.0f",
+                               ImGuiSliderFlags_Logarithmic)) {
+            ocean->setAmplitude(fftAmplitude);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Phillips spectrum energy (regenerates spectrum)");
+        }
+
+        float choppiness = ocean->getChoppiness();
+        if (ImGui::SliderFloat("Choppiness", &choppiness, 0.0f, 2.5f, "%.2f")) {
+            ocean->setChoppiness(choppiness);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Horizontal displacement - sharper wave crests");
+        }
+
+        float heightScale = ocean->getHeightScale();
+        if (ImGui::SliderFloat("Height Scale", &heightScale, 0.0f, 3.0f, "%.2f")) {
+            ocean->setHeightScale(heightScale);
+        }
+
+        float fftFoam = ocean->getFoamThreshold();
+        if (ImGui::SliderFloat("FFT Foam Threshold", &fftFoam, -1.0f, 1.0f, "%.2f")) {
+            ocean->setFoamThreshold(fftFoam);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Jacobian threshold for whitecaps (lower = less foam)");
+        }
+
+        ImGui::Spacing();
     }
 
     float amplitude = water.getWaveAmplitude();

--- a/src/passes/ComputePasses.cpp
+++ b/src/passes/ComputePasses.cpp
@@ -24,6 +24,8 @@
 #include "culling/GPUCullPass.h"
 #include "FlowMapGenerator.h"
 #include "FoamBuffer.h"
+#include "WaterDisplacement.h"
+#include "OceanFFT.h"
 #include "CloudShadowSystem.h"
 #include "WindSystem.h"
 #include "FroxelSystem.h"
@@ -142,6 +144,20 @@ PassIds addPasses(PassScheduler& graph, RendererSystems& systems, const Config& 
                 systems.foam().recordCompute(cmd, frameIndex, renderCtx->frame.deltaTime,
                                              systems.flowMap().getFlowMapView(), systems.flowMap().getFlowMapSampler());
                 systems.profiler().endGpuZone(cmd, "FoamCompute");
+
+                // Interactive water displacement (splashes/ripples) shares the
+                // water-surface dynamics toggle
+                systems.profiler().beginGpuZone(cmd, "WaterDisplacement");
+                systems.waterDisplacement().update(renderCtx->frame.deltaTime);
+                systems.waterDisplacement().recordCompute(cmd, frameIndex);
+                systems.profiler().endGpuZone(cmd, "WaterDisplacement");
+            }
+
+            // FFT ocean simulation compute pass
+            if (perfToggles->oceanFFTCompute && systems.hasOceanFFT()) {
+                systems.profiler().beginGpuZone(cmd, "OceanFFT");
+                systems.oceanFFT().recordCompute(cmd, renderCtx->frame.time);
+                systems.profiler().endGpuZone(cmd, "OceanFFT");
             }
 
             // Cloud shadow map compute pass

--- a/src/physics/PhysicsTerrainTileManager.cpp
+++ b/src/physics/PhysicsTerrainTileManager.cpp
@@ -185,6 +185,9 @@ void PhysicsTerrainTileManager::unloadPhysicsTile(uint64_t tileKey) {
 }
 
 void PhysicsTerrainTileManager::update(const glm::vec3& playerPosition) {
+    // Not initialized (e.g. terrain tile cache unavailable) - nothing to manage
+    if (!physics_ || !tileCache_) return;
+
     // Calculate required tiles at player position
     auto requiredTiles = calculateRequiredTiles(playerPosition);
 

--- a/src/water/OceanFFT.cpp
+++ b/src/water/OceanFFT.cpp
@@ -1,0 +1,702 @@
+#include "OceanFFT.h"
+#include "DescriptorManager.h"
+#include "SamplerFactory.h"
+#include "VmaBufferFactory.h"
+#include "CommandBufferUtils.h"
+#include "core/ImageBuilder.h"
+#include "core/pipeline/ComputePipelineBuilder.h"
+#include "core/vulkan/PipelineLayoutBuilder.h"
+#include "core/vulkan/BarrierHelpers.h"
+#include "core/vulkan/DescriptorSetLayoutBuilder.h"
+#include "shaders/bindings.h"
+#include <SDL3/SDL_log.h>
+#include <cmath>
+#include <cstring>
+#include <array>
+#include <vulkan/vulkan.hpp>
+
+namespace {
+
+// Memory barrier between dependent compute dispatches (all images stay in GENERAL)
+void computeToComputeBarrier(vk::CommandBuffer cmd) {
+    auto barrier = vk::MemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eShaderWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eShaderRead);
+    cmd.pipelineBarrier(vk::PipelineStageFlagBits::eComputeShader,
+                        vk::PipelineStageFlagBits::eComputeShader,
+                        {}, barrier, {}, {});
+}
+
+} // namespace
+
+std::unique_ptr<OceanFFT> OceanFFT::create(const InitInfo& info) {
+    auto ocean = std::make_unique<OceanFFT>(ConstructToken{});
+    if (!ocean->initInternal(info)) {
+        return nullptr;
+    }
+    return ocean;
+}
+
+OceanFFT::~OceanFFT() {
+    cleanup();
+}
+
+bool OceanFFT::initInternal(const InitInfo& info) {
+    device = info.device;
+    physicalDevice = info.physicalDevice;
+    allocator = info.allocator;
+    commandPool = info.commandPool;
+    computeQueue = info.computeQueue;
+    shaderPath = info.shaderPath;
+    framesInFlight = info.framesInFlight;
+    params = info.params;
+    raiiDevice_ = info.raiiDevice;
+
+    if (!raiiDevice_) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: raiiDevice is required");
+        return false;
+    }
+
+    if (params.resolution <= 0 || (params.resolution & (params.resolution - 1)) != 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: resolution must be a power of two (got %d)", params.resolution);
+        return false;
+    }
+
+    // Set up cascades. Patch sizes match the water shader push constant
+    // defaults (256m / 64m / 16m, see WaterSystem::setUseFFTOcean).
+    if (info.useCascades) {
+        cascadeCount = 3;
+        cascades.resize(cascadeCount);
+
+        // Cascade 0: Large swells (long wavelength)
+        cascades[0].config = {
+            params.oceanSize,           // 256m patch
+            params.heightScale,         // Full height
+            params.choppiness * 0.8f    // Slightly less choppy
+        };
+
+        // Cascade 1: Medium waves
+        cascades[1].config = {
+            params.oceanSize / 4.0f,    // 64m patch
+            params.heightScale * 0.4f,  // Smaller waves
+            params.choppiness
+        };
+
+        // Cascade 2: Small ripples (high frequency detail)
+        cascades[2].config = {
+            params.oceanSize / 16.0f,   // 16m patch
+            params.heightScale * 0.15f, // Tiny ripples
+            params.choppiness * 1.5f    // More choppy for detail
+        };
+    } else {
+        cascadeCount = 1;
+        cascades.resize(1);
+        cascades[0].config = {
+            params.oceanSize,
+            params.heightScale,
+            params.choppiness
+        };
+    }
+
+    // Sampler for output textures (tiling ocean with anisotropic filtering)
+    auto sampler = SamplerFactory::createSamplerLinearRepeatAnisotropic(*raiiDevice_, 16.0f, 0.0f);
+    if (!sampler) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create sampler");
+        return false;
+    }
+    sampler_ = std::move(*sampler);
+
+    if (!createComputePipelines()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create compute pipelines");
+        return false;
+    }
+
+    for (int i = 0; i < cascadeCount; i++) {
+        if (!createCascade(cascades[i])) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create cascade %d", i);
+            return false;
+        }
+    }
+
+    if (!createDescriptorSets()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create descriptor sets");
+        return false;
+    }
+
+    // Move every simulation image into GENERAL layout once. They stay there
+    // permanently (storage read/write in compute, sampled with GENERAL-layout
+    // descriptors elsewhere), so per-frame work needs only memory barriers.
+    if (!transitionImagesToGeneral()) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to transition images");
+        return false;
+    }
+
+    SDL_Log("OceanFFT: Initialized with %d cascades, resolution %d", cascadeCount, params.resolution);
+    return true;
+}
+
+void OceanFFT::cleanup() {
+    if (!raiiDevice_) return;
+
+    raiiDevice_->waitIdle();
+
+    cascades.clear();
+    descriptorPool_.reset();
+    spectrumUBOs.clear();
+    spectrumUBOMapped.clear();
+
+    spectrumPipeline_.reset();
+    spectrumPipelineLayout_.reset();
+    spectrumDescLayout_.reset();
+
+    timeEvolutionPipeline_.reset();
+    timeEvolutionPipelineLayout_.reset();
+    timeEvolutionDescLayout_.reset();
+
+    fftPipeline_.reset();
+    fftPipelineLayout_.reset();
+    fftDescLayout_.reset();
+
+    displacementPipeline_.reset();
+    displacementPipelineLayout_.reset();
+    displacementDescLayout_.reset();
+
+    sampler_.reset();
+
+    device = VK_NULL_HANDLE;
+    raiiDevice_ = nullptr;
+}
+
+bool OceanFFT::createImage(ManagedImage& image, std::optional<vk::raii::ImageView>& view,
+                           VkFormat format, VkImageUsageFlags usage) {
+    uint32_t res = static_cast<uint32_t>(params.resolution);
+    return ImageBuilder(allocator)
+        .setExtent(res, res)
+        .setFormat(format)
+        .setUsage(usage)
+        .setGpuOnly()
+        .build(*raiiDevice_, image, view);
+}
+
+bool OceanFFT::createCascade(Cascade& cascade) {
+    constexpr VkImageUsageFlags kStorageSampled = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+
+    // Spectrum textures (RGBA32F for complex H0 + conjugate)
+    if (!createImage(cascade.h0Spectrum, cascade.h0SpectrumView,
+                     VK_FORMAT_R32G32B32A32_SFLOAT, kStorageSampled)) {
+        return false;
+    }
+
+    // Angular frequency (R32F)
+    if (!createImage(cascade.omegaSpectrum, cascade.omegaSpectrumView,
+                     VK_FORMAT_R32_SFLOAT, kStorageSampled)) {
+        return false;
+    }
+
+    // Time-evolved spectra and FFT scratch (RG32F complex). Each component has
+    // its own scratch image so the three IFFTs cannot clobber each other.
+    for (int c = 0; c < kComponents; c++) {
+        if (!createImage(cascade.hkt[c], cascade.hktView[c],
+                         VK_FORMAT_R32G32_SFLOAT, VK_IMAGE_USAGE_STORAGE_BIT)) {
+            return false;
+        }
+        if (!createImage(cascade.scratch[c], cascade.scratchView[c],
+                         VK_FORMAT_R32G32_SFLOAT, VK_IMAGE_USAGE_STORAGE_BIT)) {
+            return false;
+        }
+    }
+
+    // Output textures
+    // Displacement: RGBA16F (xyz = displacement, w = jacobian)
+    if (!createImage(cascade.displacementMap, cascade.displacementMapView,
+                     VK_FORMAT_R16G16B16A16_SFLOAT, kStorageSampled)) {
+        return false;
+    }
+
+    // Normal: RGBA16F (xyz = normal encoded [0,1])
+    if (!createImage(cascade.normalMap, cascade.normalMapView,
+                     VK_FORMAT_R16G16B16A16_SFLOAT, kStorageSampled)) {
+        return false;
+    }
+
+    // Foam: R16F
+    if (!createImage(cascade.foamMap, cascade.foamMapView,
+                     VK_FORMAT_R16_SFLOAT, kStorageSampled)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool OceanFFT::createComputePipelines() {
+    // =========================================================================
+    // Spectrum Generation Pipeline
+    // =========================================================================
+    {
+        if (!DescriptorSetLayoutBuilder()
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_SPECTRUM_H0, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_SPECTRUM_OMEGA, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::uniformBuffer(Bindings::OCEAN_SPECTRUM_PARAMS, vk::ShaderStageFlagBits::eCompute))
+                .buildInto(*raiiDevice_, spectrumDescLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create spectrum descriptor layout");
+            return false;
+        }
+
+        if (!PipelineLayoutBuilder(*raiiDevice_)
+                .addDescriptorSetLayout(**spectrumDescLayout_)
+                .buildInto(spectrumPipelineLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create spectrum pipeline layout");
+            return false;
+        }
+
+        if (!ComputePipelineBuilder(*raiiDevice_)
+                .setShader(shaderPath + "/ocean_spectrum.comp.spv")
+                .setPipelineLayout(**spectrumPipelineLayout_)
+                .buildInto(spectrumPipeline_)) {
+            return false;
+        }
+    }
+
+    // =========================================================================
+    // Time Evolution Pipeline
+    // =========================================================================
+    {
+        if (!DescriptorSetLayoutBuilder()
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_HKT_DY, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_HKT_DX, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_HKT_DZ, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::combinedImageSampler(Bindings::OCEAN_H0_INPUT, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::combinedImageSampler(Bindings::OCEAN_OMEGA_INPUT, vk::ShaderStageFlagBits::eCompute))
+                .buildInto(*raiiDevice_, timeEvolutionDescLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create time evolution descriptor layout");
+            return false;
+        }
+
+        if (!PipelineLayoutBuilder(*raiiDevice_)
+                .addDescriptorSetLayout(**timeEvolutionDescLayout_)
+                .addPushConstantRange<OceanTimeEvolutionPushConstants>(vk::ShaderStageFlagBits::eCompute)
+                .buildInto(timeEvolutionPipelineLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create time evolution pipeline layout");
+            return false;
+        }
+
+        if (!ComputePipelineBuilder(*raiiDevice_)
+                .setShader(shaderPath + "/ocean_time_evolution.comp.spv")
+                .setPipelineLayout(**timeEvolutionPipelineLayout_)
+                .buildInto(timeEvolutionPipeline_)) {
+            return false;
+        }
+    }
+
+    // =========================================================================
+    // FFT Pipeline
+    // =========================================================================
+    {
+        if (!DescriptorSetLayoutBuilder()
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_FFT_INPUT, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_FFT_OUTPUT, vk::ShaderStageFlagBits::eCompute))
+                .buildInto(*raiiDevice_, fftDescLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create FFT descriptor layout");
+            return false;
+        }
+
+        if (!PipelineLayoutBuilder(*raiiDevice_)
+                .addDescriptorSetLayout(**fftDescLayout_)
+                .addPushConstantRange<OceanFFTPushConstants>(vk::ShaderStageFlagBits::eCompute)
+                .buildInto(fftPipelineLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create FFT pipeline layout");
+            return false;
+        }
+
+        if (!ComputePipelineBuilder(*raiiDevice_)
+                .setShader(shaderPath + "/ocean_fft.comp.spv")
+                .setPipelineLayout(**fftPipelineLayout_)
+                .buildInto(fftPipeline_)) {
+            return false;
+        }
+    }
+
+    // =========================================================================
+    // Displacement Generation Pipeline
+    // =========================================================================
+    {
+        if (!DescriptorSetLayoutBuilder()
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_DISP_DY, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_DISP_DX, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_DISP_DZ, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_DISP_OUTPUT, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_NORMAL_OUTPUT, vk::ShaderStageFlagBits::eCompute))
+                .addBinding(BindingBuilder::storageImage(Bindings::OCEAN_FOAM_OUTPUT, vk::ShaderStageFlagBits::eCompute))
+                .buildInto(*raiiDevice_, displacementDescLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create displacement descriptor layout");
+            return false;
+        }
+
+        if (!PipelineLayoutBuilder(*raiiDevice_)
+                .addDescriptorSetLayout(**displacementDescLayout_)
+                .addPushConstantRange<OceanDisplacementPushConstants>(vk::ShaderStageFlagBits::eCompute)
+                .buildInto(displacementPipelineLayout_)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create displacement pipeline layout");
+            return false;
+        }
+
+        if (!ComputePipelineBuilder(*raiiDevice_)
+                .setShader(shaderPath + "/ocean_displacement.comp.spv")
+                .setPipelineLayout(**displacementPipelineLayout_)
+                .buildInto(displacementPipeline_)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool OceanFFT::createDescriptorSets() {
+    const uint32_t fftSetsPerCascade = kComponents * 2;
+    const uint32_t totalSets = static_cast<uint32_t>(cascadeCount) * (3 + fftSetsPerCascade);
+
+    std::array<vk::DescriptorPoolSize, 3> poolSizes = {
+        vk::DescriptorPoolSize{}
+            .setType(vk::DescriptorType::eStorageImage)
+            .setDescriptorCount(totalSets * 6),
+        vk::DescriptorPoolSize{}
+            .setType(vk::DescriptorType::eCombinedImageSampler)
+            .setDescriptorCount(static_cast<uint32_t>(cascadeCount) * 2),
+        vk::DescriptorPoolSize{}
+            .setType(vk::DescriptorType::eUniformBuffer)
+            .setDescriptorCount(static_cast<uint32_t>(cascadeCount))
+    };
+
+    auto poolInfo = vk::DescriptorPoolCreateInfo{}
+        .setMaxSets(totalSets)
+        .setPoolSizes(poolSizes);
+
+    try {
+        descriptorPool_.emplace(*raiiDevice_, poolInfo);
+    } catch (const vk::SystemError& e) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to create descriptor pool: %s", e.what());
+        return false;
+    }
+
+    // UBOs for spectrum parameters (one per cascade; only rewritten on regen)
+    spectrumUBOs.resize(cascadeCount);
+    spectrumUBOMapped.resize(cascadeCount);
+    for (int i = 0; i < cascadeCount; i++) {
+        if (!VmaBufferFactory::createUniformBuffer(allocator, sizeof(SpectrumUBO), spectrumUBOs[i])) {
+            return false;
+        }
+        spectrumUBOMapped[i] = spectrumUBOs[i].map();
+        if (!spectrumUBOMapped[i]) {
+            return false;
+        }
+    }
+
+    vk::Device vkDevice(device);
+    auto allocateOne = [&](vk::DescriptorSetLayout layout, VkDescriptorSet& outSet) {
+        auto allocInfo = vk::DescriptorSetAllocateInfo{}
+            .setDescriptorPool(**descriptorPool_)
+            .setSetLayouts(layout);
+        try {
+            outSet = vkDevice.allocateDescriptorSets(allocInfo)[0];
+            return true;
+        } catch (const vk::SystemError& e) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "OceanFFT: Failed to allocate descriptor set: %s", e.what());
+            return false;
+        }
+    };
+
+    spectrumDescSets.resize(cascadeCount);
+    timeEvolutionDescSets.resize(cascadeCount);
+    displacementDescSets.resize(cascadeCount);
+    fftDescSets.resize(cascadeCount * fftSetsPerCascade);
+
+    for (int i = 0; i < cascadeCount; i++) {
+        Cascade& cascade = cascades[i];
+
+        // Spectrum descriptor set
+        if (!allocateOne(**spectrumDescLayout_, spectrumDescSets[i])) return false;
+        DescriptorManager::SetWriter(device, spectrumDescSets[i])
+            .writeStorageImage(Bindings::OCEAN_SPECTRUM_H0, **cascade.h0SpectrumView)
+            .writeStorageImage(Bindings::OCEAN_SPECTRUM_OMEGA, **cascade.omegaSpectrumView)
+            .writeBuffer(Bindings::OCEAN_SPECTRUM_PARAMS, spectrumUBOs[i].get(), 0, sizeof(SpectrumUBO))
+            .update();
+
+        // Time evolution descriptor set (samples h0/omega which stay in GENERAL)
+        if (!allocateOne(**timeEvolutionDescLayout_, timeEvolutionDescSets[i])) return false;
+        DescriptorManager::SetWriter(device, timeEvolutionDescSets[i])
+            .writeStorageImage(Bindings::OCEAN_HKT_DY, **cascade.hktView[0])
+            .writeStorageImage(Bindings::OCEAN_HKT_DX, **cascade.hktView[1])
+            .writeStorageImage(Bindings::OCEAN_HKT_DZ, **cascade.hktView[2])
+            .writeImage(Bindings::OCEAN_H0_INPUT, **cascade.h0SpectrumView, **sampler_, VK_IMAGE_LAYOUT_GENERAL)
+            .writeImage(Bindings::OCEAN_OMEGA_INPUT, **cascade.omegaSpectrumView, **sampler_, VK_IMAGE_LAYOUT_GENERAL)
+            .update();
+
+        // Displacement descriptor set - the IFFT result for each component is
+        // back in its hkt image (even number of ping-pong passes).
+        if (!allocateOne(**displacementDescLayout_, displacementDescSets[i])) return false;
+        DescriptorManager::SetWriter(device, displacementDescSets[i])
+            .writeStorageImage(Bindings::OCEAN_DISP_DY, **cascade.hktView[0])
+            .writeStorageImage(Bindings::OCEAN_DISP_DX, **cascade.hktView[1])
+            .writeStorageImage(Bindings::OCEAN_DISP_DZ, **cascade.hktView[2])
+            .writeStorageImage(Bindings::OCEAN_DISP_OUTPUT, **cascade.displacementMapView)
+            .writeStorageImage(Bindings::OCEAN_NORMAL_OUTPUT, **cascade.normalMapView)
+            .writeStorageImage(Bindings::OCEAN_FOAM_OUTPUT, **cascade.foamMapView)
+            .update();
+
+        // FFT descriptor sets: hkt -> scratch (pingpong 0) and scratch -> hkt
+        // (pingpong 1) for each component. Written once, never rewritten.
+        for (int c = 0; c < kComponents; c++) {
+            for (int p = 0; p < 2; p++) {
+                VkDescriptorSet& set = fftDescSets[(i * kComponents + c) * 2 + p];
+                if (!allocateOne(**fftDescLayout_, set)) return false;
+                VkImageView inputView = (p == 0) ? **cascade.hktView[c] : **cascade.scratchView[c];
+                VkImageView outputView = (p == 0) ? **cascade.scratchView[c] : **cascade.hktView[c];
+                DescriptorManager::SetWriter(device, set)
+                    .writeStorageImage(Bindings::OCEAN_FFT_INPUT, inputView)
+                    .writeStorageImage(Bindings::OCEAN_FFT_OUTPUT, outputView)
+                    .update();
+            }
+        }
+    }
+
+    return true;
+}
+
+bool OceanFFT::transitionImagesToGeneral() {
+    CommandScope cmd{vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue)};
+    if (!cmd.begin()) return false;
+
+    auto transition = [&](const ManagedImage& image) {
+        BarrierHelpers::transitionImageLayout(cmd.get(), image.get(),
+            vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+            vk::PipelineStageFlagBits::eTopOfPipe,
+            vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eVertexShader |
+                vk::PipelineStageFlagBits::eTessellationEvaluationShader | vk::PipelineStageFlagBits::eFragmentShader,
+            vk::AccessFlags{},
+            vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite);
+    };
+
+    for (Cascade& cascade : cascades) {
+        transition(cascade.h0Spectrum);
+        transition(cascade.omegaSpectrum);
+        for (int c = 0; c < kComponents; c++) {
+            transition(cascade.hkt[c]);
+            transition(cascade.scratch[c]);
+        }
+        transition(cascade.displacementMap);
+        transition(cascade.normalMap);
+        transition(cascade.foamMap);
+    }
+
+    return cmd.end();
+}
+
+void OceanFFT::recordCompute(VkCommandBuffer cmd, float time) {
+    if (!enabled) return;
+
+    vk::CommandBuffer vkCmd(cmd);
+
+    // Execution dependency against last frame's sampling of the output maps
+    // (vertex/tess-eval/fragment) before this frame overwrites them.
+    vkCmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eTessellationEvaluationShader |
+            vk::PipelineStageFlagBits::eFragmentShader,
+        vk::PipelineStageFlagBits::eComputeShader,
+        {}, {}, {}, {});
+
+    if (spectrumDirty) {
+        for (int i = 0; i < cascadeCount; i++) {
+            recordSpectrumGeneration(cmd, i);
+        }
+        computeToComputeBarrier(vkCmd);
+        spectrumDirty = false;
+    }
+
+    for (int i = 0; i < cascadeCount; i++) {
+        recordTimeEvolution(cmd, i, time);
+        computeToComputeBarrier(vkCmd);
+
+        for (int c = 0; c < kComponents; c++) {
+            recordFFT(cmd, i, c);
+        }
+
+        recordDisplacementGeneration(cmd, i);
+    }
+
+    // Make the output maps visible to the water vertex/tessellation/fragment shaders.
+    auto barrier = vk::MemoryBarrier{}
+        .setSrcAccessMask(vk::AccessFlagBits::eShaderWrite)
+        .setDstAccessMask(vk::AccessFlagBits::eShaderRead);
+    vkCmd.pipelineBarrier(
+        vk::PipelineStageFlagBits::eComputeShader,
+        vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eTessellationEvaluationShader |
+            vk::PipelineStageFlagBits::eFragmentShader,
+        {}, barrier, {}, {});
+}
+
+void OceanFFT::recordSpectrumGeneration(VkCommandBuffer cmd, int cascadeIndex) {
+    // Update UBO with current parameters. The UBO is only read by this
+    // dispatch; regeneration is rare (GUI parameter changes), so a single
+    // buffer per cascade is sufficient.
+    SpectrumUBO ubo{};
+    ubo.resolution = params.resolution;
+    ubo.oceanSize = cascades[cascadeIndex].config.oceanSize;
+    ubo.windSpeed = params.windSpeed;
+    ubo.windDirection = glm::normalize(params.windDirection);
+    ubo.amplitude = params.amplitude;
+    ubo.gravity = params.gravity;
+    ubo.smallWaveCutoff = params.smallWaveCutoff;
+    ubo.alignment = params.alignment;
+    ubo.seed = static_cast<uint32_t>(cascadeIndex * 12345 + 67890);
+    std::memcpy(spectrumUBOMapped[cascadeIndex], &ubo, sizeof(SpectrumUBO));
+
+    vk::CommandBuffer vkCmd(cmd);
+    vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, **spectrumPipeline_);
+    vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eCompute, **spectrumPipelineLayout_,
+                             0, vk::DescriptorSet(spectrumDescSets[cascadeIndex]), {});
+
+    uint32_t groupCount = (params.resolution + 15) / 16;
+    vkCmd.dispatch(groupCount, groupCount, 1);
+}
+
+void OceanFFT::recordTimeEvolution(VkCommandBuffer cmd, int cascadeIndex, float time) {
+    vk::CommandBuffer vkCmd(cmd);
+    vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, **timeEvolutionPipeline_);
+    vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eCompute, **timeEvolutionPipelineLayout_,
+                             0, vk::DescriptorSet(timeEvolutionDescSets[cascadeIndex]), {});
+
+    OceanTimeEvolutionPushConstants pushConstants = {
+        time,
+        params.resolution,
+        cascades[cascadeIndex].config.oceanSize,
+        cascades[cascadeIndex].config.choppiness
+    };
+    vkCmd.pushConstants<OceanTimeEvolutionPushConstants>(
+        **timeEvolutionPipelineLayout_, vk::ShaderStageFlagBits::eCompute, 0, pushConstants);
+
+    uint32_t groupCount = (params.resolution + 15) / 16;
+    vkCmd.dispatch(groupCount, groupCount, 1);
+}
+
+void OceanFFT::recordFFT(VkCommandBuffer cmd, int cascadeIndex, int component) {
+    // 2D inverse FFT: log2(N) horizontal butterfly passes, then log2(N)
+    // vertical ones. Each pass ping-pongs between the component's hkt image
+    // and its private scratch image; 2*log2(N) is even, so the final result
+    // lands back in the hkt image (which the displacement pass reads).
+    int numStages = 0;
+    for (int n = params.resolution; n > 1; n >>= 1) numStages++;
+
+    uint32_t groupCount = (params.resolution + 15) / 16;
+
+    vk::CommandBuffer vkCmd(cmd);
+    vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, **fftPipeline_);
+
+    int pingpong = 0;  // 0 = hkt -> scratch, 1 = scratch -> hkt
+    for (int direction = 0; direction < 2; direction++) {
+        for (int stage = 0; stage < numStages; stage++) {
+            vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eCompute, **fftPipelineLayout_,
+                                     0, vk::DescriptorSet(fftSet(cascadeIndex, component, pingpong)), {});
+
+            OceanFFTPushConstants pushData = {stage, direction, params.resolution, 1};
+            vkCmd.pushConstants<OceanFFTPushConstants>(
+                **fftPipelineLayout_, vk::ShaderStageFlagBits::eCompute, 0, pushData);
+
+            vkCmd.dispatch(groupCount, groupCount, 1);
+            computeToComputeBarrier(vkCmd);
+
+            pingpong = 1 - pingpong;
+        }
+    }
+}
+
+void OceanFFT::recordDisplacementGeneration(VkCommandBuffer cmd, int cascadeIndex) {
+    vk::CommandBuffer vkCmd(cmd);
+    vkCmd.bindPipeline(vk::PipelineBindPoint::eCompute, **displacementPipeline_);
+    vkCmd.bindDescriptorSets(vk::PipelineBindPoint::eCompute, **displacementPipelineLayout_,
+                             0, vk::DescriptorSet(displacementDescSets[cascadeIndex]), {});
+
+    OceanDisplacementPushConstants pushConstants = {
+        params.resolution,
+        cascades[cascadeIndex].config.oceanSize,
+        cascades[cascadeIndex].config.heightScale,
+        params.foamThreshold,
+        0.9f,  // foam decay
+        params.normalStrength
+    };
+    vkCmd.pushConstants<OceanDisplacementPushConstants>(
+        **displacementPipelineLayout_, vk::ShaderStageFlagBits::eCompute, 0, pushConstants);
+
+    uint32_t groupCount = (params.resolution + 15) / 16;
+    vkCmd.dispatch(groupCount, groupCount, 1);
+}
+
+VkImageView OceanFFT::getDisplacementView(int cascade) const {
+    if (cascade < 0 || cascade >= cascadeCount) return VK_NULL_HANDLE;
+    return cascades[cascade].displacementMapView ? **cascades[cascade].displacementMapView : VK_NULL_HANDLE;
+}
+
+VkImageView OceanFFT::getNormalView(int cascade) const {
+    if (cascade < 0 || cascade >= cascadeCount) return VK_NULL_HANDLE;
+    return cascades[cascade].normalMapView ? **cascades[cascade].normalMapView : VK_NULL_HANDLE;
+}
+
+VkImageView OceanFFT::getFoamView(int cascade) const {
+    if (cascade < 0 || cascade >= cascadeCount) return VK_NULL_HANDLE;
+    return cascades[cascade].foamMapView ? **cascades[cascade].foamMapView : VK_NULL_HANDLE;
+}
+
+void OceanFFT::setParams(const OceanParams& newParams) {
+    bool needsRegen = (newParams.resolution != params.resolution ||
+                       newParams.oceanSize != params.oceanSize ||
+                       newParams.windSpeed != params.windSpeed ||
+                       newParams.windDirection != params.windDirection ||
+                       newParams.amplitude != params.amplitude ||
+                       newParams.smallWaveCutoff != params.smallWaveCutoff ||
+                       newParams.alignment != params.alignment);
+
+    params = newParams;
+
+    if (needsRegen) {
+        spectrumDirty = true;
+    }
+}
+
+void OceanFFT::setWindSpeed(float speed) {
+    if (speed != params.windSpeed) {
+        params.windSpeed = speed;
+        spectrumDirty = true;
+    }
+}
+
+void OceanFFT::setWindDirection(const glm::vec2& dir) {
+    glm::vec2 normalized = glm::normalize(dir);
+    if (normalized != params.windDirection) {
+        params.windDirection = normalized;
+        spectrumDirty = true;
+    }
+}
+
+void OceanFFT::setAmplitude(float amp) {
+    if (amp != params.amplitude) {
+        params.amplitude = amp;
+        spectrumDirty = true;
+    }
+}
+
+void OceanFFT::setChoppiness(float chop) {
+    params.choppiness = chop;
+    if (cascadeCount >= 1) cascades[0].config.choppiness = chop * 0.8f;
+    if (cascadeCount >= 2) cascades[1].config.choppiness = chop;
+    if (cascadeCount >= 3) cascades[2].config.choppiness = chop * 1.5f;
+}
+
+void OceanFFT::setHeightScale(float scale) {
+    params.heightScale = scale;
+    if (cascadeCount >= 1) cascades[0].config.heightScale = scale;
+    if (cascadeCount >= 2) cascades[1].config.heightScale = scale * 0.4f;
+    if (cascadeCount >= 3) cascades[2].config.heightScale = scale * 0.15f;
+}
+
+void OceanFFT::setFoamThreshold(float threshold) {
+    params.foamThreshold = threshold;
+}

--- a/src/water/OceanFFT.h
+++ b/src/water/OceanFFT.h
@@ -1,0 +1,275 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_raii.hpp>
+#include <vk_mem_alloc.h>
+#include <glm/glm.hpp>
+#include <vector>
+#include <string>
+#include <memory>
+#include <optional>
+#include "VmaBuffer.h"
+#include "VmaImage.h"
+
+/**
+ * OceanFFT - FFT-based Ocean Simulation (Tessendorf Method)
+ *
+ * Implements a physically-based ocean surface simulation using FFT.
+ * Based on "Simulating Ocean Water" (Tessendorf, 2001).
+ *
+ * Pipeline:
+ * 1. Generate initial spectrum H0(k) using Phillips spectrum (once at init,
+ *    and again whenever parameters change)
+ * 2. Each frame:
+ *    a. Time evolution: H(k,t) from H0(k) for height + choppy X/Z displacement
+ *    b. Inverse FFT (per component) to get spatial displacement
+ *    c. Generate displacement, normal, and foam maps
+ *
+ * Three cascades (large swells / medium waves / ripples) feed the water shader's
+ * cascade bindings for multi-scale detail.
+ *
+ * All simulation images live permanently in VK_IMAGE_LAYOUT_GENERAL; consumers
+ * must bind them with that layout (like the SSR result image).
+ */
+
+// Push constant structures - must match the ocean_*.comp shaders
+struct OceanTimeEvolutionPushConstants {
+    float time;
+    int resolution;
+    float oceanSize;
+    float choppiness;
+};
+
+struct OceanFFTPushConstants {
+    int stage;
+    int direction;
+    int resolution;
+    int inverse;
+};
+
+struct OceanDisplacementPushConstants {
+    int resolution;
+    float oceanSize;
+    float heightScale;
+    float foamThreshold;
+    float foamDecay;
+    float normalStrength;
+};
+
+class OceanFFT {
+public:
+    // Passkey for controlled construction via make_unique
+    struct ConstructToken { explicit ConstructToken() = default; };
+    explicit OceanFFT(ConstructToken) {}
+
+    // Ocean simulation parameters
+    struct OceanParams {
+        int resolution = 256;           // FFT resolution (power of two)
+        float oceanSize = 256.0f;       // Physical patch size in meters (cascade 0)
+        float windSpeed = 8.0f;         // Wind speed in m/s
+        glm::vec2 windDirection = {0.8f, 0.6f};  // Wind direction (normalized)
+        float amplitude = 200.0f;       // Phillips spectrum amplitude (A constant)
+                                        // Note: the IFFT is 1/N^2-normalized, so A is
+                                        // large compared to textbook values.
+        float gravity = 9.81f;          // Gravitational constant
+        float smallWaveCutoff = 0.01f;  // Suppress waves smaller than this (meters)
+        float alignment = 0.8f;         // Wind alignment (0=omni, 1=directional)
+        float choppiness = 1.0f;        // Horizontal displacement scale (lambda)
+        float heightScale = 1.0f;       // Height multiplier
+        float foamThreshold = 0.0f;     // Jacobian threshold for foam
+        float normalStrength = 1.0f;    // Normal map intensity
+    };
+
+    // Cascade configuration for multi-scale waves
+    struct CascadeConfig {
+        float oceanSize;     // Patch size for this cascade
+        float heightScale;   // Height scale for this cascade
+        float choppiness;    // Choppiness for this cascade
+    };
+
+    struct InitInfo {
+        VkDevice device;
+        VkPhysicalDevice physicalDevice;
+        VmaAllocator allocator;
+        VkCommandPool commandPool;
+        VkQueue computeQueue;
+        std::string shaderPath;
+        uint32_t framesInFlight;
+        OceanParams params;
+        bool useCascades = true;  // Enable multi-scale cascades
+        const vk::raii::Device* raiiDevice = nullptr;
+    };
+
+    /**
+     * Factory: Create and initialize OceanFFT.
+     * Returns nullptr on failure.
+     */
+    static std::unique_ptr<OceanFFT> create(const InitInfo& info);
+
+    ~OceanFFT();
+
+    // Non-copyable, non-movable
+    OceanFFT(const OceanFFT&) = delete;
+    OceanFFT& operator=(const OceanFFT&) = delete;
+    OceanFFT(OceanFFT&&) = delete;
+    OceanFFT& operator=(OceanFFT&&) = delete;
+
+    // Record the full simulation for this frame (spectrum regen if dirty,
+    // time evolution, IFFT, displacement/normal/foam generation).
+    // Call from the compute pass, before any water rendering.
+    void recordCompute(VkCommandBuffer cmd, float time);
+
+    // Get output textures for the water shader.
+    // Images are in VK_IMAGE_LAYOUT_GENERAL - bind descriptors accordingly.
+    VkImageView getDisplacementView(int cascade = 0) const;
+    VkImageView getNormalView(int cascade = 0) const;
+    VkImageView getFoamView(int cascade = 0) const;
+    VkSampler getSampler() const { return sampler_ ? **sampler_ : VK_NULL_HANDLE; }
+
+    // Parameter access
+    void setParams(const OceanParams& newParams);
+    const OceanParams& getParams() const { return params; }
+
+    // Individual parameter setters (mark the spectrum dirty when needed)
+    void setWindSpeed(float speed);
+    void setWindDirection(const glm::vec2& dir);
+    void setAmplitude(float amp);
+    void setChoppiness(float chop);
+    void setHeightScale(float scale);
+    void setFoamThreshold(float threshold);
+
+    // Getters for UI
+    float getWindSpeed() const { return params.windSpeed; }
+    glm::vec2 getWindDirection() const { return params.windDirection; }
+    float getAmplitude() const { return params.amplitude; }
+    float getChoppiness() const { return params.choppiness; }
+    float getHeightScale() const { return params.heightScale; }
+    float getFoamThreshold() const { return params.foamThreshold; }
+    int getResolution() const { return params.resolution; }
+    float getOceanSize() const { return params.oceanSize; }
+    int getCascadeCount() const { return cascadeCount; }
+
+    bool isEnabled() const { return enabled; }
+    void setEnabled(bool enable) { enabled = enable; }
+
+private:
+    bool initInternal(const InitInfo& info);
+    void cleanup();
+
+    // Per-cascade data
+    struct Cascade {
+        // Spectrum textures (generated once / on param change)
+        ManagedImage h0Spectrum;
+        std::optional<vk::raii::ImageView> h0SpectrumView;
+
+        ManagedImage omegaSpectrum;
+        std::optional<vk::raii::ImageView> omegaSpectrumView;
+
+        // Time-evolved spectra -> become spatial displacement after IFFT.
+        // Each component ping-pongs with its own scratch image; 2*log2(N) passes
+        // is even, so the final IFFT result always lands back in the hkt image.
+        ManagedImage hkt[3];      // 0 = Dy, 1 = Dx, 2 = Dz
+        std::optional<vk::raii::ImageView> hktView[3];
+        ManagedImage scratch[3];
+        std::optional<vk::raii::ImageView> scratchView[3];
+
+        // Output textures
+        ManagedImage displacementMap;
+        std::optional<vk::raii::ImageView> displacementMapView;
+
+        ManagedImage normalMap;
+        std::optional<vk::raii::ImageView> normalMapView;
+
+        ManagedImage foamMap;
+        std::optional<vk::raii::ImageView> foamMapView;
+
+        CascadeConfig config;
+    };
+
+    static constexpr int kComponents = 3;  // Dy, Dx, Dz
+
+    bool createComputePipelines();
+    bool createCascade(Cascade& cascade);
+    bool createImage(ManagedImage& image, std::optional<vk::raii::ImageView>& view,
+                     VkFormat format, VkImageUsageFlags usage);
+    bool createDescriptorSets();
+    bool transitionImagesToGeneral();
+
+    void recordSpectrumGeneration(VkCommandBuffer cmd, int cascadeIndex);
+    void recordTimeEvolution(VkCommandBuffer cmd, int cascadeIndex, float time);
+    void recordFFT(VkCommandBuffer cmd, int cascadeIndex, int component);
+    void recordDisplacementGeneration(VkCommandBuffer cmd, int cascadeIndex);
+
+    // Device resources
+    VkDevice device = VK_NULL_HANDLE;
+    VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
+    VmaAllocator allocator = VK_NULL_HANDLE;
+    VkCommandPool commandPool = VK_NULL_HANDLE;
+    VkQueue computeQueue = VK_NULL_HANDLE;
+    std::string shaderPath;
+    uint32_t framesInFlight = 0;
+
+    // Parameters
+    OceanParams params;
+    bool enabled = true;
+    bool spectrumDirty = true;
+
+    // Cascades for multi-scale simulation
+    static constexpr int MAX_CASCADES = 3;
+    std::vector<Cascade> cascades;
+    int cascadeCount = 1;
+
+    // Compute pipelines
+    std::optional<vk::raii::Pipeline> spectrumPipeline_;
+    std::optional<vk::raii::PipelineLayout> spectrumPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> spectrumDescLayout_;
+
+    std::optional<vk::raii::Pipeline> timeEvolutionPipeline_;
+    std::optional<vk::raii::PipelineLayout> timeEvolutionPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> timeEvolutionDescLayout_;
+
+    std::optional<vk::raii::Pipeline> fftPipeline_;
+    std::optional<vk::raii::PipelineLayout> fftPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> fftDescLayout_;
+
+    std::optional<vk::raii::Pipeline> displacementPipeline_;
+    std::optional<vk::raii::PipelineLayout> displacementPipelineLayout_;
+    std::optional<vk::raii::DescriptorSetLayout> displacementDescLayout_;
+
+    // Descriptor pool and sets (all written once at init)
+    std::optional<vk::raii::DescriptorPool> descriptorPool_;
+    std::vector<VkDescriptorSet> spectrumDescSets;       // [cascade]
+    std::vector<VkDescriptorSet> timeEvolutionDescSets;  // [cascade]
+    std::vector<VkDescriptorSet> displacementDescSets;   // [cascade]
+    // FFT sets: per cascade, per component, two directions of the ping-pong
+    // (hkt -> scratch and scratch -> hkt).
+    std::vector<VkDescriptorSet> fftDescSets;            // [cascade][component][2]
+    VkDescriptorSet fftSet(int cascade, int component, int pingpong) const {
+        return fftDescSets[(cascade * kComponents + component) * 2 + pingpong];
+    }
+
+    // Spectrum parameters UBO - must match ocean_spectrum.comp layout
+    struct SpectrumUBO {
+        int resolution;
+        float oceanSize;
+        float windSpeed;
+        float padding1;
+        glm::vec2 windDirection;
+        float amplitude;
+        float gravity;
+        float smallWaveCutoff;
+        float alignment;
+        uint32_t seed;
+        float padding2;
+        float padding3;
+        float padding4;
+    };
+    std::vector<ManagedBuffer> spectrumUBOs;
+    std::vector<void*> spectrumUBOMapped;
+
+    // Sampler for output textures
+    std::optional<vk::raii::Sampler> sampler_;
+
+    // RAII device pointer
+    const vk::raii::Device* raiiDevice_ = nullptr;
+};

--- a/src/water/WaterDisplacement.cpp
+++ b/src/water/WaterDisplacement.cpp
@@ -144,36 +144,37 @@ bool WaterDisplacement::createDisplacementMap() {
         return false;
     }
 
-    // The water vertex shader samples the displacement map every frame, but the
-    // compute pass that writes it only runs when splash particles exist. Clear both
-    // maps to zero and move them to shader-read layout so they are valid to sample
-    // before (or without) any compute dispatch.
-    CommandScope initCmd{vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue)};
-    if (!initCmd.begin()) {
-        return false;
-    }
-    for (VkImage image : {displacementMap, prevDisplacementMap}) {
-        BarrierHelpers::transitionImageLayout(initCmd.get(), image,
-            vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal,
-            vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
-            {}, vk::AccessFlagBits::eTransferWrite);
+    // Clear both maps to zero and move them to SHADER_READ_ONLY so they are
+    // valid to sample (water vertex shader, compute prev-frame input) before
+    // the first recordCompute - and even if the compute never runs.
+    {
+        CommandScope cmd{vk::Device(device), vk::CommandPool(commandPool), vk::Queue(computeQueue)};
+        if (!cmd.begin()) return false;
 
         auto clearRange = vk::ImageSubresourceRange{}
             .setAspectMask(vk::ImageAspectFlagBits::eColor)
+            .setBaseMipLevel(0)
             .setLevelCount(1)
+            .setBaseArrayLayer(0)
             .setLayerCount(1);
-        initCmd.get().clearColorImage(image, vk::ImageLayout::eTransferDstOptimal,
-                                      vk::ClearColorValue{0.0f, 0.0f, 0.0f, 0.0f}, clearRange);
 
-        BarrierHelpers::transitionImageLayout(initCmd.get(), image,
-            vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal,
-            vk::PipelineStageFlagBits::eTransfer,
-            vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eFragmentShader |
-                vk::PipelineStageFlagBits::eComputeShader,
-            vk::AccessFlagBits::eTransferWrite, vk::AccessFlagBits::eShaderRead);
-    }
-    if (!initCmd.end()) {
-        return false;
+        for (VkImage image : {displacementMap, prevDisplacementMap}) {
+            BarrierHelpers::transitionImageLayout(cmd.get(), image,
+                vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal,
+                vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
+                vk::AccessFlags{}, vk::AccessFlagBits::eTransferWrite);
+            cmd.get().clearColorImage(image, vk::ImageLayout::eTransferDstOptimal,
+                                      vk::ClearColorValue{std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f}},
+                                      clearRange);
+            BarrierHelpers::transitionImageLayout(cmd.get(), image,
+                vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal,
+                vk::PipelineStageFlagBits::eTransfer,
+                vk::PipelineStageFlagBits::eComputeShader | vk::PipelineStageFlagBits::eVertexShader |
+                    vk::PipelineStageFlagBits::eTessellationEvaluationShader | vk::PipelineStageFlagBits::eFragmentShader,
+                vk::AccessFlagBits::eTransferWrite, vk::AccessFlagBits::eShaderRead);
+        }
+
+        if (!cmd.end()) return false;
     }
 
     return true;

--- a/src/water/WaterSystem.cpp
+++ b/src/water/WaterSystem.cpp
@@ -445,7 +445,8 @@ bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffe
                                         VkSampler tileSampler,
                                         const std::array<VkBuffer, 3>& tileInfoBuffers,
                                         VkImageView envCubemapView,
-                                        VkSampler envCubemapSampler) {
+                                        VkSampler envCubemapSampler,
+                                        const OceanCascadeViews* oceanViews) {
     // Store tile info buffers for per-frame updates (triple-buffered)
     tileInfoBuffers_.resize(tileInfoBuffers.size());
     for (size_t i = 0; i < tileInfoBuffers.size(); ++i) {
@@ -478,11 +479,19 @@ bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffe
         writer.writeImage(8, causticsTexture->getImageView(), causticsTexture->getSampler());
         writer.writeImage(9, ssrView, ssrSampler, VK_IMAGE_LAYOUT_GENERAL);
         writer.writeImage(10, sceneDepthView, sceneDepthSampler, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
-        // Ocean detail bindings (11-13): the multi-cascade FFT ocean was never wired up
-        // and has been removed, so these reuse the interactive WaterDisplacement map.
-        writer.writeImage(11, displacementMapView, displacementMapSampler);  // ocean displacement
-        writer.writeImage(12, displacementMapView, displacementMapSampler);  // ocean normal
-        writer.writeImage(13, displacementMapView, displacementMapSampler);  // ocean foam
+        // Ocean cascade 0 bindings (11-13). When OceanFFT is available its maps
+        // (in GENERAL layout) are bound; otherwise fall back to the interactive
+        // WaterDisplacement map so the bindings stay valid.
+        const bool hasOcean = oceanViews && oceanViews->isValid();
+        if (hasOcean) {
+            writer.writeImage(11, oceanViews->displacement[0], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(12, oceanViews->normal[0], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(13, oceanViews->foam[0], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+        } else {
+            writer.writeImage(11, displacementMapView, displacementMapSampler);  // ocean displacement
+            writer.writeImage(12, displacementMapView, displacementMapSampler);  // ocean normal
+            writer.writeImage(13, displacementMapView, displacementMapSampler);  // ocean foam
+        }
 
         // Tile cache bindings (14 and 15) - for high-res terrain sampling
         if (tileArrayView != VK_NULL_HANDLE && tileSampler != VK_NULL_HANDLE) {
@@ -493,17 +502,27 @@ bool WaterSystem::createDescriptorSets(const std::vector<VkBuffer>& uniformBuffe
             writer.writeBuffer(15, tileInfoBuffers_[0], 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         }
 
-        // Ocean cascade 1 and 2 (bindings 16-21): the multi-scale FFT cascades were never
-        // wired up (OceanFFT removed), so these reuse the same WaterDisplacement map.
-        // The shader still samples all bindings, so they must point at a valid image.
-        writer.writeImage(16, displacementMapView, displacementMapSampler);  // cascade 1 displacement
-        writer.writeImage(17, displacementMapView, displacementMapSampler);  // cascade 1 normal
-        writer.writeImage(18, displacementMapView, displacementMapSampler);  // cascade 1 foam
-        writer.writeImage(19, displacementMapView, displacementMapSampler);  // cascade 2 displacement
-        writer.writeImage(20, displacementMapView, displacementMapSampler);  // cascade 2 normal
-        writer.writeImage(21, displacementMapView, displacementMapSampler);  // cascade 2 foam
+        // Ocean cascade 1 and 2 (bindings 16-21). The shader samples all bindings
+        // regardless of mode, so they must always point at a valid image.
+        if (hasOcean) {
+            writer.writeImage(16, oceanViews->displacement[1], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(17, oceanViews->normal[1], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(18, oceanViews->foam[1], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(19, oceanViews->displacement[2], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(20, oceanViews->normal[2], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+            writer.writeImage(21, oceanViews->foam[2], oceanViews->sampler, VK_IMAGE_LAYOUT_GENERAL);
+        } else {
+            writer.writeImage(16, displacementMapView, displacementMapSampler);  // cascade 1 displacement
+            writer.writeImage(17, displacementMapView, displacementMapSampler);  // cascade 1 normal
+            writer.writeImage(18, displacementMapView, displacementMapSampler);  // cascade 1 foam
+            writer.writeImage(19, displacementMapView, displacementMapSampler);  // cascade 2 displacement
+            writer.writeImage(20, displacementMapView, displacementMapSampler);  // cascade 2 normal
+            writer.writeImage(21, displacementMapView, displacementMapSampler);  // cascade 2 foam
+        }
 
-        // Environment cubemap (binding 22) - Phase 2 SSR fallback
+        // Environment cubemap (binding 22) - Phase 2 SSR fallback.
+        // The binding is a samplerCube, so the fallback must be a cube-view image;
+        // the black placeholder makes the shader use its procedural sky path.
         if (envCubemapView != VK_NULL_HANDLE && envCubemapSampler != VK_NULL_HANDLE) {
             writer.writeImage(22, envCubemapView, envCubemapSampler);
         } else {

--- a/src/water/WaterSystem.h
+++ b/src/water/WaterSystem.h
@@ -118,6 +118,26 @@ public:
     // Update extent for viewport (on window resize)
     void setExtent(VkExtent2D newExtent) { extent = newExtent; }
 
+    // FFT ocean cascade outputs for bindings 11-13 / 16-18 / 19-21.
+    // Images are expected to be in VK_IMAGE_LAYOUT_GENERAL (see OceanFFT).
+    struct OceanCascadeViews {
+        std::array<VkImageView, 3> displacement{};  // [cascade]
+        std::array<VkImageView, 3> normal{};
+        std::array<VkImageView, 3> foam{};
+        VkSampler sampler = VK_NULL_HANDLE;
+
+        bool isValid() const {
+            if (sampler == VK_NULL_HANDLE) return false;
+            for (int i = 0; i < 3; i++) {
+                if (displacement[i] == VK_NULL_HANDLE || normal[i] == VK_NULL_HANDLE ||
+                    foam[i] == VK_NULL_HANDLE) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    };
+
     // Create descriptor sets after main UBO is ready
     bool createDescriptorSets(const std::vector<VkBuffer>& uniformBuffers,
                               VkDeviceSize uniformBufferSize,
@@ -138,7 +158,8 @@ public:
                               VkSampler tileSampler = VK_NULL_HANDLE,
                               const std::array<VkBuffer, 3>& tileInfoBuffers = {},
                               VkImageView envCubemapView = VK_NULL_HANDLE,
-                              VkSampler envCubemapSampler = VK_NULL_HANDLE);
+                              VkSampler envCubemapSampler = VK_NULL_HANDLE,
+                              const OceanCascadeViews* oceanViews = nullptr);
 
     // Update water uniforms (call each frame)
     void updateUniforms(uint32_t frameIndex);

--- a/src/water/WaterSystemGroup.cpp
+++ b/src/water/WaterSystemGroup.cpp
@@ -8,6 +8,7 @@
 #include "SSRSystem.h"
 #include "WaterTileCull.h"
 #include "WaterGBuffer.h"
+#include "OceanFFT.h"
 #include "RendererSystems.h"
 #include "ShadowSystem.h"
 #include "TerrainSystem.h"
@@ -149,6 +150,25 @@ std::optional<WaterSystemGroup::Bundle> WaterSystemGroup::createAll(
         }
     }
 
+    // 8. Create OceanFFT (optional - FFT-based Tessendorf ocean simulation)
+    {
+        OceanFFT::InitInfo info{};
+        info.device = ctx.device;
+        info.physicalDevice = ctx.physicalDevice;
+        info.allocator = ctx.allocator;
+        info.commandPool = ctx.commandPool;
+        info.computeQueue = ctx.graphicsQueue;
+        info.shaderPath = ctx.shaderPath;
+        info.framesInFlight = ctx.framesInFlight;
+        info.useCascades = true;
+        info.raiiDevice = ctx.raiiDevice;
+
+        bundle.oceanFFT = OceanFFT::create(info);
+        if (!bundle.oceanFFT) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "WaterSystemGroup: OceanFFT creation failed (non-fatal, falling back to Gerstner waves)");
+        }
+    }
+
     SDL_Log("WaterSystemGroup: All systems created successfully");
     return bundle;
 }
@@ -174,6 +194,12 @@ bool WaterSystemGroup::configureSubsystems(
     water.setShoreBlendDistance(8.0f);
     water.setShoreFoamWidth(15.0f);
     water.setCameraPlanes(0.1f, 50000.0f);
+
+    // Use the FFT ocean for wave displacement when available (cascade patch
+    // sizes match the OceanFFT defaults: 256m / 64m / 16m).
+    if (systems.hasOceanFFT()) {
+        water.setUseFFTOcean(true);
+    }
 
     // Generate flow map from terrain data
     FlowMapGenerator::Config flowConfig{};
@@ -217,6 +243,18 @@ bool WaterSystemGroup::createDescriptorSets(
         terrainSystem.getTileInfoBuffer(2)
     };
 
+    // Gather FFT ocean cascade views when the OceanFFT system is available
+    WaterSystem::OceanCascadeViews oceanViews{};
+    if (systems.hasOceanFFT()) {
+        auto& ocean = systems.oceanFFT();
+        for (int i = 0; i < 3; i++) {
+            oceanViews.displacement[i] = ocean.getDisplacementView(i);
+            oceanViews.normal[i] = ocean.getNormalView(i);
+            oceanViews.foam[i] = ocean.getFoamView(i);
+        }
+        oceanViews.sampler = ocean.getSampler();
+    }
+
     if (!systems.water().createDescriptorSets(
             uniformBuffers, uniformBufferSize, shadowSystem,
             terrainSystem.getHeightMapView(), terrainSystem.getHeightMapSampler(),
@@ -226,7 +264,9 @@ bool WaterSystemGroup::createDescriptorSets(
             systems.ssr().getSSRResultView(), systems.ssr().getSampler(),
             postProcessSystem.getHDRDepthView(), depthSampler,
             terrainSystem.getTileArrayView(), terrainSystem.getTileSampler(),
-            waterTileInfoBuffers)) {
+            waterTileInfoBuffers,
+            VK_NULL_HANDLE, VK_NULL_HANDLE,
+            oceanViews.isValid() ? &oceanViews : nullptr)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create water descriptor sets");
         return false;
     }

--- a/src/water/WaterSystemGroup.h
+++ b/src/water/WaterSystemGroup.h
@@ -17,6 +17,7 @@ class FoamBuffer;
 class SSRSystem;
 class WaterTileCull;
 class WaterGBuffer;
+class OceanFFT;
 class ShadowSystem;
 class TerrainSystem;
 class PostProcessSystem;
@@ -62,6 +63,7 @@ struct WaterSystemGroup {
     SYSTEM_MEMBER(SSRSystem, ssr);
     SYSTEM_MEMBER(WaterTileCull, tileCull);
     SYSTEM_MEMBER(WaterGBuffer, gBuffer);
+    SYSTEM_MEMBER(OceanFFT, oceanFFT);
 
     // Required system accessors
     REQUIRED_SYSTEM_ACCESSORS(WaterSystem, system)
@@ -73,6 +75,7 @@ struct WaterSystemGroup {
     // Optional system accessors (may be null)
     OPTIONAL_SYSTEM_ACCESSORS(WaterTileCull, tileCull, TileCull)
     OPTIONAL_SYSTEM_ACCESSORS(WaterGBuffer, gBuffer, GBuffer)
+    OPTIONAL_SYSTEM_ACCESSORS(OceanFFT, oceanFFT, OceanFFT)
 
     // Validation (only required systems)
     bool isValid() const {
@@ -95,6 +98,7 @@ struct WaterSystemGroup {
         std::unique_ptr<SSRSystem> ssr;
         std::unique_ptr<WaterTileCull> tileCull;      // Optional
         std::unique_ptr<WaterGBuffer> gBuffer;        // Optional
+        std::unique_ptr<OceanFFT> oceanFFT;           // Optional
     };
 
     /**


### PR DESCRIPTION
Water looked flat and lifeless: the FFT ocean was deleted before ever
being wired up (the shaders' useFFTOcean path was dead, sampling
placeholder textures), and several Vulkan bugs degraded what did render.

Foundation fixes:
- Push constants now use the full stage flags declared in the pipeline
  layout (vertex + tess control + tess eval); pushing with eVertex only
  was a validation violation and broke the tessellation path.
- Binding 22 (samplerCube) received a 2D displacement-map view when no
  environment cubemap exists (none does anywhere in the engine) -
  undefined behavior corrupting reflections. A 1x1 black placeholder
  cubemap now makes the shader fall back to its procedural sky.
- water.frag dropped the GL-style *0.5+0.5 NDC remap before depth
  linearization, fixing geometry-intersection foam and soft edges.
- WaterDisplacement maps were sampled while still in UNDEFINED layout
  with garbage contents; they are now cleared and transitioned at init,
  and the splash compute (never called before) runs in the compute pass.
- WaterGBuffer pass disabled by default: nothing consumes its output.
- PhysicsTerrainTileManager::update no longer dereferences empty
  optionals when the terrain tile cache is unavailable.
- Vulkan instance now enables the surface extensions SDL reports
  (after SDL_Vulkan_LoadLibrary), so non-default SDL video drivers like
  offscreen (VK_EXT_headless_surface) work; also fixed a segfault
  passing vk::ArrayWrapper1D deviceName to a varargs %s.

FFT ocean (Tessendorf, 3 cascades at 256m/64m/16m):
- Recreated src/water/OceanFFT as a RAII system. The deleted version
  never worked: it didn't compile (undeclared vkDevice) and its three
  component IFFTs clobbered each other in two shared scratch images.
  Each component now ping-pongs with its own scratch image and lands
  back in its hkt image, with persistent descriptor sets written once.
- Fixed ocean_fft.comp: the DIT butterfly was fed natural-order input;
  stage 0 now reads through the bit-reversal permutation.
- Fixed ocean_displacement.comp: undo the (-1)^(x+y) modulation from
  the centered spectrum (checkerboard artifact), and replaced the
  illegal image function parameter with an in-helper selector.
- Fixed ocean_spectrum.comp: 'input' is a reserved word.
- Compiled the four ocean_*.comp shaders in CMake (they never were),
  scheduled the simulation in the compute pass (oceanFFTCompute toggle),
  wired the 9 cascade outputs into water descriptor bindings 11-21
  (GENERAL layout), enabled FFT mode by default when OceanFFT exists,
  and added GUI controls (wind, amplitude, choppiness, height, foam).

Testing: full build compiles (C++ + all shaders). Under lavapipe the
app initializes every subsystem cleanly (OceanFFT: 3 cascades @ 256,
water descriptor sets OK); the remaining first-frame crash reproduces
with all water rendering disabled and is a software-rasterizer issue
in unrelated shaders.

https://claude.ai/code/session_01Rvh1pztWY3VEzM618BQgWj